### PR TITLE
fix: display correct error frame when `fireEvent` fails

### DIFF
--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -17,6 +17,18 @@ const OnPressComponent = ({ onPress }) => (
   </View>
 );
 
+const DisabledComponent = ({ onPress, disabled = false }) => (
+  <View>
+    <TouchableOpacity
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityStates={[disabled ? 'disabled' : 'selected']}
+    >
+      <Text testID="disabled-press-me">Press me</Text>
+    </TouchableOpacity>
+  </View>
+);
+
 const WithoutEventComponent = () => (
   <View>
     <Text testID="text">Content</Text>
@@ -60,7 +72,7 @@ describe('fireEvent', () => {
     const { getByTestId } = render(<WithoutEventComponent />);
 
     expect(() => fireEvent(getByTestId('text'), 'press')).toThrow(
-      'No handler function found for event: press'
+      'No handler function found for event: "press"'
     );
   });
 
@@ -88,6 +100,17 @@ describe('fireEvent', () => {
     );
 
     expect(() => fireEvent.press(getByTestId('test'))).toThrow();
+    expect(onPressMock).not.toHaveBeenCalled();
+  });
+
+  test('should not stop bubbling when disabled element found', () => {
+    const onPressMock = jest.fn();
+
+    const { getByTestId } = render(
+      <DisabledComponent disabled onPress={onPressMock} />
+    );
+    fireEvent.press(getByTestId('disabled-press-me'));
+
     expect(onPressMock).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -17,18 +17,6 @@ const OnPressComponent = ({ onPress }) => (
   </View>
 );
 
-const DisabledComponent = ({ onPress, disabled = false }) => (
-  <View>
-    <TouchableOpacity
-      onPress={onPress}
-      disabled={disabled}
-      accessibilityStates={[disabled ? 'disabled' : 'selected']}
-    >
-      <Text testID="disabled-press-me">Press me</Text>
-    </TouchableOpacity>
-  </View>
-);
-
 const WithoutEventComponent = () => (
   <View>
     <Text testID="text">Content</Text>
@@ -100,17 +88,6 @@ describe('fireEvent', () => {
     );
 
     expect(() => fireEvent.press(getByTestId('test'))).toThrow();
-    expect(onPressMock).not.toHaveBeenCalled();
-  });
-
-  test('should not stop bubbling when disabled element found', () => {
-    const onPressMock = jest.fn();
-
-    const { getByTestId } = render(
-      <DisabledComponent disabled onPress={onPressMock} />
-    );
-    fireEvent.press(getByTestId('disabled-press-me'));
-
     expect(onPressMock).not.toHaveBeenCalled();
   });
 });

--- a/src/fireEvent.js
+++ b/src/fireEvent.js
@@ -2,8 +2,30 @@
 import act from './act';
 import { ErrorWithStack } from './helpers/errors';
 
-const findEventHandler = (element: ReactTestInstance, eventName: string) => {
+const isDisabled = element => {
+  const { disabled, accessibilityStates = [] } = element.props;
+  const hasA11yDisabledState = accessibilityStates.includes('disabled');
+  // TODO: make this throw an error in v2, so user can get a more helpful message with a codeframe
+  if (disabled && !hasA11yDisabledState) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Element disabled but not accessible. Please consider adding \`accessibilityStates: ["disabled"]\` prop next to "disabled".`
+    );
+  }
+
+  return disabled;
+};
+
+const findEventHandler = (
+  element: ReactTestInstance,
+  eventName: string,
+  callsite?: any
+) => {
   const eventHandler = toEventHandlerName(eventName);
+
+  if (isDisabled(element)) {
+    return null;
+  }
 
   if (typeof element.props[eventHandler] === 'function') {
     return element.props[eventHandler];
@@ -14,20 +36,25 @@ const findEventHandler = (element: ReactTestInstance, eventName: string) => {
   // Do not bubble event to the root element
   if (element.parent === null || element.parent.parent === null) {
     throw new ErrorWithStack(
-      `No handler function found for event: ${eventName}`,
-      invokeEvent
+      `No handler function found for event: "${eventName}"`,
+      callsite || invokeEvent
     );
   }
 
-  return findEventHandler(element.parent, eventName);
+  return findEventHandler(element.parent, eventName, callsite);
 };
 
 const invokeEvent = (
   element: ReactTestInstance,
   eventName: string,
-  data?: *
-): any => {
-  const handler = findEventHandler(element, eventName);
+  data?: any,
+  callsite?: any
+) => {
+  const handler = findEventHandler(element, eventName, callsite);
+
+  if (!handler) {
+    return null;
+  }
 
   let returnValue;
 
@@ -42,11 +69,11 @@ const toEventHandlerName = (eventName: string) =>
   `on${eventName.charAt(0).toUpperCase()}${eventName.slice(1)}`;
 
 const pressHandler = (element: ReactTestInstance) =>
-  invokeEvent(element, 'press');
+  invokeEvent(element, 'press', undefined, pressHandler);
 const changeTextHandler = (element: ReactTestInstance, data?: *) =>
-  invokeEvent(element, 'changeText', data);
+  invokeEvent(element, 'changeText', data, changeTextHandler);
 const scrollHandler = (element: ReactTestInstance, data?: *) =>
-  invokeEvent(element, 'scroll', data);
+  invokeEvent(element, 'scroll', data, scrollHandler);
 
 const fireEvent = invokeEvent;
 

--- a/src/fireEvent.js
+++ b/src/fireEvent.js
@@ -2,30 +2,12 @@
 import act from './act';
 import { ErrorWithStack } from './helpers/errors';
 
-const isDisabled = element => {
-  const { disabled, accessibilityStates = [] } = element.props;
-  const hasA11yDisabledState = accessibilityStates.includes('disabled');
-  // TODO: make this throw an error in v2, so user can get a more helpful message with a codeframe
-  if (disabled && !hasA11yDisabledState) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `Element disabled but not accessible. Please consider adding \`accessibilityStates: ["disabled"]\` prop next to "disabled".`
-    );
-  }
-
-  return disabled;
-};
-
 const findEventHandler = (
   element: ReactTestInstance,
   eventName: string,
   callsite?: any
 ) => {
   const eventHandler = toEventHandlerName(eventName);
-
-  if (isDisabled(element)) {
-    return null;
-  }
 
   if (typeof element.props[eventHandler] === 'function') {
     return element.props[eventHandler];


### PR DESCRIPTION
### Summary

The error callsites for special handlers (`press`, `changeText`, `scroll`) in `fireEvent` were wrong. We can fix that by passing the correct callsite along so that it's available.

### Test plan

Before
<img width="552" alt="Screenshot 2019-05-29 at 16 38 39" src="https://user-images.githubusercontent.com/5106466/58566124-4b9afb80-8230-11e9-826b-01514fd47a4d.png">
After
<img width="494" alt="Screenshot 2019-05-29 at 16 38 19" src="https://user-images.githubusercontent.com/5106466/58566125-4c339200-8230-11e9-92e4-c23eee53b000.png">

