### PR TITLE
feat: add instance and renderer back to RenderResults

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -16,6 +16,8 @@ export default function render(
   const instance = renderer.root;
 
   return {
+    instance,
+    renderer,
     ...getByAPI(instance),
     ...queryByAPI(instance),
     update: renderer.update,


### PR DESCRIPTION
Closes #32.

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
The `instance` and `renderer` fields are [documented in the README](https://github.com/callstack/react-native-testing-library/blob/6097c8f64ce6ad0b3626e2616615d74d73318b22/README.md#render) but were removed from `RenderResult` in e6ac5ad9977b81619ddf1e7cbdeb98cf553c82a8. I think they add value and (at least `renderer`) should still be included. This PR re-introduces them to the object returned from `render`.

##### Alternatives:

- only include `renderer` (as `instance` is just `renderer.root` anyway)
- leave them out of `RenderResult` and remove them from the README

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
N/A
