### PR TITLE
fix: add errors for queryBy* helpers when more instances found

### DIFF
--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -124,6 +124,7 @@ test('getByText, queryByText', () => {
 
   expect(queryByText(/change/i)).toBe(button);
   expect(queryByText('InExistent')).toBeNull();
+  expect(() => queryByText(/fresh/)).toThrow('Expected 1 but found 3');
 });
 
 test('getAllByText, queryAllByText', () => {

--- a/src/helpers/queryByAPI.js
+++ b/src/helpers/queryByAPI.js
@@ -11,58 +11,60 @@ import {
   getAllByText,
   getAllByProps,
 } from './getByAPI';
-import { logDeprecationWarning } from './errors';
+import { ErrorWithStack, logDeprecationWarning } from './errors';
 
-export const queryByName = (instance: ReactTestInstance) => (
-  name: string | React.ComponentType<*>
-) => {
-  logDeprecationWarning('queryByName', 'getByName');
-  try {
-    return getByName(instance)(name);
-  } catch (error) {
+const createQueryByError = (error: Error, callsite: Function) => {
+  if (error.message.includes('No instances found')) {
     return null;
   }
+  throw new ErrorWithStack(error.message, callsite);
 };
 
-export const queryByType = (instance: ReactTestInstance) => (
-  type: React.ComponentType<*>
-) => {
-  try {
-    return getByType(instance)(type);
-  } catch (error) {
-    return null;
-  }
-};
+export const queryByName = (instance: ReactTestInstance) =>
+  function queryByNameFn(name: string | React.ComponentType<*>) {
+    logDeprecationWarning('queryByName', 'getByName');
+    try {
+      return getByName(instance)(name);
+    } catch (error) {
+      return createQueryByError(error, queryByNameFn);
+    }
+  };
 
-export const queryByText = (instance: ReactTestInstance) => (
-  text: string | RegExp
-) => {
-  try {
-    return getByText(instance)(text);
-  } catch (error) {
-    return null;
-  }
-};
+export const queryByType = (instance: ReactTestInstance) =>
+  function queryByTypeFn(type: React.ComponentType<*>) {
+    try {
+      return getByType(instance)(type);
+    } catch (error) {
+      return createQueryByError(error, queryByTypeFn);
+    }
+  };
 
-export const queryByProps = (instance: ReactTestInstance) => (props: {
-  [propName: string]: any,
-}) => {
-  try {
-    return getByProps(instance)(props);
-  } catch (error) {
-    return null;
-  }
-};
+export const queryByText = (instance: ReactTestInstance) =>
+  function queryByTextFn(text: string | RegExp) {
+    try {
+      return getByText(instance)(text);
+    } catch (error) {
+      return createQueryByError(error, queryByTextFn);
+    }
+  };
 
-export const queryByTestId = (instance: ReactTestInstance) => (
-  testID: string
-) => {
-  try {
-    return getByTestId(instance)(testID);
-  } catch (error) {
-    return null;
-  }
-};
+export const queryByProps = (instance: ReactTestInstance) =>
+  function queryByPropsFn(props: { [propName: string]: any }) {
+    try {
+      return getByProps(instance)(props);
+    } catch (error) {
+      return createQueryByError(error, queryByPropsFn);
+    }
+  };
+
+export const queryByTestId = (instance: ReactTestInstance) =>
+  function queryByTestIdFn(testID: string) {
+    try {
+      return getByTestId(instance)(testID);
+    } catch (error) {
+      return createQueryByError(error, queryByTestIdFn);
+    }
+  };
 
 export const queryAllByName = (instance: ReactTestInstance) => (
   name: string | React.ComponentType<*>


### PR DESCRIPTION
### Summary

Fixed all `queryBy` helpers to throw when they find more than 1 instances. 
The previous behavior was buggy, because when more instances were found, it would still happily return `null`, while user expected to find 0 instances.

<img width="474" alt="screenshot 2018-11-29 at 09 41 35" src="https://user-images.githubusercontent.com/5106466/49209553-1580da00-f3bb-11e8-9573-4643028a24b2.png">


### Test plan

Added a test.
