### PR TITLE
Add fireEvent.blur support

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -200,6 +200,25 @@ const { getByTestId } = render(
 fireEvent.changeText(getByTestId('text-input'), CHANGE_TEXT);
 ```
 
+### `fireEvent.blur: (element: ReactTestInstance) => void`
+
+Invokes `blur` event handler on the element or parent element in the tree.
+
+```jsx
+import { View, TextInput } from 'react-native';
+import { render, fireEvent } from 'react-native-testing-library';
+
+const onBlurMock = jest.fn();
+
+const { getByTestId } = render(
+  <View>
+    <TextInput testID="text-input" onBlur={onBlurMock} />
+  </View>
+);
+
+fireEvent.blur(getByTestId('text-input'));
+```
+
 ### `fireEvent.scroll: (element: ReactTestInstance, data?: *) => void`
 
 Invokes `scroll` event handler on the element or parent element in the tree.

--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -128,3 +128,17 @@ test('fireEvent.changeText', () => {
 
   expect(onChangeTextMock).toHaveBeenCalledWith(CHANGE_TEXT);
 });
+
+test('fireEvent.blur', () => {
+  const onBlurMock = jest.fn();
+
+  const { getByTestId } = render(
+    <View>
+      <TextInput testID="text-input" onBlur={onBlurMock} />
+    </View>
+  );
+
+  fireEvent.blur(getByTestId('text-input'));
+
+  expect(onBlurMock).toHaveBeenCalled();
+});

--- a/src/fireEvent.js
+++ b/src/fireEvent.js
@@ -34,6 +34,8 @@ const toEventHandlerName = (eventName: string) =>
 
 const pressHandler = (element: ReactTestInstance) =>
   invokeEvent(element, 'press');
+const blurHandler = (element: ReactTestInstance) =>
+  invokeEvent(element, 'blur');
 const changeTextHandler = (element: ReactTestInstance, data?: *) =>
   invokeEvent(element, 'changeText', data);
 const scrollHandler = (element: ReactTestInstance, data?: *) =>
@@ -42,6 +44,7 @@ const scrollHandler = (element: ReactTestInstance, data?: *) =>
 const fireEvent = invokeEvent;
 
 fireEvent.press = pressHandler;
+fireEvent.blur = blurHandler;
 fireEvent.changeText = changeTextHandler;
 fireEvent.scroll = scrollHandler;
 


### PR DESCRIPTION
### Summary
There is not yet support for calling text input blur events via `fireEvent`. This PR adds that support.

### Test plan
+ Query the test instance for a react native `TextInput`
+ Call `fireEvent.blur()` on the `TextInput` test instance
+ Verify the supplied handler is called properly