### PR TITLE
feat: Add `wrapper` option to render

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -15,7 +15,7 @@ Defined as:
 function render(
   component: React.Element<any>,
   options?: {
-    /* Provide a React Component to have it rendered around the inner element on initial  render and on rerender/update  */
+    /* A React Component that renders `component` as children */
     wrapper?: React.ComponentType<any>,
     /* You won't often use this, but it's helpful when testing refs */
     createNodeMock: (element: React.Element<any>) => any,

--- a/docs/API.md
+++ b/docs/API.md
@@ -15,6 +15,8 @@ Defined as:
 function render(
   component: React.Element<any>,
   options?: {
+    /* Provide a React Component to have it rendered around the inner element on initial  render and on rerender/update  */
+    wrapper?: React.ComponentType<any>,
     /* You won't often use this, but it's helpful when testing refs */
     createNodeMock: (element: React.Element<any>) => any,
   }

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -1,7 +1,13 @@
 // @flow
 /* eslint-disable react/no-multi-comp */
 import React from 'react';
-import { View, Text, TextInput, TouchableOpacity } from 'react-native';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  SafeAreaView,
+} from 'react-native';
 import stripAnsi from 'strip-ansi';
 import { render, fireEvent } from '..';
 
@@ -290,4 +296,51 @@ test('debug changing component', () => {
   expect(stripAnsi(mockCalls[4][0])).toMatchSnapshot(
     'bananaFresh button message should now be "fresh"'
   );
+});
+
+test('renders options.wrapper around node', () => {
+  const WrapperComponent = ({ children }) => (
+    <SafeAreaView testID="wrapper">{children}</SafeAreaView>
+  );
+
+  const { toJSON, getByTestId } = render(<View testID="inner" />, {
+    wrapper: WrapperComponent,
+  });
+
+  expect(getByTestId('wrapper')).toBeTruthy();
+  expect(toJSON()).toMatchInlineSnapshot(`
+                <RCTSafeAreaView
+                  emulateUnlessSupported={true}
+                  testID="wrapper"
+                >
+                  <View
+                    testID="inner"
+                  />
+                </RCTSafeAreaView>
+        `);
+});
+
+test('renders options.wrapper around updated node', () => {
+  const WrapperComponent = ({ children }) => (
+    <SafeAreaView testID="wrapper">{children}</SafeAreaView>
+  );
+
+  const { toJSON, getByTestId, rerender } = render(<View testID="inner" />, {
+    wrapper: WrapperComponent,
+  });
+
+  rerender(<View testID="inner" accessibilityLabel="test" />);
+
+  expect(getByTestId('wrapper')).toBeTruthy();
+  expect(toJSON()).toMatchInlineSnapshot(`
+        <RCTSafeAreaView
+          emulateUnlessSupported={true}
+          testID="wrapper"
+        >
+          <View
+            accessibilityLabel="test"
+            testID="inner"
+          />
+        </RCTSafeAreaView>
+    `);
 });

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -309,15 +309,15 @@ test('renders options.wrapper around node', () => {
 
   expect(getByTestId('wrapper')).toBeTruthy();
   expect(toJSON()).toMatchInlineSnapshot(`
-                <RCTSafeAreaView
-                  emulateUnlessSupported={true}
-                  testID="wrapper"
-                >
-                  <View
-                    testID="inner"
-                  />
-                </RCTSafeAreaView>
-        `);
+    <RCTSafeAreaView
+      emulateUnlessSupported={true}
+      testID="wrapper"
+    >
+      <View
+        testID="inner"
+      />
+    </RCTSafeAreaView>
+  `);
 });
 
 test('renders options.wrapper around updated node', () => {
@@ -333,14 +333,14 @@ test('renders options.wrapper around updated node', () => {
 
   expect(getByTestId('wrapper')).toBeTruthy();
   expect(toJSON()).toMatchInlineSnapshot(`
-        <RCTSafeAreaView
-          emulateUnlessSupported={true}
-          testID="wrapper"
-        >
-          <View
-            accessibilityLabel="test"
-            testID="inner"
-          />
-        </RCTSafeAreaView>
-    `);
+    <RCTSafeAreaView
+      emulateUnlessSupported={true}
+      testID="wrapper"
+    >
+      <View
+        accessibilityLabel="test"
+        testID="inner"
+      />
+    </RCTSafeAreaView>
+  `);
 });

--- a/src/render.js
+++ b/src/render.js
@@ -38,12 +38,14 @@ export default function render(
 
   const instance = renderer.root;
 
+  const update = updateWithAct(renderer, wrapUiIfNeeded);
+
   return {
     ...getByAPI(instance),
     ...queryByAPI(instance),
     ...a11yAPI(instance),
-    update: updateWithAct(renderer, wrapUiIfNeeded),
-    rerender: updateWithAct(renderer, wrapUiIfNeeded), // alias for `update`
+    update,
+    rerender: update, // alias for `update`
     unmount: renderer.unmount,
     toJSON: renderer.toJSON,
     debug: debug(instance, renderer),

--- a/src/render.js
+++ b/src/render.js
@@ -61,11 +61,11 @@ function renderWithAct(
 
 function updateWithAct(
   renderer: ReactTestRenderer,
-  wrapUiIfNeeded: (innerElement: React.Element<any>) => React.Element<any>
+  wrap: (innerElement: React.Element<any>) => React.Element<any>
 ) {
   return function(component: React.Element<any>) {
     act(() => {
-      renderer.update(wrapUiIfNeeded(component));
+      renderer.update(wrap(component));
     });
   };
 }

--- a/src/render.js
+++ b/src/render.js
@@ -24,7 +24,7 @@ export default function render(
   component: React.Element<any>,
   { wrapper: WrapperComponent, createNodeMock }: Options = {}
 ) {
-  const wrapUiIfNeeded = (innerElement: React.Element<any>) =>
+  const wrap = (innerElement: React.Element<any>) =>
     WrapperComponent ? (
       <WrapperComponent>{innerElement}</WrapperComponent>
     ) : (
@@ -32,13 +32,13 @@ export default function render(
     );
 
   const renderer = renderWithAct(
-    wrapUiIfNeeded(component),
+    wrap(component),
     createNodeMock ? { createNodeMock } : undefined
   );
 
   const instance = renderer.root;
 
-  const update = updateWithAct(renderer, wrapUiIfNeeded);
+  const update = updateWithAct(renderer, wrap);
 
   return {
     ...getByAPI(instance),

--- a/src/render.js
+++ b/src/render.js
@@ -20,25 +20,19 @@ type TestRendererOptions = {
  * Renders test component deeply using react-test-renderer and exposes helpers
  * to assert on the output.
  */
-export default function render(
-  component: React.Element<any>,
-  { wrapper: WrapperComponent, createNodeMock }: Options = {}
+export default function render<T>(
+  component: React.Element<T>,
+  { wrapper: Wrapper, createNodeMock }: Options = {}
 ) {
   const wrap = (innerElement: React.Element<any>) =>
-    WrapperComponent ? (
-      <WrapperComponent>{innerElement}</WrapperComponent>
-    ) : (
-      innerElement
-    );
+    Wrapper ? <Wrapper>{innerElement}</Wrapper> : innerElement;
 
   const renderer = renderWithAct(
     wrap(component),
     createNodeMock ? { createNodeMock } : undefined
   );
-
-  const instance = renderer.root;
-
   const update = updateWithAct(renderer, wrap);
+  const instance = renderer.root;
 
   return {
     ...getByAPI(instance),

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -74,7 +74,8 @@ export interface Thenable {
 }
 
 export interface RenderOptions {
-  createNodeMock: (element: React.ReactElement<any>) => any;
+  wrapper?: React.ComponentType<any>;
+  createNodeMock?: (element: React.ReactElement<any>) => any;
 }
 
 export interface RenderAPI extends GetByAPI, QueryByAPI, A11yAPI {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary
Adds `wrapper` option to render function to allow users to specify a WrapperComponent that will be used by render, update, and rerender.

Resolves #172

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan
Added tests. Tested `rerender` and not `update` since it is an alias. Could test both or just `update` instead...
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

### Notes
1. I was basing this off of `native-testing-library` https://github.com/testing-library/native-testing-library/blob/master/src/index.js#L16-L23. They are wrapping all tests in `AppContainer` which I'm not sure why. Maybe to pick up yellow box errors?
2. I thought their implementation was also hiding the WrappedComponent from errors and debug/snapshot outputs. Pretty sure they aren't doing any such thing and it's just that the Providers I was rendering don't actually have any user facing output. (Still getting used to non-enzyme shallow tests...)
3. I've never written flow types before and was mostly just copying code over, feel free to suggest/change things to improve  this or make it fit the style of the repo.
4. Feel free to suggest a better way to pass the rest of the options down to `TestRenderer.create`. I initially tried spreading the rest out but couldn't get flow to cooperate.
5. Might be useful to link to or provide docs like https://www.native-testing-library.com/docs/setup#custom-render which are a suggestion of how to use this.