### PR TITLE
feat: add wait function for custom expectations

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -247,6 +247,33 @@ test('waiting for an Banana to be ready', async () => {
 });
 ```
 
+## `wait`
+
+Defined as:
+
+```jsx
+function wait(
+  expectation: () => Promise<{}> = () => Promise.resolve({}),
+  timeout: number = 4500,
+  interval: number = 50
+): Promise<{}> {}
+```
+
+Waits for non-deterministic periods of time until your expectation function succeed or times out. `wait` is an alias
+of the `waitForElement` function with a default empty expectation that can be used to make a one tick wait.
+
+```jsx
+import { render, wait } from 'react-testing-library';
+
+test('waiting for an Banana to be ready', async () => {
+  const { getByText, toJSON } = render(<Banana />);
+
+  const loadingScreenHasDisappearedTest = () => expect(getByText('Loading...')).toThrow();
+  await wait(loadingScreenHasDisappearedTest);
+  expect(toJSON()).toMatchSnapshot();
+});
+```
+
 If you're using Jest's [Timer Mocks](https://jestjs.io/docs/en/timer-mocks#docsNav), remember not to use `async/await` syntax as it will stall your tests.
 
 ## `debug`

--- a/src/__tests__/wait.js
+++ b/src/__tests__/wait.js
@@ -1,0 +1,20 @@
+// @flow
+import { wait } from '..';
+
+test('it waits for the data to be loaded', async () => {
+  const spy = jest.fn();
+  const randomTimeout = Math.floor(Math.random() * 60);
+  setTimeout(spy, randomTimeout);
+
+  await wait(() => expect(spy).toHaveBeenCalledTimes(1));
+  expect(spy).toHaveBeenCalledWith();
+});
+
+test('can just be used for a next tick', async () => {
+  const spy = jest.fn();
+  Promise.resolve().then(spy);
+  expect(spy).toHaveBeenCalledTimes(0);
+  await wait();
+  expect(spy).toHaveBeenCalledTimes(1);
+  jest.clearAllTimers();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import flushMicrotasksQueue from './flushMicrotasksQueue';
 import debug from './debug';
 import fireEvent from './fireEvent';
 import waitForElement from './waitForElement';
+import wait from './wait';
 
 export { render };
 export { shallow };
@@ -12,3 +13,4 @@ export { flushMicrotasksQueue };
 export { debug };
 export { fireEvent };
 export { waitForElement };
+export { wait };

--- a/src/wait.js
+++ b/src/wait.js
@@ -1,0 +1,10 @@
+// @flow
+import waitForExpect from './waitForElement';
+
+export default function wait(
+  expectation: () => Promise<{}> = () => Promise.resolve({}),
+  timeout: number = 4500,
+  interval: number = 50
+): Promise<{}> {
+  return waitForExpect(expectation, timeout, interval);
+}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -19,7 +19,9 @@ export interface QueryByAPI {
   queryByText: (name: string | RegExp) => ReactTestInstance | null;
   queryByProps: (props: Record<string, any>) => ReactTestInstance | null;
   queryByTestId: (testID: string) => ReactTestInstance | null;
-  queryAllByName: (name: React.ReactType | string) => Array<ReactTestInstance> | [];
+  queryAllByName: (
+    name: React.ReactType | string
+  ) => Array<ReactTestInstance> | [];
   queryAllByType: <P>(
     type: React.ComponentType<P>
   ) => Array<ReactTestInstance> | [];
@@ -58,6 +60,12 @@ export type WaitForElementFunction = <T = any>(
   interval?: number
 ) => Promise<T>;
 
+export type WaitFunction = (
+  expectation: () => Promise<{}>,
+  timeout?: number,
+  interval?: number
+) => Promise<{}>;
+
 export type DebugFunction = (
   instance: ReactTestInstance | React.ReactElement<any>,
   message?: string
@@ -82,3 +90,4 @@ export declare const flushMicrotasksQueue: () => Promise<any>;
 export declare const debug: DebugAPI;
 export declare const fireEvent: FireEventAPI;
 export declare const waitForElement: WaitForElementFunction;
+export declare const wait: WaitFunction;


### PR DESCRIPTION
### Summary
Closes #61 adding a wait function that gives the library user more autonomy writing a complex expectation and not simply waiting for a component.