### PR TITLE
fix: stack traces for get APIs

### DIFF
--- a/src/helpers/errorWithStack.js
+++ b/src/helpers/errorWithStack.js
@@ -1,6 +1,6 @@
 // @flow
 export default class ErrorWithStack extends Error {
-  constructor(message: ?string, callsite: Function) {
+  constructor(message: ?string, callsite?: Function) {
     super(message);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, callsite);

--- a/src/helpers/errorWithStack.js
+++ b/src/helpers/errorWithStack.js
@@ -1,6 +1,6 @@
 // @flow
 export default class ErrorWithStack extends Error {
-  constructor(message: ?string, callsite?: Function) {
+  constructor(message: ?string, callsite: Function) {
     super(message);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, callsite);

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -13,68 +13,64 @@ const getNodeByText = (node, text) =>
     ? text === node.props.children
     : text.test(node.props.children));
 
-export const getByName = (instance: ReactTestInstance) => (
-  name: string | React.ComponentType<*>
-) => {
-  try {
-    return instance.find(node => getNodeByName(node, name));
-  } catch (error) {
-    throw new ErrorWithStack(`Error: Component not found.`, getByName);
-  }
-};
+export const getByName = (instance: ReactTestInstance) =>
+  function getByNameFn(name: string | React.ComponentType<*>) {
+    try {
+      return instance.find(node => getNodeByName(node, name));
+    } catch (error) {
+      throw new ErrorWithStack(`Component not found.`, getByNameFn);
+    }
+  };
 
-export const getByText = (instance: ReactTestInstance) => (
-  text: string | RegExp
-) => {
-  try {
-    return instance.find(node => getNodeByText(node, text));
-  } catch (error) {
-    throw new ErrorWithStack(`Error: Component not found.`, getByText);
-  }
-};
+export const getByText = (instance: ReactTestInstance) =>
+  function getByTextFn(text: string | RegExp) {
+    try {
+      return instance.find(node => getNodeByText(node, text));
+    } catch (error) {
+      throw new ErrorWithStack(`Component not found.`, getByTextFn);
+    }
+  };
 
-export const getByProps = (instance: ReactTestInstance) => (props: {
-  [propName: string]: any,
-}) => {
-  try {
-    return instance.findByProps(props);
-  } catch (error) {
-    throw new ErrorWithStack(`Error: Component not found.`, getByProps);
-  }
-};
+export const getByProps = (instance: ReactTestInstance) =>
+  function getByPropsFn(props: { [propName: string]: any }) {
+    try {
+      return instance.findByProps(props);
+    } catch (error) {
+      throw new ErrorWithStack(`Component not found.`, getByPropsFn);
+    }
+  };
 
-export const getByTestId = (instance: ReactTestInstance) => (testID: string) =>
-  getByProps(instance)({ testID });
+export const getByTestId = (instance: ReactTestInstance) =>
+  function getByTestIdFn(testID: string) {
+    return getByProps(instance)({ testID });
+  };
 
-export const getAllByName = (instance: ReactTestInstance) => (
-  name: string | React.ComponentType<*>
-) => {
-  const results = instance.findAll(node => getNodeByName(node, name));
-  if (results.length === 0) {
-    throw new ErrorWithStack(`Error: Components not found.`, getAllByName);
-  }
-  return results;
-};
+export const getAllByName = (instance: ReactTestInstance) =>
+  function getAllByNameFn(name: string | React.ComponentType<*>) {
+    const results = instance.findAll(node => getNodeByName(node, name));
+    if (results.length === 0) {
+      throw new ErrorWithStack(`Components not found.`, getAllByNameFn);
+    }
+    return results;
+  };
 
-export const getAllByText = (instance: ReactTestInstance) => (
-  text: string | RegExp
-) => {
-  const results = instance.findAll(node => getNodeByText(node, text));
-  if (results.length === 0) {
-    throw new ErrorWithStack(`Error: Components not found.`, getAllByText);
-  }
-  return results;
-};
+export const getAllByText = (instance: ReactTestInstance) =>
+  function getAllByTextFn(text: string | RegExp) {
+    const results = instance.findAll(node => getNodeByText(node, text));
+    if (results.length === 0) {
+      throw new ErrorWithStack(`Components not found.`, getAllByTextFn);
+    }
+    return results;
+  };
 
-export const getAllByProps = (instance: ReactTestInstance) => (props: {
-  [propName: string]: any,
-}) => {
-  const results = instance.findAllByProps(props);
-  if (results.length === 0) {
-    throw new ErrorWithStack(`Error: Components not found.`, getAllByProps);
-  }
-  return results;
-};
+export const getAllByProps = (instance: ReactTestInstance) =>
+  function getAllByPropsFn(props: { [propName: string]: any }) {
+    const results = instance.findAllByProps(props);
+    if (results.length === 0) {
+      throw new ErrorWithStack(`Components not found.`, getAllByPropsFn);
+    }
+    return results;
+  };
 
 export const getByAPI = (instance: ReactTestInstance) => ({
   getByTestId: getByTestId(instance),

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -42,7 +42,11 @@ export const getByProps = (instance: ReactTestInstance) =>
 
 export const getByTestId = (instance: ReactTestInstance) =>
   function getByTestIdFn(testID: string) {
-    return getByProps(instance)({ testID });
+    try {
+      return instance.findByProps({ testID });
+    } catch (error) {
+      throw new ErrorWithStack(`Component not found.`, getByTestIdFn);
+    }
   };
 
 export const getAllByName = (instance: ReactTestInstance) =>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

When moving `get` APIs outside of `render`, we needed to wrap them with a closure injecting `instance` to act on. This resulted in an anonymous callsite that wasn't properly processed by our `ErrorWithStack` helper.



### Test plan

|before|after|
|--|--|
|<img width="305" alt="screenshot 2018-10-07 at 16 09 27" src="https://user-images.githubusercontent.com/5106466/46582694-6fb08f00-ca4b-11e8-94f8-40dcb2211d46.png">|<img width="491" alt="screenshot 2018-10-07 at 16 09 18" src="https://user-images.githubusercontent.com/5106466/46582698-73dcac80-ca4b-11e8-94ce-4fd16ce1f845.png">|
