### PR TITLE
Allow for text to match children who are composed as array

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -50,6 +50,8 @@ type ReactTestInstance = {
 
 A method returning a `ReactTestInstance` with matching text – may be a string or regular expression. Throws when no matches.
 
+This method will join `<Text>` siblings to find matches, similarly to [how React Native handles these components](https://facebook.github.io/react-native/docs/text#containers). This will allow for querying for strings that will be visually rendered together, but may be semantically separate React components.
+
 ### `getAllByText: (text: string | RegExp)`
 
 A method returning an array of `ReactTestInstance`s with matching text – may be a string or regular expression.

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -149,8 +149,22 @@ test('getByText, queryByText with children as Array', () => {
   );
 
   const { getByText } = render(<BananaStore />);
+
+  const { toJSON } = render(<BananaCounter numBananas={3} />);
+  expect(toJSON()).toMatchInlineSnapshot(`
+<Text>
+  There are 
+  3
+   bananas in the bunch
+</Text>
+`);
+
   const threeBananaBunch = getByText('There are 3 bananas in the bunch');
-  expect(threeBananaBunch.props.numBananas).toEqual(3);
+  expect(threeBananaBunch.props.children).toEqual([
+    'There are ',
+    3,
+    ' bananas in the bunch',
+  ]);
 });
 
 test('getAllByText, queryAllByText', () => {

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -135,6 +135,24 @@ test('getByText, queryByText', () => {
   expect(() => queryByText(/fresh/)).toThrow('Expected 1 but found 3');
 });
 
+test('getByText, queryByText with children as Array', () => {
+  const BananaCounter = ({ numBananas }) => (
+    <Text>There are {numBananas} bananas in the bunch</Text>
+  );
+
+  const BananaStore = () => (
+    <View>
+      <BananaCounter numBananas={3} />
+      <BananaCounter numBananas={6} />
+      <BananaCounter numBananas={5} />
+    </View>
+  );
+
+  const { getByText } = render(<BananaStore />);
+  const threeBananaBunch = getByText('There are 3 bananas in the bunch');
+  expect(threeBananaBunch.props.numBananas).toEqual(3);
+});
+
 test('getAllByText, queryAllByText', () => {
   const { getAllByText, queryAllByText } = render(<Banana />);
   const buttons = getAllByText(/fresh/i);

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -17,12 +17,20 @@ const getNodeByText = (node, text) => {
   try {
     // eslint-disable-next-line
     const { Text, TextInput } = require('react-native');
-    return (
-      (filterNodeByType(node, Text) || filterNodeByType(node, TextInput)) &&
-      (typeof text === 'string'
-        ? text === node.props.children
-        : text.test(node.props.children))
-    );
+    const isTextNode =
+      filterNodeByType(node, Text) || filterNodeByType(node, TextInput);
+    if (isTextNode) {
+      const textChildren = React.Children.map(node.props.children, child =>
+        child.toString()
+      );
+      if (textChildren) {
+        const textToTest = textChildren.join('');
+        return typeof text === 'string'
+          ? text === textToTest
+          : text.test(textToTest);
+      }
+    }
+    return false;
   } catch (error) {
     throw createLibraryNotSupportedError(error);
   }

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -17,9 +17,9 @@ const getNodeByText = (node, text) => {
   try {
     // eslint-disable-next-line
     const { Text, TextInput } = require('react-native');
-    const isTextNode =
+    const isTextComponent =
       filterNodeByType(node, Text) || filterNodeByType(node, TextInput);
-    if (isTextNode) {
+    if (isTextComponent) {
       const textChildren = React.Children.map(node.props.children, child =>
         child.toString()
       );


### PR DESCRIPTION
### Summary

Given a component that renders text by composing together literal text with an inline expression for a dynamic variable, React Native will render this as a `<Text>` element with multiple children. For example:

```js
const BananaCounter = ({ numBananas }) => (
  <Text>There are {numBananas} bananas in the bunch</Text>
);

const { toJSON, debug } = render(<BananaCounter numBananas={3} />);

debug();
/*
      <Text>
        There are
        3
         bananas in the bunch
      </Text>
*/

expect(toJSON()).toMatchInlineSnapshot(`
<Text>
  There are 
  3
   bananas in the bunch
</Text>
`);
```

This makes sense, as the component is a:
- literal string
- a dynamic evaluation
- literal string

Unfortunately, this means that writing a test that finds an element based on that dynamic evaluation fails when using `getByText`.

```js

const { getByText } = render(<BananaCounter numBananas={3} />);
expect(getByText('There are 3 bananas in the bunch')).toBeTruthy(); // Fails
```

This is because we compare the given test string directly against `children`. https://github.com/callstack/react-native-testing-library/blob/ce3bf28f308728672bc5502e120048821c60218b/src/helpers/getByAPI.js#L23-L24

This results in comparing `'There are 3 bananas in the bunch' === ['There are ' 3, ' bananas in the bunch']`, which of course will fail.

The solution is to join children and compare the joined result against the given text string.

### Test plan

A test for this new functionality is provided!