### PR TITLE
Fixed a 404 in `README.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ React Native Testing Library is an open source project and will always remain fr
 
 ---
 
-Supported and used by [Rally Health](https://www.rallyhealth.com/company/careers).
+Supported and used by [Rally Health](https://www.rallyhealth.com/careers-home).
 
 <!-- badges -->
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

The readme's "Rally Health" link is a 404.  It appears to attempt to link to a careers page.  I skillfully sniffed out a suitable careers page by scrolling down on the 404 page and clicking "careers".

### Test plan

0. Scroll to the bottom of `README.md`;
0. Middle click on "Rally Health";
0. Bask (optional).
