### PR TITLE
imp: Re-alias deprecated matchers and warn

### DIFF
--- a/src/helpers/errors.js
+++ b/src/helpers/errors.js
@@ -13,30 +13,6 @@ export const createLibraryNotSupportedError = (error: Error) =>
     `Currently the only supported library to search by text is "react-native".\n\n${error.message}`
   );
 
-const warned = {
-  getByName: false,
-  getAllByName: false,
-  queryByName: false,
-  queryAllByName: false,
-};
-
-export const logDeprecationWarning = (
-  deprecatedFnName: string,
-  alternativeFnName: string
-) => {
-  if (warned[deprecatedFnName]) {
-    return;
-  }
-  console.warn(`Deprecation Warning:
-
-  "${deprecatedFnName}" is deprecated and will be removed in next major release. Please use "${alternativeFnName}" instead.
-
-  Docs: https://github.com/callstack/react-native-testing-library#${alternativeFnName.toLowerCase()}-type-reactcomponenttype
-    `);
-
-  warned[deprecatedFnName] = true;
-};
-
 export const prepareErrorMessage = (error: Error) =>
   // Strip info about custom predicate
   error.message.replace(/ matching custom predicate[^]*/gm, '');
@@ -47,3 +23,34 @@ export const createQueryByError = (error: Error, callsite: Function) => {
   }
   throw new ErrorWithStack(error.message, callsite);
 };
+
+const warned = {
+  getByName: false,
+  getAllByName: false,
+  queryByName: false,
+  queryAllByName: false,
+
+  getByProps: false,
+  getAllByProps: false,
+  queryByProps: false,
+  queryAllByProps: false,
+
+  getByType: false,
+  getAllByType: false,
+  queryByType: false,
+  queryAllByType: false,
+};
+
+export function printDeprecationWarning(functionName: string) {
+  if (warned[functionName]) {
+    return;
+  }
+
+  console.warn(`
+  Deprecation Warning:
+  ${functionName} is not recommended for use and has been renamed to UNSAFE_${functionName}.
+  In react-native-testing-library 2.x only the UNSAFE_${functionName} name will work.
+  `);
+
+  warned[functionName] = true;
+}

--- a/src/helpers/errors.js
+++ b/src/helpers/errors.js
@@ -48,6 +48,19 @@ export function printDeprecationWarning(functionName: string) {
 
   console.warn(`
   Deprecation Warning:
+  ${functionName} is not recommended for use and will be deleted in react-native-testing-library 2.x.
+  `);
+
+  warned[functionName] = true;
+}
+
+export function printUnsafeWarning(functionName: string) {
+  if (warned[functionName]) {
+    return;
+  }
+
+  console.warn(`
+  Deprecation Warning:
   ${functionName} is not recommended for use and has been renamed to UNSAFE_${functionName}.
   In react-native-testing-library 2.x only the UNSAFE_${functionName} name will work.
   `);

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -4,8 +4,8 @@ import prettyFormat from 'pretty-format';
 import {
   ErrorWithStack,
   createLibraryNotSupportedError,
-  logDeprecationWarning,
   prepareErrorMessage,
+  printDeprecationWarning,
 } from './errors';
 
 const filterNodeByType = (node, type) => node.type === type;
@@ -68,9 +68,9 @@ const getTextInputNodeByDisplayValue = (node, value) => {
   }
 };
 
-export const getByName = (instance: ReactTestInstance) =>
+export const getByName = (instance: ReactTestInstance, warnFn?: Function) =>
   function getByNameFn(name: string | React.ComponentType<any>) {
-    logDeprecationWarning('getByName', 'getByType');
+    warnFn && warnFn('getByName');
     try {
       return typeof name === 'string'
         ? instance.find(node => filterNodeByName(node, name))
@@ -80,8 +80,9 @@ export const getByName = (instance: ReactTestInstance) =>
     }
   };
 
-export const getByType = (instance: ReactTestInstance) =>
+export const getByType = (instance: ReactTestInstance, warnFn?: Function) =>
   function getByTypeFn(type: React.ComponentType<any>) {
+    warnFn && warnFn('getByType');
     try {
       return instance.findByType(type);
     } catch (error) {
@@ -120,8 +121,9 @@ export const getByDisplayValue = (instance: ReactTestInstance) =>
     }
   };
 
-export const getByProps = (instance: ReactTestInstance) =>
+export const getByProps = (instance: ReactTestInstance, warnFn?: Function) =>
   function getByPropsFn(props: { [propName: string]: any }) {
+    warnFn && warnFn('getByProps');
     try {
       return instance.findByProps(props);
     } catch (error) {
@@ -138,9 +140,9 @@ export const getByTestId = (instance: ReactTestInstance) =>
     }
   };
 
-export const getAllByName = (instance: ReactTestInstance) =>
+export const getAllByName = (instance: ReactTestInstance, warnFn?: Function) =>
   function getAllByNameFn(name: string | React.ComponentType<any>) {
-    logDeprecationWarning('getAllByName', 'getAllByType');
+    warnFn && warnFn('getAllByName');
     const results =
       typeof name === 'string'
         ? instance.findAll(node => filterNodeByName(node, name))
@@ -151,8 +153,9 @@ export const getAllByName = (instance: ReactTestInstance) =>
     return results;
   };
 
-export const getAllByType = (instance: ReactTestInstance) =>
+export const getAllByType = (instance: ReactTestInstance, warnFn?: Function) =>
   function getAllByTypeFn(type: React.ComponentType<any>) {
+    warnFn && warnFn('getAllByType');
     const results = instance.findAllByType(type);
     if (results.length === 0) {
       throw new ErrorWithStack('No instances found', getAllByTypeFn);
@@ -200,8 +203,9 @@ export const getAllByDisplayValue = (instance: ReactTestInstance) =>
     return results;
   };
 
-export const getAllByProps = (instance: ReactTestInstance) =>
+export const getAllByProps = (instance: ReactTestInstance, warnFn?: Function) =>
   function getAllByPropsFn(props: { [propName: string]: any }) {
+    warnFn && warnFn('getAllByProps');
     const results = instance.findAllByProps(props);
     if (results.length === 0) {
       throw new ErrorWithStack(
@@ -229,17 +233,25 @@ export const getAllByTestId = (instance: ReactTestInstance) =>
 
 export const getByAPI = (instance: ReactTestInstance) => ({
   getByTestId: getByTestId(instance),
-  getByName: getByName(instance),
-  getByType: getByType(instance),
+  getByName: getByName(instance, printDeprecationWarning),
+  getByType: getByType(instance, printDeprecationWarning),
   getByText: getByText(instance),
   getByPlaceholder: getByPlaceholder(instance),
   getByDisplayValue: getByDisplayValue(instance),
-  getByProps: getByProps(instance),
+  getByProps: getByProps(instance, printDeprecationWarning),
   getAllByTestId: getAllByTestId(instance),
-  getAllByName: getAllByName(instance),
-  getAllByType: getAllByType(instance),
+  getAllByName: getAllByName(instance, printDeprecationWarning),
+  getAllByType: getAllByType(instance, printDeprecationWarning),
   getAllByText: getAllByText(instance),
   getAllByPlaceholder: getAllByPlaceholder(instance),
   getAllByDisplayValue: getAllByDisplayValue(instance),
-  getAllByProps: getAllByProps(instance),
+  getAllByProps: getAllByProps(instance, printDeprecationWarning),
+
+  // Unsafe aliases
+  UNSAFE_getByName: getByName(instance),
+  UNSAFE_getAllByName: getAllByName(instance),
+  UNSAFE_getByType: getByType(instance),
+  UNSAFE_getAllByType: getAllByType(instance),
+  UNSAFE_getByProps: getByProps(instance),
+  UNSAFE_getAllByProps: getAllByProps(instance),
 });

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -6,6 +6,7 @@ import {
   createLibraryNotSupportedError,
   prepareErrorMessage,
   printDeprecationWarning,
+  printUnsafeWarning,
 } from './errors';
 
 const filterNodeByType = (node, type) => node.type === type;
@@ -234,22 +235,20 @@ export const getAllByTestId = (instance: ReactTestInstance) =>
 export const getByAPI = (instance: ReactTestInstance) => ({
   getByTestId: getByTestId(instance),
   getByName: getByName(instance, printDeprecationWarning),
-  getByType: getByType(instance, printDeprecationWarning),
+  getByType: getByType(instance, printUnsafeWarning),
   getByText: getByText(instance),
   getByPlaceholder: getByPlaceholder(instance),
   getByDisplayValue: getByDisplayValue(instance),
-  getByProps: getByProps(instance, printDeprecationWarning),
+  getByProps: getByProps(instance, printUnsafeWarning),
   getAllByTestId: getAllByTestId(instance),
   getAllByName: getAllByName(instance, printDeprecationWarning),
-  getAllByType: getAllByType(instance, printDeprecationWarning),
+  getAllByType: getAllByType(instance, printUnsafeWarning),
   getAllByText: getAllByText(instance),
   getAllByPlaceholder: getAllByPlaceholder(instance),
   getAllByDisplayValue: getAllByDisplayValue(instance),
-  getAllByProps: getAllByProps(instance, printDeprecationWarning),
+  getAllByProps: getAllByProps(instance, printUnsafeWarning),
 
   // Unsafe aliases
-  UNSAFE_getByName: getByName(instance),
-  UNSAFE_getAllByName: getAllByName(instance),
   UNSAFE_getByType: getByType(instance),
   UNSAFE_getAllByType: getAllByType(instance),
   UNSAFE_getByProps: getByProps(instance),

--- a/src/helpers/queryByAPI.js
+++ b/src/helpers/queryByAPI.js
@@ -16,11 +16,11 @@ import {
   getAllByDisplayValue,
   getAllByProps,
 } from './getByAPI';
-import { logDeprecationWarning, createQueryByError } from './errors';
+import { createQueryByError, printDeprecationWarning } from './errors';
 
-export const queryByName = (instance: ReactTestInstance) =>
+export const queryByName = (instance: ReactTestInstance, warnFn?: Function) =>
   function queryByNameFn(name: string | React.ComponentType<any>) {
-    logDeprecationWarning('queryByName', 'getByName');
+    warnFn && warnFn('queryByName');
     try {
       return getByName(instance)(name);
     } catch (error) {
@@ -28,8 +28,9 @@ export const queryByName = (instance: ReactTestInstance) =>
     }
   };
 
-export const queryByType = (instance: ReactTestInstance) =>
+export const queryByType = (instance: ReactTestInstance, warnFn?: Function) =>
   function queryByTypeFn(type: React.ComponentType<any>) {
+    warnFn && warnFn('queryByType');
     try {
       return getByType(instance)(type);
     } catch (error) {
@@ -64,8 +65,9 @@ export const queryByDisplayValue = (instance: ReactTestInstance) =>
     }
   };
 
-export const queryByProps = (instance: ReactTestInstance) =>
+export const queryByProps = (instance: ReactTestInstance, warnFn?: Function) =>
   function queryByPropsFn(props: { [propName: string]: any }) {
+    warnFn && warnFn('queryByProps');
     try {
       return getByProps(instance)(props);
     } catch (error) {
@@ -82,10 +84,11 @@ export const queryByTestId = (instance: ReactTestInstance) =>
     }
   };
 
-export const queryAllByName = (instance: ReactTestInstance) => (
-  name: string | React.ComponentType<any>
-) => {
-  logDeprecationWarning('queryAllByName', 'getAllByName');
+export const queryAllByName = (
+  instance: ReactTestInstance,
+  warnFn?: Function
+) => (name: string | React.ComponentType<any>) => {
+  warnFn && warnFn('queryAllByName');
   try {
     return getAllByName(instance)(name);
   } catch (error) {
@@ -93,9 +96,11 @@ export const queryAllByName = (instance: ReactTestInstance) => (
   }
 };
 
-export const queryAllByType = (instance: ReactTestInstance) => (
-  type: React.ComponentType<any>
-) => {
+export const queryAllByType = (
+  instance: ReactTestInstance,
+  warnFn?: Function
+) => (type: React.ComponentType<any>) => {
+  warnFn && warnFn('queryAllByType');
   try {
     return getAllByType(instance)(type);
   } catch (error) {
@@ -133,9 +138,11 @@ export const queryAllByDisplayValue = (instance: ReactTestInstance) => (
   }
 };
 
-export const queryAllByProps = (instance: ReactTestInstance) => (props: {
-  [propName: string]: any,
-}) => {
+export const queryAllByProps = (
+  instance: ReactTestInstance,
+  warnFn?: Function
+) => (props: { [propName: string]: any }) => {
+  warnFn && warnFn('queryAllByProps');
   try {
     return getAllByProps(instance)(props);
   } catch (error) {
@@ -155,17 +162,25 @@ export const queryAllByTestId = (instance: ReactTestInstance) => (
 
 export const queryByAPI = (instance: ReactTestInstance) => ({
   queryByTestId: queryByTestId(instance),
-  queryByName: queryByName(instance),
-  queryByType: queryByType(instance),
+  queryByName: queryByName(instance, printDeprecationWarning),
+  queryByType: queryByType(instance, printDeprecationWarning),
   queryByText: queryByText(instance),
   queryByPlaceholder: queryByPlaceholder(instance),
   queryByDisplayValue: queryByDisplayValue(instance),
-  queryByProps: queryByProps(instance),
+  queryByProps: queryByProps(instance, printDeprecationWarning),
   queryAllByTestId: queryAllByTestId(instance),
-  queryAllByName: queryAllByName(instance),
-  queryAllByType: queryAllByType(instance),
+  queryAllByName: queryAllByName(instance, printDeprecationWarning),
+  queryAllByType: queryAllByType(instance, printDeprecationWarning),
   queryAllByText: queryAllByText(instance),
   queryAllByPlaceholder: queryAllByPlaceholder(instance),
   queryAllByDisplayValue: queryAllByDisplayValue(instance),
-  queryAllByProps: queryAllByProps(instance),
+  queryAllByProps: queryAllByProps(instance, printDeprecationWarning),
+
+  // Unsafe aliases
+  UNSAFE_queryByName: queryByName(instance),
+  UNSAFE_queryAllByName: queryAllByName(instance),
+  UNSAFE_queryByType: queryByType(instance),
+  UNSAFE_queryAllByType: queryAllByType(instance),
+  UNSAFE_queryByProps: queryByProps(instance),
+  UNSAFE_queryAllByProps: queryAllByProps(instance),
 });

--- a/src/helpers/queryByAPI.js
+++ b/src/helpers/queryByAPI.js
@@ -16,7 +16,11 @@ import {
   getAllByDisplayValue,
   getAllByProps,
 } from './getByAPI';
-import { createQueryByError, printDeprecationWarning } from './errors';
+import {
+  createQueryByError,
+  printDeprecationWarning,
+  printUnsafeWarning,
+} from './errors';
 
 export const queryByName = (instance: ReactTestInstance, warnFn?: Function) =>
   function queryByNameFn(name: string | React.ComponentType<any>) {
@@ -163,22 +167,20 @@ export const queryAllByTestId = (instance: ReactTestInstance) => (
 export const queryByAPI = (instance: ReactTestInstance) => ({
   queryByTestId: queryByTestId(instance),
   queryByName: queryByName(instance, printDeprecationWarning),
-  queryByType: queryByType(instance, printDeprecationWarning),
+  queryByType: queryByType(instance, printUnsafeWarning),
   queryByText: queryByText(instance),
   queryByPlaceholder: queryByPlaceholder(instance),
   queryByDisplayValue: queryByDisplayValue(instance),
-  queryByProps: queryByProps(instance, printDeprecationWarning),
+  queryByProps: queryByProps(instance, printUnsafeWarning),
   queryAllByTestId: queryAllByTestId(instance),
   queryAllByName: queryAllByName(instance, printDeprecationWarning),
-  queryAllByType: queryAllByType(instance, printDeprecationWarning),
+  queryAllByType: queryAllByType(instance, printUnsafeWarning),
   queryAllByText: queryAllByText(instance),
   queryAllByPlaceholder: queryAllByPlaceholder(instance),
   queryAllByDisplayValue: queryAllByDisplayValue(instance),
-  queryAllByProps: queryAllByProps(instance, printDeprecationWarning),
+  queryAllByProps: queryAllByProps(instance, printUnsafeWarning),
 
   // Unsafe aliases
-  UNSAFE_queryByName: queryByName(instance),
-  UNSAFE_queryAllByName: queryAllByName(instance),
   UNSAFE_queryByType: queryByType(instance),
   UNSAFE_queryAllByType: queryAllByType(instance),
   UNSAFE_queryByProps: queryByProps(instance),

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -21,8 +21,6 @@ export interface GetByAPI {
 
 
   // Unsafe aliases
-  UNSAFE_getByName: (name: React.ReactType | string) => ReactTestInstance,
-  UNSAFE_getAllByName: (name: React.ReactType | string) => Array<ReactTestInstance>,
   UNSAFE_getByType: <P>(type: React.ComponentType<P>) => ReactTestInstance,
   UNSAFE_getAllByType: <P>(type: React.ComponentType<P>) => Array<ReactTestInstance>,
   UNSAFE_getByProps: (props: Record<string, any>) => ReactTestInstance,
@@ -58,8 +56,6 @@ export interface QueryByAPI {
   ) => Array<ReactTestInstance> | [];
 
   // Unsafe aliases
-  UNSAFE_queryByName: (name: React.ReactType | string) => ReactTestInstance | null,
-  UNSAFE_queryAllByName: (name: React.ReactType | string) => Array<ReactTestInstance> | [],
   UNSAFE_queryByType: <P>(type: React.ComponentType<P>) => ReactTestInstance | null,
   UNSAFE_queryAllByType: <P>(type: React.ComponentType<P>) => Array<ReactTestInstance> | [],
   UNSAFE_queryByProps: (props: Record<string, any>) => ReactTestInstance | null,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -18,6 +18,15 @@ export interface GetByAPI {
   ) => Array<ReactTestInstance>;
   getAllByDisplayValue: (value: string | RegExp) => Array<ReactTestInstance>;
   getAllByProps: (props: Record<string, any>) => Array<ReactTestInstance>;
+
+
+  // Unsafe aliases
+  UNSAFE_getByName: (name: React.ReactType | string) => ReactTestInstance,
+  UNSAFE_getAllByName: (name: React.ReactType | string) => Array<ReactTestInstance>,
+  UNSAFE_getByType: <P>(type: React.ComponentType<P>) => ReactTestInstance,
+  UNSAFE_getAllByType: <P>(type: React.ComponentType<P>) => Array<ReactTestInstance>,
+  UNSAFE_getByProps: (props: Record<string, any>) => ReactTestInstance,
+  UNSAFE_getAllByProps: (props: Record<string, any>) => Array<ReactTestInstance>,
 }
 
 export interface QueryByAPI {
@@ -47,6 +56,14 @@ export interface QueryByAPI {
   queryAllByProps: (
     props: Record<string, any>
   ) => Array<ReactTestInstance> | [];
+
+  // Unsafe aliases
+  UNSAFE_queryByName: (name: React.ReactType | string) => ReactTestInstance | null,
+  UNSAFE_queryAllByName: (name: React.ReactType | string) => Array<ReactTestInstance> | [],
+  UNSAFE_queryByType: <P>(type: React.ComponentType<P>) => ReactTestInstance | null,
+  UNSAFE_queryAllByType: <P>(type: React.ComponentType<P>) => Array<ReactTestInstance> | [],
+  UNSAFE_queryByProps: (props: Record<string, any>) => ReactTestInstance | null,
+  UNSAFE_queryAllByProps: (props: Record<string, any>) => Array<ReactTestInstance> | [],
 }
 
 type QueryFn = (text: string | RegExp) => ReactTestInstance | null;


### PR DESCRIPTION
### Summary

Re-alias every deprecated method with `UNSAFE_` prefix and add a warning.
For now, I decided not to include any warnings for re-aliased functions (but we should definitely include some messages after we delete original methods)

cc @thymikee 

### Test plan

Everything is logged correctly.

https://app.circleci.com/pipelines/github/callstack/react-native-testing-library/758/workflows/e3d488a4-dd12-4e68-9bae-7cbc7951bd96/jobs/2865/parallel-runs/0/steps/0-102
