### PR TITLE
feat(website): add DocSearch as recommended by docusaurus.

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -84,6 +84,12 @@ const siteConfig = {
   // template. For example, if you need your repo's URL...
   repoUrl,
   usePrism: ['jsx'],
+  
+  // search
+  algolia: {
+    apiKey: 'cd9b8b73f97b64ed04570e41c507683f',
+    indexName: 'react-native-testing-library',
+  },
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.