### PR TITLE
feat: add `rerender` as an alias for `update`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -5,7 +5,7 @@ title: API
 
 This page gathers public API of `react-native-testing-library` along with usage examples.
 
-## `render` 
+## `render`
 
 - [`Example code`](https://github.com/callstack/react-native-testing-library/blob/master/src/__tests__/render.test.js)
 
@@ -97,6 +97,8 @@ A method returning an array of `ReactTestInstance`s with matching a React compon
 > This method has been **deprecated** because using it results in fragile tests that may break between minor React Native versions. It will be removed in next major release (v2.0). Use [`getAllByType`](#getallbytype-type-reactcomponenttype) instead.
 
 ### `update: (element: React.Element<any>) => void`
+
+_Also available under `rerender` alias_
 
 Re-render the in-memory tree with a new root element. This simulates a React update at the root. If the new element has the same type and key as the previous element, the tree will be updated; otherwise, it will re-mount a new tree. This is useful when testing for `componentDidUpdate` behavior, by passing updated props to the component.
 

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -153,7 +153,7 @@ test('getByText, queryByText with children as Array', () => {
   const { toJSON } = render(<BananaCounter numBananas={3} />);
   expect(toJSON()).toMatchInlineSnapshot(`
 <Text>
-  There are
+  There are 
   3
    bananas in the bunch
 </Text>

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -153,7 +153,7 @@ test('getByText, queryByText with children as Array', () => {
   const { toJSON } = render(<BananaCounter numBananas={3} />);
   expect(toJSON()).toMatchInlineSnapshot(`
 <Text>
-  There are 
+  There are
   3
    bananas in the bunch
 </Text>
@@ -237,14 +237,15 @@ test('getAllByProp, queryAllByProps', () => {
 
 test('update', () => {
   const fn = jest.fn();
-  const { getByName, update } = render(<Banana onUpdate={fn} />);
+  const { getByName, update, rerender } = render(<Banana onUpdate={fn} />);
   const button = getByName('Button');
 
   button.props.onPress();
 
   update(<Banana onUpdate={fn} />);
+  rerender(<Banana onUpdate={fn} />);
 
-  expect(fn).toHaveBeenCalledTimes(2);
+  expect(fn).toHaveBeenCalledTimes(3);
 });
 
 test('unmount', () => {

--- a/src/render.js
+++ b/src/render.js
@@ -27,6 +27,7 @@ export default function render(
     ...getByAPI(instance),
     ...queryByAPI(instance),
     update: updateWithAct(renderer),
+    rerender: updateWithAct(renderer), // alias for `update`
     unmount: renderer.unmount,
     toJSON: renderer.toJSON,
     debug: debug(instance, renderer),

--- a/typings/__tests__/index.test.tsx
+++ b/typings/__tests__/index.test.tsx
@@ -99,6 +99,7 @@ const debugFn = tree.debug();
 const debugFnWithMessage = tree.debug('my message');
 
 tree.update(<View />);
+tree.rerender(<View />);
 tree.unmount();
 
 // fireEvent API tests

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -43,6 +43,7 @@ export interface RenderOptions {
 
 export interface RenderAPI extends GetByAPI, QueryByAPI {
   update(nextElement: React.ReactElement<any>): void;
+  rerender(nextElement: React.ReactElement<any>): void;
   unmount(nextElement?: React.ReactElement<any>): void;
   toJSON(): ReactTestRendererJSON | null;
   debug(message?: string): void;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Users of `react-testing-library` use `rerender` wording instead of `update`. Let's make it easier for them by aliasing it.
See: https://testing-library.com/docs/react-testing-library/api#rerender

### Test plan

Added cases for JS tests and TS typings