### PR TITLE
feat: being able to fire custom events that do not need to start with "on"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 *.log
 .eslintcache
 build
+.idea

--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -29,6 +29,14 @@ const CustomEventComponent = ({ onCustomEvent }) => (
   </TouchableOpacity>
 );
 
+const MyCustomButton = ({ handlePress }) => (
+  <OnPressComponent onPress={handlePress} />
+);
+
+const CustomEventComponentWithCustomName = ({ handlePress }) => (
+  <MyCustomButton testID="my-custom-button" handlePress={handlePress} />
+);
+
 describe('fireEvent', () => {
   test('should invoke specified event', () => {
     const onPressMock = jest.fn();
@@ -127,4 +135,16 @@ test('fireEvent.changeText', () => {
   fireEvent.changeText(getByTestId('text-input'), CHANGE_TEXT);
 
   expect(onChangeTextMock).toHaveBeenCalledWith(CHANGE_TEXT);
+});
+
+test('custom component with custom event name', () => {
+  const handlePress = jest.fn();
+
+  const { getByTestId } = render(
+    <CustomEventComponentWithCustomName handlePress={handlePress} />
+  );
+
+  fireEvent(getByTestId('my-custom-button'), 'handlePress');
+
+  expect(handlePress).toHaveBeenCalled();
 });

--- a/src/fireEvent.js
+++ b/src/fireEvent.js
@@ -7,6 +7,8 @@ const findEventHandler = (element: ReactTestInstance, eventName: string) => {
 
   if (typeof element.props[eventHandler] === 'function') {
     return element.props[eventHandler];
+  } else if (typeof element.props[eventName] === 'function') {
+    return element.props[eventName];
   }
 
   // Do not bubble event to the root element


### PR DESCRIPTION
### Summary

If I have a custom button like:

```js
<MyCustomButton handlePress={onPress} />
```

The following will not work:

```js
fireEvent(getByTestId('my-custom-button'), 'handlePress');
```

Because we are trying to call `onHandlePress`.

### Test plan

```
yarn test fireEvent
```
