### PR TITLE
Sync yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,13 +20,12 @@ jobs:
           at: ~/react-native-testing-library
       - restore_cache:
           keys:
-            - dependencies-{{ checksum "package.json" }}
-            - dependencies-
-      - run: yarn install
+            - dependencies-{{ checksum "yarn.lock" }}
+      - run: yarn install --frozen-lockfile --no-progress --non-interactive --cache-folder ~/.cache/yarn
       - save_cache:
-          key: dependencies-{{ checksum "package.json" }}
+          key: dependencies-{{ checksum "yarn.lock" }}
           paths:
-            - node_modules
+            - ~/.cache/yarn
       - persist_to_workspace:
           root: .
           paths:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3516,10 +3516,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.0.tgz#55122b6536ea496b4b44893ee2608141d10d9916"
   integrity sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==
 
-flow-bin@^0.103.0:
-  version "0.103.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.103.0.tgz#7aec510d85e1c1b0f2b912bb988337d70035cb0f"
-  integrity sha512-Y3yrnE5ICN1Kl/y10BwjA3JSuS+gt4jVPNyUNCZb0RqmkdssMrW8QNNysJYvhgAY/JBJH8Qv7NVUf11MiwfSlA==
+flow-bin@^0.104.0:
+  version "0.104.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.104.0.tgz#ef5b3600dfd36abe191a87d19f66e481bad2e235"
+  integrity sha512-EZXRRmf7m7ET5Lcnwm/I/T8G3d427Bq34vmO3qIlRcPIYloGuVoqRCwjaeezLRDntHkdciagAKbhJ+NTbDjnkw==
 
 flow-copy-source@^2.0.6:
   version "2.0.7"


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

I noticed that `yarn.lock` is currently outdated on master, to prevent such a situation, we can setup CircleCI to froze the lock file, so from now CircleCI will fail on unsynced lock file.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

CircleCI.
