### PR TITLE
docs: add fireEvent.scroll example for FlatList

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -211,8 +211,10 @@ fireEvent.changeText(getByTestId('text-input'), CHANGE_TEXT);
 
 Invokes `scroll` event handler on the element or parent element in the tree.
 
+#### On a `ScrollView`
+
 ```jsx
-import { ScrollView, TextInput } from 'react-native';
+import { ScrollView, Text } from 'react-native';
 import { render, fireEvent } from 'react-native-testing-library';
 
 const onScrollMock = jest.fn();
@@ -231,6 +233,43 @@ const { getByTestId } = render(
 );
 
 fireEvent.scroll(getByTestId('scroll-view'), eventData);
+```
+
+#### On a `FlatList`
+
+```jsx
+import { FlatList, View } from 'react-native';
+import { render, fireEvent } from 'react-native-testing-library';
+
+const onEndReached = jest.fn();
+const { getByType } = render(
+  <FlatList
+    data={Array.from({ length: 10 }, (_, key) => ({ key: `${key}` }))}
+    renderItem={() => <View style={{ height: 500, width: 100 }} />}
+    onEndReached={onEndReached}
+    onEndReachedThreshold={0.2}
+  />
+);
+const eventData = {
+  nativeEvent: {
+    contentOffset: {
+      y: 500,
+    },
+    contentSize: {
+      // Dimensions of the scrollable content
+      height: 500,
+      width: 100,
+    },
+    layoutMeasurement: {
+      // Dimensions of the device
+      height: 100,
+      width: 100,
+    },
+  },
+};
+
+fireEvent.scroll(getByType(ScrollView), eventData);
+expect(onEndReached).toHaveBeenCalled();
 ```
 
 ## `waitForElement`


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
When testing scroll on a flatlist, I was getting the error : `TypeError: cannot read property 'height' of undefined`

#### Error thrown
![image](https://user-images.githubusercontent.com/14874974/65528488-c4ffdd80-def4-11e9-9562-3de5c7ddd86a.png)

#### Component tested

```
export class InfiniteScrollFlatList<Item> extends PureComponent<Props<Item>> {
  private handleLoadMore = () => {
    if (!this.props.isLoadingMore && this.props.nextPage) {
      this.props.fetchMore({ page: this.props.nextPage });
    }
  };

  private renderListFooter = () => {
    if (this.props.isLoadingMore) return <Loader />;
    return null;
  };

  public render() {
    return (
      <FlatList
        {...this.props}
        onEndReachedThreshold={0.2}
        onEndReached={this.handleLoadMore}
        ListFooterComponent={this.renderListFooter}
      />
    );
  }
}
```

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

