### PR TITLE
fix: remove deprecated existential Flow type and use any for now

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,10 +8,10 @@ Defined as:
 
 ```jsx
 function render(
-  component: React.Element<*>,
+  component: React.Element<any>,
   options?: {
     /* You won't often use this, but it's helpful when testing refs */
-    createNodeMock: (element: React.Element<*>) => any,
+    createNodeMock: (element: React.Element<any>) => any,
   }
 ): RenderResult {}
 ```
@@ -77,7 +77,7 @@ A method returning an array of `ReactTestInstance`s with matching a React compon
 
 > This method has been **deprecated** because using it results in fragile tests that may break between minor React Native versions. It will be removed in next major release (v2.0). Use [`getAllByType`](#getallbytype-type-reactcomponenttype) instead.
 
-### `update: (element: React.Element<*>) => void`
+### `update: (element: React.Element<any>) => void`
 
 Re-render the in-memory tree with a new root element. This simulates a React update at the root. If the new element has the same type and key as the previous element, the tree will be updated; otherwise, it will re-mount a new tree.
 

--- a/src/__tests__/__snapshots__/shallow.test.js.snap
+++ b/src/__tests__/__snapshots__/shallow.test.js.snap
@@ -13,7 +13,9 @@ exports[`shallow rendering React Test Instance 1`] = `
 `;
 
 exports[`shallow rendering React elements 1`] = `
-<View>
+<View
+  testID="2"
+>
   <Text
     testID="text-button"
   >

--- a/src/__tests__/shallow.test.js
+++ b/src/__tests__/shallow.test.js
@@ -14,11 +14,7 @@ const TextPress = ({ dummyID }: Props) => (
 );
 
 test('shallow rendering React elements', () => {
-  const { output } = shallow(
-    <TextPress dummyID="2">
-      <Text>ka</Text>
-    </TextPress>
-  );
+  const { output } = shallow(<TextPress dummyID="2" />);
 
   expect(output).toMatchSnapshot();
 });

--- a/src/__tests__/shallow.test.js
+++ b/src/__tests__/shallow.test.js
@@ -3,14 +3,22 @@ import React from 'react';
 import { View, Text } from 'react-native';
 import { shallow, render } from '..';
 
-const TextPress = () => (
-  <View>
+type Props = {|
+  +dummyID?: string,
+|};
+
+const TextPress = ({ dummyID }: Props) => (
+  <View testID={dummyID}>
     <Text testID="text-button">Press me</Text>
   </View>
 );
 
 test('shallow rendering React elements', () => {
-  const { output } = shallow(<TextPress />);
+  const { output } = shallow(
+    <TextPress dummyID="2">
+      <Text>ka</Text>
+    </TextPress>
+  );
 
   expect(output).toMatchSnapshot();
 });

--- a/src/debug.js
+++ b/src/debug.js
@@ -10,11 +10,11 @@ import format from './helpers/format';
  * Log pretty-printed deep test component instance
  */
 function debugDeepElementOrInstance(
-  instance: React.Element<*> | ?ReactTestRendererJSON,
+  instance: React.Element<any> | ?ReactTestRendererJSON,
   message?: any = ''
 ) {
   try {
-    // We're assuming React.Element<*> here and fallback to
+    // We're assuming React.Element<any> here and fallback to
     // rendering ?ReactTestRendererJSON
     // $FlowFixMe
     const { toJSON } = render(instance);
@@ -29,7 +29,10 @@ function debugDeepElementOrInstance(
   }
 }
 
-function debug(instance: ReactTestInstance | React.Element<*>, message?: any) {
+function debug(
+  instance: ReactTestInstance | React.Element<any>,
+  message?: any
+) {
   return debugShallow(instance, message);
 }
 

--- a/src/helpers/debugShallow.js
+++ b/src/helpers/debugShallow.js
@@ -7,7 +7,7 @@ import format from './format';
  * Log pretty-printed shallow test component instance
  */
 export default function debugShallow(
-  instance: ReactTestInstance | React.Element<*>,
+  instance: ReactTestInstance | React.Element<any>,
   message?: any
 ) {
   const { output } = shallow(instance);

--- a/src/render.js
+++ b/src/render.js
@@ -11,8 +11,8 @@ import debugDeep from './helpers/debugDeep';
  * to assert on the output.
  */
 export default function render(
-  component: React.Element<*>,
-  options?: { createNodeMock: (element: React.Element<*>) => any }
+  component: React.Element<any>,
+  options?: { createNodeMock: (element: React.Element<any>) => any }
 ) {
   const renderer = TestRenderer.create(component, options);
   const instance = renderer.root;

--- a/src/shallow.js
+++ b/src/shallow.js
@@ -6,7 +6,7 @@ import ShallowRenderer from 'react-test-renderer/shallow'; // eslint-disable-lin
  * Renders test component shallowly using react-test-renderer/shallow
  */
 export default function shallow(
-  instance: ReactTestInstance | React.Element<*>
+  instance: ReactTestInstance | React.Element<any>
 ) {
   const renderer = new ShallowRenderer();
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Existential type (`*`) is long deprecated, let's just use `any` for now.

### Test plan

Added some more Flow typings to `shallow.test.js` that were failing because of existential type.
