### PR TITLE
Add act to update call to support hooks

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -384,4 +384,4 @@ expect(submitButtons).toHaveLength(3); // expect 3 elements
 
 ## `act`
 
-Useful function to help testing components that use hooks API. By default any `render` and `fireEvent` calls are wrapped by this function, so there is no need to wrap it manually. This method is re-exported from [`react-test-renderer`](https://github.com/facebook/react/blob/master/packages/react-test-renderer/src/ReactTestRenderer.js#L567]).
+Useful function to help testing components that use hooks API. By default any `render`, `update`, and `fireEvent` calls are wrapped by this function, so there is no need to wrap it manually. This method is re-exported from [`react-test-renderer`](https://github.com/facebook/react/blob/master/packages/react-test-renderer/src/ReactTestRenderer.js#L567]).

--- a/src/__tests__/act.test.js
+++ b/src/__tests__/act.test.js
@@ -28,6 +28,14 @@ test('render should trigger useEffect', () => {
   expect(effectCallback).toHaveBeenCalledTimes(1);
 });
 
+test('updaate should trigger useEffect', () => {
+  const effectCallback = jest.fn();
+  const { update } = render(<UseEffect callback={effectCallback} />);
+  update(<UseEffect callback={effectCallback} />);
+
+  expect(effectCallback).toHaveBeenCalledTimes(2);
+});
+
 test('fireEvent should trigger useState', () => {
   const { getByTestId } = render(<Counter />);
   const counter = getByTestId('counter');

--- a/src/__tests__/act.test.js
+++ b/src/__tests__/act.test.js
@@ -28,7 +28,7 @@ test('render should trigger useEffect', () => {
   expect(effectCallback).toHaveBeenCalledTimes(1);
 });
 
-test('updaate should trigger useEffect', () => {
+test('update should trigger useEffect', () => {
   const effectCallback = jest.fn();
   const { update } = render(<UseEffect callback={effectCallback} />);
   update(<UseEffect callback={effectCallback} />);

--- a/src/render.js
+++ b/src/render.js
@@ -47,12 +47,11 @@ function renderWithAct(
 }
 
 function updateWithAct(renderer: ReactTestRenderer) {
-  function updateImpl(component: React.Element<any>) {
+  return function(component: React.Element<any>) {
     act(() => {
       renderer.update(component);
     });
-  }
-  return updateImpl;
+  };
 }
 
 function debug(instance: ReactTestInstance, renderer) {

--- a/src/render.js
+++ b/src/render.js
@@ -26,7 +26,7 @@ export default function render(
   return {
     ...getByAPI(instance),
     ...queryByAPI(instance),
-    update: renderer.update,
+    update: updateWithAct(renderer),
     unmount: renderer.unmount,
     toJSON: renderer.toJSON,
     debug: debug(instance, renderer),
@@ -44,6 +44,15 @@ function renderWithAct(
   });
 
   return ((renderer: any): ReactTestRenderer);
+}
+
+function updateWithAct(renderer: ReactTestRenderer) {
+  function updateImpl(component: React.Element<any>) {
+    act(() => {
+      renderer.update(component);
+    });
+  }
+  return updateImpl;
 }
 
 function debug(instance: ReactTestInstance, renderer) {


### PR DESCRIPTION
### Summary
Currently `render` and `fireEvent` are wrapped in `act` to support hooks. This pull request wraps the update call in `act` to support testing component updates (e.g. prop changes).

### Test plan
* I have added a test for update in `__tests__/act.test.js`.
* A useEffect hook should run again on `update` calls (if the hook dependency array is satisfied).