### PR TITLE
Feat: adding renderHook to test hooks in isolation

### DIFF
--- a/src/__tests__/renderHook.test.js
+++ b/src/__tests__/renderHook.test.js
@@ -1,0 +1,63 @@
+import { useState, useEffect } from 'react';
+import { renderHook } from '../renderHook';
+
+describe('renderHook', () => {
+  test('should call the hook', () => {
+    const spy = jest.fn();
+    renderHook(spy);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('should trigger cleanup behavior on unmount', () => {
+    const hookCleanup = jest.fn();
+    const { unmount } = renderHook(() => {
+      useEffect(() => {
+        return hookCleanup;
+      });
+    });
+    expect(hookCleanup).not.toHaveBeenCalled();
+    unmount();
+    expect(hookCleanup).toHaveBeenCalledTimes(1);
+  });
+
+  test('should rerun hook on rerender', () => {
+    let renderCount = 0;
+    const { rerender } = renderHook(() => {
+      useEffect(() => {
+        renderCount++;
+      });
+    });
+
+    expect(renderCount).toBe(1);
+    rerender();
+    expect(renderCount).toBe(2);
+  });
+
+  test('should pass new parameters to hook on rerender', () => {
+    let passedParameters;
+    const { rerender } = renderHook(parameters => {
+      useEffect(() => {
+        passedParameters = parameters;
+      });
+    }, 'banana');
+
+    expect(passedParameters).toBe('banana');
+    rerender('split');
+    expect(passedParameters).toBe('split');
+  });
+
+  test('getValue should return latest hook execution result', () => {
+    const { getResult } = renderHook(() => {
+      const [state, setState] = useState(0);
+
+      return {
+        state,
+        setState,
+      };
+    });
+
+    expect(getResult().state).toBe(0);
+    getResult().setState(5);
+    expect(getResult().state).toBe(5);
+  });
+});

--- a/src/renderHook.js
+++ b/src/renderHook.js
@@ -1,0 +1,32 @@
+// @flow
+import * as React from 'react';
+import render from './render';
+
+export const renderHook = <THook: (...arg: Array<mixed>) => mixed>(
+  hook: THook,
+  ...initialParams: Parameters<THook>
+) => {
+  type HookParameters = Parameters<THook>;
+  let result: ReturnType<THook>;
+
+  const HookTestHarness: React.FC<{ parameters: HookParameters }> = ({
+    parameters,
+  }) => {
+    result = hook(...parameters);
+    return null;
+  };
+
+  const getResult = () => result;
+
+  const { unmount, update } = render(
+    <HookTestHarness parameters={initialParams} />
+  );
+
+  return {
+    getResult,
+    unmount,
+    rerender: (...newParams: HookParameters) => {
+      update(<HookTestHarness parameters={newParams} />);
+    },
+  };
+};

--- a/typings/__tests__/index.test.tsx
+++ b/typings/__tests__/index.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { ReactTestInstance } from 'react-test-renderer';
 import {
   render,
+  renderHook,
   fireEvent,
   shallow,
   flushMicrotasksQueue,
@@ -112,6 +113,16 @@ fireEvent.scroll(getByNameString, 'eventData');
 const shallowTree: { output: React.ReactElement<any> } = shallow(
   <TestComponent />
 );
+
+// renderHook API
+const { rerender, unmount, getResult } = renderHook((
+  firstParam: boolean, secondParam: number) => `${firstParam} ${secondParam}`,
+  false,
+  42,
+);
+rerender(true, 1337);
+getResult();
+unmount();
 
 const waitForFlush: Promise<any> = flushMicrotasksQueue();
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ReactTestInstance, ReactTestRendererJSON } from 'react-test-renderer';
+import { ReactTestInstance, ReactTestRendererJSON, TestRendererOptions } from 'react-test-renderer';
 
 export interface GetByAPI {
   getByName: (name: React.ReactType | string) => ReactTestInstance;
@@ -35,10 +35,6 @@ export interface QueryByAPI {
 
 export interface Thenable {
   then: (resolve: () => any, reject?: () => any) => any,
-}
-
-export interface RenderOptions {
-  createNodeMock: (element: React.ReactElement<any>) => any;
 }
 
 export interface RenderAPI extends GetByAPI, QueryByAPI {
@@ -79,9 +75,9 @@ export type DebugAPI = DebugFunction & {
   ) => void;
 };
 
-export declare const render: (
-  component: React.ReactElement<any>,
-  options?: RenderOptions
+export declare const render: <P = {}>(
+  component: React.ReactElement<P>,
+  options?: TestRendererOptions
 ) => RenderAPI;
 export declare const shallow: <P = {}>(
   instance: ReactTestInstance | React.ReactElement<P>

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -44,6 +44,12 @@ export interface RenderAPI extends GetByAPI, QueryByAPI {
   debug(message?: string): void;
 }
 
+export interface RenderHookAPI<HP extends any[] = [], R = any> {
+  getResult(): R;
+  rerender(...hookParameters: HP): void;
+  unmount(): void;
+};
+
 export type FireEventFunction = (
   element: ReactTestInstance,
   eventName: string,
@@ -82,6 +88,7 @@ export declare const render: <P = {}>(
 export declare const shallow: <P = {}>(
   instance: ReactTestInstance | React.ReactElement<P>
 ) => { output: React.ReactElement<P> };
+export declare const renderHook: <THook extends (...args: any[]) => any>(hook: THook, ...initialParams: Parameters<THook>) => RenderHookAPI<Parameters<THook>, ReturnType<THook>>;
 export declare const flushMicrotasksQueue: () => Promise<any>;
 export declare const debug: DebugAPI;
 export declare const fireEvent: FireEventAPI;


### PR DESCRIPTION
### Summary

Taking a lot of inspiration from https://github.com/mpeyper/react-hooks-testing-library/, this PR adds a `renderHook` function to render React hooks in isolation. This will remove the need to render a component just to test the behavior and return values for custom hooks.

Under the hood, `renderHook` renders a minimal component called the `HookTestHarness` that executes the hook under test, stores the hook return value, and ultimately renders nothing. 

I made this light wrapper for use in our project at Peloton, and it's helped us a ton so far. We have some integration tests that include both a view component and its associated hook, but if the point of hooks is to isolate and share logic, we should have a simple way of testing them without having to create numerous fake components just to successfully execute them.

This is the super minimal structure we're using right now, I'm open to suggestions for more features and improvements.

### Usage
```javascript
const { getValue, rerender, unmount } = renderHook(myHook, firstParam, secondParam, ...);
```

* API:
  * `renderHook: (hook: (...params: HP) => R, initialParams: ...HP) => RenderHookAPI`
  * `RenderHookAPI`:
    * `getValue: () => any` - returns the latest return value from the hook under test.
    * `rerender: (...newParams: Array<any>) => void` - updates the `HookTestHarness` with the new passed in props. This will re-execute the hook under test with new params.
    * `unmount: () => void` - unmounts the `HookTestHarness`, triggering any hook cleanup behavior.

### Test plan
* I have included tests for all API methods, typescript types, and typings tests. Tests can be found in `__tests__/renderHook.test.js`
* I'm not super familiar with advanced Flow typing, so I wasn't able to get as much type inference as I was in the Typescript types. In Typescript, the RenderHookAPI object is type safe with regards to the return value and parameters of the hook under test.