### PR TITLE
Clarify RNTL is tested to work with Jest

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You finally want to approach testing using only best practices, while Enzyme may
 
 The `react-native-testing-library` is a lightweight solution for testing your React Native components. It provides light utility functions on top of `react-test-renderer` letting you always be up to date with latest React features and write any component tests you like, be it shallow or deeply rendered ones. But really not any, it prevents you from testing implementation details because we stand this is a very bad practice.
 
-This library is a replacement for [Enzyme](http://airbnb.io/enzyme/).
+This library is a replacement for [Enzyme](http://airbnb.io/enzyme/). It is tested to work with Jest, but it should work with other test runners as well.
 
 ## Example
 


### PR DESCRIPTION
### Summary

As discussed in https://github.com/callstack/react-native-testing-library/issues/96, I found that I could get RNTL working with Jest but not with Mocha. I haven't _confirmed_ it doesn't work with Mocha, but I think it would be helpful for users (like me) who don't have a strong preference which runner to use, to know that Jest could be a good first choice.

### Test plan

No code changes, just README