### PR TITLE
feat: add toJSON to render; cleanup shallow

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Unmount the in-memory tree, triggering the appropriate lifecycle events
 
 When using React context providers, like Redux Provider, you'll likely want to wrap rendered component with them. In such cases it's convenient to create your custom `render` method. [Follow this great guide on how to set this up](https://github.com/kentcdodds/react-testing-library#custom-render).
 
+### `toJSON: () => ?ReactTestRendererJSON`
+
+Get the rendered component JSON representation, e.g. for snapshot testing.
+
 ## `shallow`
 
 Shallowly render given React component. Since it doesn't return helpers to query the output, it's mostly advised to used for snapshot testing (short snapshots are best for code reviewers).

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "react": ">=16.0.0",
     "react-test-renderer": ">= 16.0.0"
   },
-  "dependencies": {},
   "scripts": {
     "test": "jest",
     "flow-check": "flow check",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,7 @@
     "react": ">=16.0.0",
     "react-test-renderer": ">= 16.0.0"
   },
-  "dependencies": {
-    "react-is": "^16.5.2"
-  },
+  "dependencies": {},
   "scripts": {
     "test": "jest",
     "flow-check": "flow check",

--- a/src/__tests__/__snapshots__/render.test.js.snap
+++ b/src/__tests__/__snapshots__/render.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`toJSON 1`] = `"press me"`;

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -161,3 +161,9 @@ test('unmount', () => {
   unmount();
   expect(fn).toHaveBeenCalled();
 });
+
+test('toJSON', () => {
+  const { toJSON } = render(<Button>press me</Button>);
+
+  expect(toJSON()).toMatchSnapshot();
+});

--- a/src/debug.js
+++ b/src/debug.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import prettyFormat, { plugins } from 'pretty-format'; // eslint-disable-line import/no-extraneous-dependencies
-import { shallow } from '.';
+import shallow from './shallow';
 
 /**
  * Log pretty-printed shallow test component instance

--- a/src/debug.js
+++ b/src/debug.js
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import prettyFormat, { plugins } from 'pretty-format'; // eslint-disable-line import/no-extraneous-dependencies
-import shallow from './shallow';
+import { shallow } from '.';
 
 /**
  * Log pretty-printed shallow test component instance

--- a/src/render.js
+++ b/src/render.js
@@ -20,5 +20,6 @@ export default function render(
     ...queryByAPI(instance),
     update: renderer.update,
     unmount: renderer.unmount,
+    toJSON: renderer.toJSON,
   };
 }

--- a/src/shallow.js
+++ b/src/shallow.js
@@ -1,6 +1,5 @@
 // @flow
 import * as React from 'react';
-import { isValidElementType } from 'react-is';
 import ShallowRenderer from 'react-test-renderer/shallow'; // eslint-disable-line import/no-extraneous-dependencies
 
 /**
@@ -10,15 +9,10 @@ export default function shallow(
   instance: ReactTestInstance | React.Element<*>
 ) {
   const renderer = new ShallowRenderer();
-  if (isValidElementType(instance)) {
-    // $FlowFixMe - instance is React.Element<*> in this branch
-    renderer.render(instance);
-  } else {
-    renderer.render(React.createElement(instance.type, instance.props));
-  }
-  const output = renderer.getRenderOutput();
+
+  renderer.render(React.createElement(instance.type, instance.props));
 
   return {
-    output,
+    output: renderer.getRenderOutput(),
   };
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ReactTestInstance } from 'react-test-renderer';
+import { ReactTestInstance, ReactTestRendererJSON } from 'react-test-renderer';
 
 export interface GetByAPI {
   getByName: (name: React.ReactType) => ReactTestInstance;
@@ -30,6 +30,7 @@ export interface RenderOptions {
 export interface RenderAPI extends GetByAPI, QueryByAPI {
   update(nextElement: React.ReactElement<any>): void;
   unmount(nextElement?: React.ReactElement<any>): void;
+  toJSON(): ReactTestRendererJSON | null;
 }
 
 export type FireEventFunction = (


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Exposing `toJSON` so it's possible to snapshot/debug the fully rendered component.
By the way removed the dead code in `shallow` that was not supported (we've never actually wanted to support `shallow(Component)` as it doesn't make sense without passing props.

Fixes #33.

### Test plan

Added a test, which renders funny because of our mocks.
