### PR TITLE
docs: add note about new APIs in v1.4

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -59,9 +59,13 @@ A method returning an array of `ReactTestInstance`s with matching props object.
 
 ### `getByType: (type: React.ComponentType<*>)`
 
+> Note: added in v1.4
+
 A method returning a `ReactTestInstance` with matching a React component type. Throws when no matches.
 
 ### `getAllByType: (type: React.ComponentType<*>)`
+
+> Note: added in v1.4
 
 A method returning an array of `ReactTestInstance`s with matching a React component type.
 


### PR DESCRIPTION
### Summary

`getByType` was added in v1.4, but since we're not versioning our docs, it's worth to not when it was added.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
