### PR TITLE
imp: Deprecate shallow

### DIFF
--- a/src/helpers/debugShallow.js
+++ b/src/helpers/debugShallow.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import shallow from '../shallow';
+import { shallowInternal } from '../shallow';
 import format from './format';
 
 /**
@@ -10,7 +10,7 @@ export default function debugShallow(
   instance: ReactTestInstance | React.Element<any>,
   message?: any
 ) {
-  const { output } = shallow(instance);
+  const { output } = shallowInternal(instance);
 
   if (message) {
     console.log(`${message}\n\n`, format(output));

--- a/src/shallow.js
+++ b/src/shallow.js
@@ -1,11 +1,12 @@
 // @flow
 import * as React from 'react';
 import ShallowRenderer from 'react-test-renderer/shallow'; // eslint-disable-line import/no-extraneous-dependencies
+import { printDeprecationWarning } from './helpers/errors';
 
 /**
  * Renders test component shallowly using react-test-renderer/shallow
  */
-export default function shallow(
+export function shallowInternal(
   instance: ReactTestInstance | React.Element<any>
 ) {
   const renderer = new ShallowRenderer();
@@ -15,4 +16,12 @@ export default function shallow(
   return {
     output: renderer.getRenderOutput(),
   };
+}
+
+export default function shallow(
+  instance: ReactTestInstance | React.Element<any>
+) {
+  printDeprecationWarning('shallow');
+
+  return shallowInternal(instance);
 }


### PR DESCRIPTION
### Summary

Deprecate `shallow` function and prepare to remove it from exports for the next release.

### Test plan

Nice and clean warning message.
