### PR TITLE
fix: (getByText) more robust null/undefined check for text children

### DIFF
--- a/src/__tests__/__snapshots__/render.test.js.snap
+++ b/src/__tests__/__snapshots__/render.test.js.snap
@@ -57,6 +57,9 @@ exports[`debug 1`] = `
   >
     Second Text
   </Text>
+  <Text>
+    0
+  </Text>
 </View>"
 `;
 
@@ -117,6 +120,9 @@ exports[`debug changing component: bananaFresh button message should now be "fre
   >
     Second Text
   </Text>
+  <Text>
+    0
+  </Text>
 </View>"
 `;
 
@@ -161,6 +167,9 @@ exports[`debug: shallow 1`] = `
     testID=\\"duplicateText\\"
   >
     Second Text
+  </Text>
+  <Text>
+    0
   </Text>
 </View>"
 `;
@@ -208,6 +217,9 @@ exports[`debug: shallow with message 1`] = `
     testID=\\"duplicateText\\"
   >
     Second Text
+  </Text>
+  <Text>
+    0
   </Text>
 </View>"
 `;
@@ -270,6 +282,9 @@ exports[`debug: with message 1`] = `
     testID=\\"duplicateText\\"
   >
     Second Text
+  </Text>
+  <Text>
+    0
   </Text>
 </View>"
 `;

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -52,6 +52,7 @@ class Banana extends React.Component<*, *> {
   };
 
   render() {
+    const test = 0;
     return (
       <View>
         <Text>Is the banana fresh?</Text>
@@ -73,6 +74,7 @@ class Banana extends React.Component<*, *> {
         </Button>
         <Text testID="duplicateText">First Text</Text>
         <Text testID="duplicateText">Second Text</Text>
+        <Text>{test}</Text>
       </View>
     );
   }
@@ -122,7 +124,7 @@ test('getByName, queryByName', () => {
 
   expect(bananaFresh.props.children).toBe('not fresh');
   expect(() => getByName('InExistent')).toThrow('No instances found');
-  expect(() => getByName(Text)).toThrow('Expected 1 but found 5');
+  expect(() => getByName(Text)).toThrow('Expected 1 but found 6');
 
   expect(queryByName('Button')).toBe(button);
   expect(queryByName('InExistent')).toBeNull();
@@ -166,9 +168,12 @@ test('getByText, queryByText', () => {
   expect(sameButton.props.children).toBe('not fresh');
   expect(() => getByText('InExistent')).toThrow('No instances found');
 
+  const zeroText = getByText('0');
+
   expect(queryByText(/change/i)).toBe(button);
   expect(queryByText('InExistent')).toBeNull();
   expect(() => queryByText(/fresh/)).toThrow('Expected 1 but found 3');
+  expect(queryByText('0')).toBe(zeroText);
 });
 
 test('getByText, queryByText with children as Array', () => {

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -22,8 +22,8 @@ const getNodeByText = (node, text) => {
     if (isTextComponent) {
       const textChildren = React.Children.map(
         node.props.children,
-        // In some cases child might be undefined
-        child => (child ? child.toString() : '')
+        // In some cases child might be undefined or null
+        child => (child !== undefined && child !== null ? child.toString() : '')
       );
       if (textChildren) {
         const textToTest = textChildren.join('');


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
When the number `0` is integrated into a component via a variable, `getByText('0')` does not find any `Text` instance.
#### Examples

**Example.jsx**:

```jsx
const test = 0;
...
<Text>{test}</Text>
```

**Example.test.jsx**:

```jsx
const testInstance = render(<Example/>);
getByText('0'); // throws whereas it should not, as there is a 0 in a text component
```

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
A test has been added in render.test.js
