### PR TITLE
Exclude src and website folder from npm release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,5 @@ __tests__
 __mocks__
 .github
 .circleci
+src
+website


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

I noticed that `src` folder was published along with `build`, and `website` was all included in the release on npm.

By removing these two folders, we moved from:

- 📦A tarball of 162 KB to 34 KB **(-79%)**.
- 🗂️An unzipped folder of 295 KB to 135 KB **(-54%)**.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Ran our tests with modified `react-native-testing-library`.
