### PR TITLE
Fixed an issue where xByText would call toString() on objects and only match on `[object Object]`

### DIFF
--- a/src/__tests__/queryByApi.test.js
+++ b/src/__tests__/queryByApi.test.js
@@ -1,0 +1,49 @@
+// @flow
+import React from 'react';
+import { Text, Image } from 'react-native';
+import { render } from '..';
+
+test('queryByText nested <Image> in <Text> at start', () => {
+  expect(
+    render(
+      <Text>
+        <Image source={{}} />
+        Hello
+      </Text>
+    ).queryByText('Hello')
+  ).toBeTruthy();
+});
+
+test('queryByText nested <Image> in <Text> at end', () => {
+  expect(
+    render(
+      <Text>
+        Hello
+        <Image source={{}} />
+      </Text>
+    ).queryByText('Hello')
+  ).toBeTruthy();
+});
+
+test('queryByText nested <Image> in <Text> in middle', () => {
+  expect(
+    render(
+      <Text>
+        Hello
+        <Image source={{}} />
+        World
+      </Text>
+    ).queryByText('HelloWorld')
+  ).toBeTruthy();
+});
+
+test('queryByText not found', () => {
+  expect(
+    render(
+      <Text>
+        Hello
+        <Image source={{}} />
+      </Text>
+    ).queryByText('SomethingElse')
+  ).toBeFalsy();
+});

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -18,14 +18,10 @@ const filterNodeByName = (node, name) =>
 const getNodeByText = (node, text) => {
   try {
     // eslint-disable-next-line
-    const { Text, TextInput } = require('react-native');
+    const { Text } = require('react-native');
     const isTextComponent = filterNodeByType(node, Text);
     if (isTextComponent) {
-      const textChildren = React.Children.map(
-        node.props.children,
-        // In some cases child might be undefined or null
-        child => (child !== undefined && child !== null ? child.toString() : '')
-      );
+      const textChildren = getChildrenAsText(node.props.children);
       if (textChildren) {
         const textToTest = textChildren.join('');
         return typeof text === 'string'
@@ -37,6 +33,20 @@ const getNodeByText = (node, text) => {
   } catch (error) {
     throw createLibraryNotSupportedError(error);
   }
+};
+
+const getChildrenAsText = children => {
+  return React.Children.map(children, child => {
+    if (typeof child === 'string') {
+      return child;
+    }
+
+    if (typeof child === 'number') {
+      return child.toString();
+    }
+
+    return '';
+  });
 };
 
 const getTextInputNodeByPlaceholder = (node, placeholder) => {


### PR DESCRIPTION
### Summary

This fixes the problem as described in https://github.com/testing-library/native-testing-library/issues/121. In short, `getByText` and `queryByText` would not find a match when the `<Text>` component has a nested component inside of it. This was caused by calling `toString()` on all components it found, meaning something like an `<Image>` would result in `[object Object]`.

A workaround would be to use a regex match for your text instead so you could decide that that is better than this proposed fix, although I would recommend detailing that somewhere as this isn't easy to debug.

### Test plan

I've provided a few unit tests and made sure the code supports a scenario in an existing unit test. That being said, I'm not 100% confident that this change will behave as intended for all scenarios (i.e. we now explicitly take care of `string` and `number` -- are there other data types that should be included)?
