### PR TITLE
fix: correct typings for a11y queries

### DIFF
--- a/src/helpers/a11yAPI.js
+++ b/src/helpers/a11yAPI.js
@@ -2,29 +2,33 @@
 import makeQuery from './makeQuery';
 
 type QueryFn = (string | RegExp) => ReactTestInstance | null;
+type QueryAllFn = (string | RegExp) => Array<ReactTestInstance> | [];
 type GetFn = (string | RegExp) => ReactTestInstance;
 type GetAllFn = (string | RegExp) => Array<ReactTestInstance>;
 type ArrayQueryFn = (string | Array<string>) => ReactTestInstance | null;
+type ArrayQueryAllFn = (
+  string | Array<string>
+) => Array<ReactTestInstance> | [];
 type ArrayGetFn = (string | Array<string>) => ReactTestInstance;
-type ArrayGetAllFn = (string | Array<string>) => Array<ReactTestInstance> | [];
+type ArrayGetAllFn = (string | Array<string>) => Array<ReactTestInstance>;
 
 type A11yAPI = {
   getByA11yLabel: GetFn,
   getAllByA11yLabel: GetAllFn,
   queryByA11yLabel: QueryFn,
-  queryAllByA11yLabel: GetAllFn,
+  queryAllByA11yLabel: QueryAllFn,
   getByA11yHint: GetFn,
   getAllByA11yHint: GetAllFn,
   queryByA11yHint: QueryFn,
-  queryAllByA11yHint: GetAllFn,
+  queryAllByA11yHint: QueryAllFn,
   getByA11yRole: GetFn,
   getAllByA11yRole: GetAllFn,
   queryByA11yRole: QueryFn,
-  queryAllByA11yRole: GetAllFn,
+  queryAllByA11yRole: QueryAllFn,
   getByA11yStates: ArrayGetFn,
   getAllByA11yStates: ArrayGetAllFn,
   queryByA11yStates: ArrayQueryFn,
-  queryAllByA11yStates: ArrayGetAllFn,
+  queryAllByA11yStates: ArrayQueryAllFn,
 };
 
 export function matchStringValue(prop?: string, matcher: string | RegExp) {

--- a/src/helpers/a11yAPI.js
+++ b/src/helpers/a11yAPI.js
@@ -3,7 +3,7 @@ import makeQuery from './makeQuery';
 
 type QueryFn = (string | RegExp) => ReactTestInstance | null;
 type GetFn = (string | RegExp) => ReactTestInstance;
-type GetAllFn = (string | RegExp) => Array<ReactTestInstance> | [];
+type GetAllFn = (string | RegExp) => Array<ReactTestInstance>;
 type ArrayQueryFn = (string | Array<string>) => ReactTestInstance | null;
 type ArrayGetFn = (string | Array<string>) => ReactTestInstance;
 type ArrayGetAllFn = (string | Array<string>) => Array<ReactTestInstance> | [];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -50,31 +50,33 @@ export interface QueryByAPI {
 }
 
 type QueryFn = (text: string | RegExp) => ReactTestInstance | null;
+type QueryAllFn = (text: string | RegExp) => Array<ReactTestInstance> | [];
 type GetFn = (text: string | RegExp) => ReactTestInstance;
-type GetAllFn = (text: string | RegExp) => Array<ReactTestInstance> | [];
+type GetAllFn = (text: string | RegExp) => Array<ReactTestInstance>;
 type ArrayQueryFn = (text: string | Array<string>) => ReactTestInstance | null;
-type ArrayGetFn = (text: string | Array<string>) => ReactTestInstance;
-type ArrayGetAllFn = (
+type ArrayQueryAllFn = (
   text: string | Array<string>
 ) => Array<ReactTestInstance> | [];
+type ArrayGetFn = (text: string | Array<string>) => ReactTestInstance;
+type ArrayGetAllFn = (text: string | Array<string>) => Array<ReactTestInstance>;
 
 export interface A11yAPI {
   getByA11yLabel: GetFn;
   getAllByA11yLabel: GetAllFn;
   queryByA11yLabel: QueryFn;
-  queryAllByA11yLabel: GetAllFn;
+  queryAllByA11yLabel: QueryAllFn;
   getByA11yHint: GetFn;
   getAllByA11yHint: GetAllFn;
   queryByA11yHint: QueryFn;
-  queryAllByA11yHint: GetAllFn;
+  queryAllByA11yHint: QueryAllFn;
   getByA11yRole: GetFn;
   getAllByA11yRole: GetAllFn;
   queryByA11yRole: QueryFn;
-  queryAllByA11yRole: GetAllFn;
+  queryAllByA11yRole: QueryAllFn;
   getByA11yStates: ArrayGetFn;
   getAllByA11yStates: ArrayGetAllFn;
   queryByA11yStates: ArrayQueryFn;
-  queryAllByA11yStates: ArrayGetAllFn;
+  queryAllByA11yStates: ArrayQueryAllFn;
 }
 
 export interface Thenable {


### PR DESCRIPTION
### Summary

Fix for `getAllByA11y*` types.

Types were failing for following use case:
```ts
fireEvent.press(getAllByA11yLabel('label')[0]);
```

