### PR TITLE
Added usage notes for ByTestId queries

### DIFF
--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -91,7 +91,9 @@ const { getByTestId } = render(<MyComponent />);
 const element = getByTestId('unique-id');
 ```
 
-*Note:* Please be mindful when using these API and **treat it as an escape hatch**. Your users can't interact with `testID` anyhow, so you may end up writing tests that provide false sense of security. Favor text and accessibility queries instead. 
+:::caution
+Please be mindful when using these API and **treat it as an escape hatch**. Your users can't interact with `testID` anyhow, so you may end up writing tests that provide false sense of security. Favor text and accessibility queries instead. 
+:::
 
 :::danger
 Current implementation of `getByTestId` and `queryByTestId` has a serious flaw, which results in finding more IDs than there really would be present in native React host components. Fixing it may break some of your tests so we'll do it in next major release (v2). As a temporary workaround, please use `getAllByTestId('your-id')[0]` or `queryAllByTestId('your-id')[0]` or migrate off testing with testID, which is considered to be an escape hatch.

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -93,7 +93,9 @@ const element = getByTestId('unique-id');
 
 *Note:* Please be mindful when using these API and **treat it as an escape hatch**. Your users can't interact with `testID` anyhow, so you may end up writing tests that provide false sense of security. Favor text and accessibility queries instead. 
 
-*Warning:* Current implementation of `getByTestId` and `queryByTestId` has a serious flaw, which results in finding more IDs than there really would be present in native React host components. Fixing it may break some of your tests so we'll do it in next major release (v2). As a temporary workaround, please use `getAllByTestId('your-id')[0]` or `queryAllByTestId('your-id')[0]` or migrate off testing with testID, which is considered to be an escape hatch.
+:::danger
+Current implementation of `getByTestId` and `queryByTestId` has a serious flaw, which results in finding more IDs than there really would be present in native React host components. Fixing it may break some of your tests so we'll do it in next major release (v2). As a temporary workaround, please use `getAllByTestId('your-id')[0]` or `queryAllByTestId('your-id')[0]` or migrate off testing with testID, which is considered to be an escape hatch.
+:::
 
 ### `ByA11yLabel`, `ByAccessibilityLabel`
 

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -91,6 +91,10 @@ const { getByTestId } = render(<MyComponent />);
 const element = getByTestId('unique-id');
 ```
 
+*Note:* Please be mindful when using these API and **treat it as an escape hatch**. Your users can't interact with `testID` anyhow, so you may end up writing tests that provide false sense of security. Favor text and accessibility queries instead. 
+
+*Warning:* Current implementation of `getByTestId` and `queryByTestId` has a serious flaw, which results in finding more IDs than there really would be present in native React host components. Fixing it may break some of your tests so we'll do it in next major release (v2). As a temporary workaround, please use `getAllByTestId('your-id')[0]` or `queryAllByTestId('your-id')[0]` or migrate off testing with testID, which is considered to be an escape hatch.
+
 ### `ByA11yLabel`, `ByAccessibilityLabel`
 
 > getByA11yLabel, getAllByA11yLabel, queryByA11yLabel, queryAllByA11yLabel


### PR DESCRIPTION
### Summary

Based on [this issue](https://github.com/callstack/react-native-testing-library/issues/303) I've updated the docs for ByTestId queries.

Closes #303

### Test plan
Not applicable.
