### PR TITLE
docs: Add new a11y matchers and prepare for 2.x

### DIFF
--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -187,14 +187,23 @@ const element = getByA11yValue({ min: 40 });
 
 The interface is the same as for other queries, but we won't provide full names so that they're harder to find by search engines.
 
-### `UNSAFE_ByType`
+### `UNSAFE_ByType`, `ByType`
 
 > Note: added in v1.4
 
+> This method has been **deprecated** and has been prepended with `UNSAFE_` prefix. In react-native-testing-library 2.x only the prefixed version will work.
+
 A method returning a `ReactTestInstance` with matching a React component type. Throws when no matches.
 
-### `UNSAFE_ByProps`
+### `UNSAFE_ByProps`, `ByProps`
+
+> This method has been **deprecated** and has been prepended with `UNSAFE_` prefix. In react-native-testing-library 2.x only the prefixed version will work.
 
 A method returning a `ReactTestInstance` with matching props object
+
+### `ByName`
+
+> This method has been **deprecated** because using it results in fragile tests that may break between minor React Native versions. **DON'T USE IT**. It will be removed in next major release (v2.0). Use [`getByTestId`](#bytestid) instead. It's listed here only for back-compat purposes for early adopters of the library
+A method returning a `ReactTestInstance` with matching a React component type. Throws when no matches.
 
 </details>

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -148,6 +148,34 @@ const { getByA11yRole } = render(<MyComponent />);
 const element = getByA11yRole('button');
 ```
 
+### `ByA11yState`, `ByAccessibilityState`
+
+> getByA11yState, getAllByA11yState, queryByA11yState, queryAllByA11yState
+> getByAccessibilityState, getAllByAccessibilityState, queryByAccessibilityState, queryAllByAccessibilityState
+
+Returns a `ReactTestInstance` with matching `accessibilityState` prop.
+
+```jsx
+import { render } from 'react-native-testing-library';
+
+const { getByA11yState } = render(<Component />);
+const element = getByA11yState({ disabled: true });
+```
+
+### `ByA11Value`, `ByAccessibilityValue`
+
+> getByA11yValue, getAllByA11yValue, queryByA11yValue, queryAllByA11yValue
+> getByAccessibilityValue, getAllByAccessibilityValue, queryByAccessibilityValue, queryAllByAccessibilityValue
+
+Returns a `ReactTestInstance` with matching `accessibilityValue` prop.
+
+```jsx
+import { render } from 'react-native-testing-library';
+
+const { getByA11yValue } = render(<Component />);
+const element = getByA11yValue({ min: 40 });
+```
+
 ## Unit testing helpers
 
 > Use sparingly and responsibly, escape hatches here
@@ -159,20 +187,14 @@ const element = getByA11yRole('button');
 
 The interface is the same as for other queries, but we won't provide full names so that they're harder to find by search engines.
 
-### `ByType`
+### `UNSAFE_ByType`
 
 > Note: added in v1.4
 
 A method returning a `ReactTestInstance` with matching a React component type. Throws when no matches.
 
-### `ByProps`
+### `UNSAFE_ByProps`
 
 A method returning a `ReactTestInstance` with matching props object
-
-### `ByName`
-
-> This method has been **deprecated** because using it results in fragile tests that may break between minor React Native versions. **DON'T USE IT**. It will be removed in next major release (v2.0). Use [`getByTestId`](#bytestid) instead. It's listed here only for back-compat purposes for early adopters of the library
-
-A method returning a `ReactTestInstance` with matching a React component type. Throws when no matches.
 
 </details>


### PR DESCRIPTION
### Summary

- Add docs for `a11yState` and `a11yValue`.
- Prepare docs for 2.x release

