### PR TITLE
docs: Remove misleading recommendation to use shallow in snapshot tests

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -139,7 +139,7 @@ Get the rendered component JSON representation, e.g. for snapshot testing.
 
 - [`Example code`](https://github.com/callstack/react-native-testing-library/blob/master/src/__tests__/shallow.test.js)
 
-Shallowly renders given React component. Since it doesn't return helpers to query the output, it's mostly advised to used for snapshot testing (short snapshots are best for code reviewers).
+Shallowly renders given React component.
 
 ```jsx
 import { shallow } from 'react-native-testing-library';


### PR DESCRIPTION
### Summary

I removed misleading recommendation to render components with `shallow` in snapshot tests as a result of the conversation in Issue #127.

### Test plan

Review text in API.md
