### PR TITLE
feat: add "cleanup" function

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -115,6 +115,45 @@ toJSON(): ReactTestRendererJSON | null
 
 Get the rendered component JSON representation, e.g. for snapshot testing.
 
+## `cleanup`
+
+```ts
+const cleanup: () => void
+```
+
+Unmounts React trees that were mounted with `render`.
+
+For example, if you're using the `jest` testing framework, then you would need to use the `afterEach` hook like so:
+
+```jsx
+import { cleanup, render } from 'react-native-testing-library'
+import { View } from 'react-native'
+
+afterEach(cleanup)
+
+it('renders a view', () => {
+  render(<View />)
+  // ...
+})
+```
+
+The `afterEach(cleanup)` call also works in `describe` blocks:
+
+```jsx
+describe('when logged in', () => {
+  afterEach(cleanup)
+
+  it('renders the user', () => {
+    render(<SiteHeader />)
+    // ...
+  });
+})
+```
+
+Failing to call `cleanup` when you've called `render` could result in a memory leak and tests which are not "idempotent" (which can lead to difficult to debug errors in your tests).
+
+The alternative to `cleanup` is balancing every `render` with an `unmount` method call.
+
 ## `fireEvent`
 
 ```ts

--- a/src/__tests__/cleanup.test.js
+++ b/src/__tests__/cleanup.test.js
@@ -17,8 +17,11 @@ class Test extends React.Component<*> {
 
 test('cleanup', () => {
   const fn = jest.fn();
+
+  render(<Test onUnmount={fn} />);
   render(<Test onUnmount={fn} />);
   expect(fn).not.toHaveBeenCalled();
+
   cleanup();
-  expect(fn).toHaveBeenCalled();
+  expect(fn).toHaveBeenCalledTimes(2);
 });

--- a/src/__tests__/cleanup.test.js
+++ b/src/__tests__/cleanup.test.js
@@ -1,0 +1,24 @@
+// @flow
+/* eslint-disable react/no-multi-comp */
+import React from 'react';
+import { View } from 'react-native';
+import { cleanup, render } from '..';
+
+class Test extends React.Component<*> {
+  componentWillUnmount() {
+    if (this.props.onUnmount) {
+      this.props.onUnmount();
+    }
+  }
+  render() {
+    return <View />;
+  }
+}
+
+test('cleanup', () => {
+  const fn = jest.fn();
+  render(<Test onUnmount={fn} />);
+  expect(fn).not.toHaveBeenCalled();
+  cleanup();
+  expect(fn).toHaveBeenCalled();
+});

--- a/src/cleanup.js
+++ b/src/cleanup.js
@@ -1,0 +1,6 @@
+export default function cleanup() {
+  cleanup.queue.forEach(fn => fn());
+  cleanup.queue.clear();
+}
+
+cleanup.queue = new Set();

--- a/src/cleanup.js
+++ b/src/cleanup.js
@@ -1,6 +1,13 @@
+// @flow
+let cleanupQueue = new Set();
+
 export default function cleanup() {
-  cleanup.queue.forEach(fn => fn());
-  cleanup.queue.clear();
+  cleanupQueue.forEach(fn => fn());
+  cleanupQueue.clear();
 }
 
-cleanup.queue = new Set();
+export function addToCleanupQueue(
+  fn: (nextElement?: React$Element<any>) => void
+) {
+  cleanupQueue.add(fn);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,18 @@
 // @flow
 import act from './act';
-import render from './render';
-import shallow from './shallow';
-import flushMicrotasksQueue from './flushMicrotasksQueue';
+import cleanup from './cleanup';
 import debug from './debug';
 import fireEvent from './fireEvent';
+import flushMicrotasksQueue from './flushMicrotasksQueue';
+import render from './render';
+import shallow from './shallow';
 import waitForElement from './waitForElement';
 
-export { render };
-export { shallow };
-export { flushMicrotasksQueue };
+export { act };
+export { cleanup };
 export { debug };
 export { fireEvent };
+export { flushMicrotasksQueue };
+export { render };
+export { shallow };
 export { waitForElement };
-export { act };

--- a/src/render.js
+++ b/src/render.js
@@ -2,12 +2,12 @@
 import * as React from 'react';
 import TestRenderer, { type ReactTestRenderer } from 'react-test-renderer'; // eslint-disable-line import/no-extraneous-dependencies
 import act from './act';
+import { addToCleanupQueue } from './cleanup';
 import { getByAPI } from './helpers/getByAPI';
 import { queryByAPI } from './helpers/queryByAPI';
 import a11yAPI from './helpers/a11yAPI';
 import debugShallow from './helpers/debugShallow';
 import debugDeep from './helpers/debugDeep';
-import cleanup from './cleanup';
 
 type Options = {
   wrapper?: React.ComponentType<any>,
@@ -35,7 +35,8 @@ export default function render<T>(
   const update = updateWithAct(renderer, wrap);
   const instance = renderer.root;
 
-  cleanup.queue.add(renderer.unmount);
+  addToCleanupQueue(renderer.unmount);
+
   return {
     ...getByAPI(instance),
     ...queryByAPI(instance),

--- a/src/render.js
+++ b/src/render.js
@@ -7,6 +7,7 @@ import { queryByAPI } from './helpers/queryByAPI';
 import a11yAPI from './helpers/a11yAPI';
 import debugShallow from './helpers/debugShallow';
 import debugDeep from './helpers/debugDeep';
+import cleanup from './cleanup';
 
 type Options = {
   wrapper?: React.ComponentType<any>,
@@ -34,6 +35,7 @@ export default function render<T>(
   const update = updateWithAct(renderer, wrap);
   const instance = renderer.root;
 
+  cleanup.queue.add(renderer.unmount);
   return {
     ...getByAPI(instance),
     ...queryByAPI(instance),

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -135,6 +135,7 @@ export declare const shallow: <P = {}>(
   instance: ReactTestInstance | React.ReactElement<P>
 ) => { output: React.ReactElement<P> };
 export declare const flushMicrotasksQueue: () => Promise<any>;
+export declare const cleanup: () => void;
 export declare const debug: DebugAPI;
 export declare const fireEvent: FireEventAPI;
 export declare const waitForElement: WaitForElementFunction;


### PR DESCRIPTION
### Summary

https://github.com/callstack/react-native-testing-library/issues/234#issuecomment-555725623

Every `render` call stores its `unmount` function in a global `Set` called `cleanup.queue`. This is how RTL does it (except it doesn't expose the queue). I exposed the queue on `cleanup` because it was easiest. You can adjust that in a follow-up commit if you want.

The `cleanup` function is **never** called automatically in this PR.

### Test plan

https://github.com/callstack/react-native-testing-library/commit/f08f132a202eaaf88019dab7c40c855105afd2af