### PR TITLE
Add getByPlaceholder query functionality

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -56,7 +56,7 @@ A method returning an array of `ReactTestInstance`s with matching text – may b
 
 A method returning a `ReactTestInstance` for a `TextInput` with a matching placeholder – may be a string or regular expression. Throws when no matches.
 
-### `getAllByPlaceholder: (text: string | RegExp)`
+### `getAllByPlaceholder: (placeholder: string | RegExp)`
 
 A method returning an array of `ReactTestInstance`s for `TextInput`'s with a matching placeholder – may be a string or regular expression.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -52,6 +52,14 @@ A method returning a `ReactTestInstance` with matching text – may be a string 
 
 A method returning an array of `ReactTestInstance`s with matching text – may be a string or regular expression.
 
+### `getByPlaceholder: (placeholder: string | RegExp)`
+
+A method returning a `ReactTestInstance` for a `TextInput` with a matching placeholder – may be a string or regular expression. Throws when no matches.
+
+### `getAllByPlaceholder: (text: string | RegExp)`
+
+A method returning an array of `ReactTestInstance`s for `TextInput`'s with a matching placeholder – may be a string or regular expression.
+
 ### `getByProps: (props: { [propName: string]: any })`
 
 A method returning a `ReactTestInstance` with matching props object. Throws when no matches.

--- a/src/__tests__/__snapshots__/render.test.js.snap
+++ b/src/__tests__/__snapshots__/render.test.js.snap
@@ -10,6 +10,18 @@ exports[`debug 1`] = `
   >
     not fresh
   </Text>
+  <TextInput
+    allowFontScaling={true}
+    placeholder=\\"Add custom freshness\\"
+    testID=\\"bananaCustomFreshness\\"
+    underlineColorAndroid=\\"transparent\\"
+  />
+  <TextInput
+    allowFontScaling={true}
+    placeholder=\\"Who inspected freshness?\\"
+    testID=\\"bananaChef\\"
+    underlineColorAndroid=\\"transparent\\"
+  />
   <View
     accessible={true}
     isTVSelectable={true}
@@ -42,6 +54,18 @@ exports[`debug changing component: bananaFresh button message should now be "fre
   >
     fresh
   </Text>
+  <TextInput
+    allowFontScaling={true}
+    placeholder=\\"Add custom freshness\\"
+    testID=\\"bananaCustomFreshness\\"
+    underlineColorAndroid=\\"transparent\\"
+  />
+  <TextInput
+    allowFontScaling={true}
+    placeholder=\\"Who inspected freshness?\\"
+    testID=\\"bananaChef\\"
+    underlineColorAndroid=\\"transparent\\"
+  />
   <View
     accessible={true}
     isTVSelectable={true}
@@ -74,6 +98,18 @@ exports[`debug: shallow 1`] = `
   >
     not fresh
   </Text>
+  <TextInput
+    allowFontScaling={true}
+    placeholder=\\"Add custom freshness\\"
+    testID=\\"bananaCustomFreshness\\"
+    underlineColorAndroid=\\"transparent\\"
+  />
+  <TextInput
+    allowFontScaling={true}
+    placeholder=\\"Who inspected freshness?\\"
+    testID=\\"bananaChef\\"
+    underlineColorAndroid=\\"transparent\\"
+  />
   <Button
     onPress={[Function anonymous]}
     type=\\"primary\\"
@@ -95,6 +131,18 @@ exports[`debug: shallow with message 1`] = `
   >
     not fresh
   </Text>
+  <TextInput
+    allowFontScaling={true}
+    placeholder=\\"Add custom freshness\\"
+    testID=\\"bananaCustomFreshness\\"
+    underlineColorAndroid=\\"transparent\\"
+  />
+  <TextInput
+    allowFontScaling={true}
+    placeholder=\\"Who inspected freshness?\\"
+    testID=\\"bananaChef\\"
+    underlineColorAndroid=\\"transparent\\"
+  />
   <Button
     onPress={[Function anonymous]}
     type=\\"primary\\"
@@ -116,6 +164,18 @@ exports[`debug: with message 1`] = `
   >
     not fresh
   </Text>
+  <TextInput
+    allowFontScaling={true}
+    placeholder=\\"Add custom freshness\\"
+    testID=\\"bananaCustomFreshness\\"
+    underlineColorAndroid=\\"transparent\\"
+  />
+  <TextInput
+    allowFontScaling={true}
+    placeholder=\\"Who inspected freshness?\\"
+    testID=\\"bananaChef\\"
+    underlineColorAndroid=\\"transparent\\"
+  />
   <View
     accessible={true}
     isTVSelectable={true}

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -1,9 +1,12 @@
 // @flow
 /* eslint-disable react/no-multi-comp */
 import React from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View, Text, TextInput, TouchableOpacity } from 'react-native';
 import stripAnsi from 'strip-ansi';
 import { render, fireEvent } from '..';
+
+const PLACEHOLDER_FRESHNESS = 'Add custom freshness';
+const PLACEHOLDER_CHEF = 'Who inspected freshness?';
 
 class Button extends React.Component<*> {
   render() {
@@ -45,6 +48,11 @@ class Banana extends React.Component<*, *> {
         <Text testID="bananaFresh">
           {this.state.fresh ? 'fresh' : 'not fresh'}
         </Text>
+        <TextInput
+          testID="bananaCustomFreshness"
+          placeholder={PLACEHOLDER_FRESHNESS}
+        />
+        <TextInput testID="bananaChef" placeholder={PLACEHOLDER_CHEF} />
         <Button onPress={this.changeFresh} type="primary">
           Change freshness!
         </Button>
@@ -136,6 +144,37 @@ test('getAllByText, queryAllByText', () => {
 
   expect(queryAllByText(/fresh/i)).toEqual(buttons);
   expect(queryAllByText('InExistent')).toHaveLength(0);
+});
+
+test('getByPlaceholder, queryByPlaceholder', () => {
+  const { getByPlaceholder, queryByPlaceholder } = render(<Banana />);
+  const input = getByPlaceholder(/custom/i);
+
+  expect(input.props.placeholder).toBe(PLACEHOLDER_FRESHNESS);
+
+  const sameInput = getByPlaceholder(PLACEHOLDER_FRESHNESS);
+
+  expect(sameInput.props.placeholder).toBe(PLACEHOLDER_FRESHNESS);
+  expect(() => getByPlaceholder('no placeholder')).toThrow(
+    'No instances found'
+  );
+
+  expect(queryByPlaceholder(/add/i)).toBe(input);
+  expect(queryByPlaceholder('no placeholder')).toBeNull();
+  expect(() => queryByPlaceholder(/fresh/)).toThrow('Expected 1 but found 2');
+});
+
+test('getAllByPlaceholder, queryAllByPlaceholder', () => {
+  const { getAllByPlaceholder, queryAllByPlaceholder } = render(<Banana />);
+  const inputs = getAllByPlaceholder(/fresh/i);
+
+  expect(inputs).toHaveLength(2);
+  expect(() => getAllByPlaceholder('no placeholder')).toThrow(
+    'No instances found'
+  );
+
+  expect(queryAllByPlaceholder(/fresh/i)).toEqual(inputs);
+  expect(queryAllByPlaceholder('no placeholder')).toHaveLength(0);
 });
 
 test('getByProps, queryByProps', () => {

--- a/src/helpers/queryByAPI.js
+++ b/src/helpers/queryByAPI.js
@@ -5,10 +5,12 @@ import {
   getByName,
   getByType,
   getByText,
+  getByPlaceholder,
   getByProps,
   getAllByName,
   getAllByType,
   getAllByText,
+  getAllByPlaceholder,
   getAllByProps,
 } from './getByAPI';
 import { ErrorWithStack, logDeprecationWarning } from './errors';
@@ -45,6 +47,15 @@ export const queryByText = (instance: ReactTestInstance) =>
       return getByText(instance)(text);
     } catch (error) {
       return createQueryByError(error, queryByTextFn);
+    }
+  };
+
+export const queryByPlaceholder = (instance: ReactTestInstance) =>
+  function queryByPlaceholderFn(placeholder: string | RegExp) {
+    try {
+      return getByPlaceholder(instance)(placeholder);
+    } catch (error) {
+      return createQueryByError(error, queryByPlaceholder);
     }
   };
 
@@ -97,6 +108,16 @@ export const queryAllByText = (instance: ReactTestInstance) => (
   }
 };
 
+export const queryAllByPlaceholder = (instance: ReactTestInstance) => (
+  placeholder: string | RegExp
+) => {
+  try {
+    return getAllByPlaceholder(instance)(placeholder);
+  } catch (error) {
+    return [];
+  }
+};
+
 export const queryAllByProps = (instance: ReactTestInstance) => (props: {
   [propName: string]: any,
 }) => {
@@ -112,9 +133,11 @@ export const queryByAPI = (instance: ReactTestInstance) => ({
   queryByName: queryByName(instance),
   queryByType: queryByType(instance),
   queryByText: queryByText(instance),
+  queryByPlaceholder: queryByPlaceholder(instance),
   queryByProps: queryByProps(instance),
   queryAllByName: queryAllByName(instance),
   queryAllByType: queryAllByType(instance),
   queryAllByText: queryAllByText(instance),
+  queryAllByPlaceholder: queryAllByPlaceholder(instance),
   queryAllByProps: queryAllByProps(instance),
 });

--- a/typings/__tests__/index.test.tsx
+++ b/typings/__tests__/index.test.tsx
@@ -15,6 +15,7 @@ interface HasRequiredProp {
 
 const View = props => props.children;
 const Text = props => props.children;
+const TextInput = props => props.children;
 const ElementWithRequiredProps = (props: HasRequiredProp) => (
   <Text>{props.requiredProp}</Text>
 );
@@ -22,6 +23,7 @@ const ElementWithRequiredProps = (props: HasRequiredProp) => (
 const TestComponent = () => (
   <View>
     <Text>Test component</Text>
+    <TextInput placeholder="my placeholder" />
   </View>
 );
 
@@ -36,6 +38,8 @@ const getByTypeWithRequiredProps: ReactTestInstance = tree.getByType(
 );
 const getByTextString: ReactTestInstance = tree.getByText('<View />');
 const getByTextRegExp: ReactTestInstance = tree.getByText(/View/g);
+const getByPlaceholderString: ReactTestInstance = tree.getByPlaceholder('my placeholder');
+const getByPlaceholderRegExp: ReactTestInstance = tree.getByPlaceholder(/placeholder/g);
 const getByProps: ReactTestInstance = tree.getByProps({ value: 2 });
 const getByTestId: ReactTestInstance = tree.getByTestId('test-id');
 const getAllByNameString: Array<ReactTestInstance> = tree.getAllByName('View');
@@ -65,6 +69,10 @@ const queryByTextString: ReactTestInstance | null = tree.queryByText(
   '<View />'
 );
 const queryByTextRegExp: ReactTestInstance | null = tree.queryByText(/View/g);
+const queryByPlaceholderString: ReactTestInstance | null = tree.queryByText(
+  'my placeholder'
+);
+const queryByPlaceholderRegExp: ReactTestInstance | null = tree.queryByText(/placeholder/g);
 const queryByProps: ReactTestInstance | null = tree.queryByProps({ value: 2 });
 const queryByTestId: ReactTestInstance | null = tree.queryByTestId('test-id');
 const queryAllByNameString: Array<ReactTestInstance> = tree.getAllByName(

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5,11 +5,13 @@ export interface GetByAPI {
   getByName: (name: React.ReactType | string) => ReactTestInstance;
   getByType: <P>(type: React.ComponentType<P>) => ReactTestInstance;
   getByText: (text: string | RegExp) => ReactTestInstance;
+  getByPlaceholder: (placeholder: string | RegExp) => ReactTestInstance;
   getByProps: (props: Record<string, any>) => ReactTestInstance;
   getByTestId: (testID: string) => ReactTestInstance;
   getAllByName: (name: React.ReactType | string) => Array<ReactTestInstance>;
   getAllByType: <P>(type: React.ComponentType<P>) => Array<ReactTestInstance>;
   getAllByText: (text: string | RegExp) => Array<ReactTestInstance>;
+  getAllByPlaceholder: (placeholder: string | RegExp) => Array<ReactTestInstance>;
   getAllByProps: (props: Record<string, any>) => Array<ReactTestInstance>;
 }
 
@@ -17,6 +19,7 @@ export interface QueryByAPI {
   queryByName: (name: React.ReactType | string) => ReactTestInstance | null;
   queryByType: <P>(type: React.ComponentType<P>) => ReactTestInstance | null;
   queryByText: (name: string | RegExp) => ReactTestInstance | null;
+  queryByPlaceholder: (placeholder: string | RegExp) => ReactTestInstance | null;
   queryByProps: (props: Record<string, any>) => ReactTestInstance | null;
   queryByTestId: (testID: string) => ReactTestInstance | null;
   queryAllByName: (name: React.ReactType | string) => Array<ReactTestInstance> | [];
@@ -24,6 +27,7 @@ export interface QueryByAPI {
     type: React.ComponentType<P>
   ) => Array<ReactTestInstance> | [];
   queryAllByText: (text: string | RegExp) => Array<ReactTestInstance> | [];
+  queryAllByPlaceholder: (placeholder: string | RegExp) => Array<ReactTestInstance> | [];
   queryAllByProps: (
     props: Record<string, any>
   ) => Array<ReactTestInstance> | [];


### PR DESCRIPTION
### Summary
There is a helper that exists in `react-testing-library` to query inputs by their `placeholder`. This PR adds that support.

You **could** achieve this by querying for a `placeholder` prop, or querying for react native `TextInput`s manually and then checking their props, but it felt cleaner to have this contained in the testing library itself. It will also allow you to bypass any other instances that may have a `placeholder` prop that aren't `TextInput`s.

If we don't want to expand the surface of the library further, I completely understand that and am fine with this being closed. Just seems like it may be useful and save some time for several scenarios =)

### Test plan
+ Render a `TextInput` with a `placeholder` prop
+ Query the test instance via `getByPlaceholder` for the input
+ Verify the test instance is found