### PR TITLE
fix(breaking): `getByTestId` should work only for native elements

### DIFF
--- a/src/__tests__/getByApi.test.js
+++ b/src/__tests__/getByApi.test.js
@@ -1,0 +1,40 @@
+// @flow
+import React from 'react';
+import { View, Text, TextInput, Button } from 'react-native';
+import { render } from '..';
+
+const options = { timeout: 10 }; // Short timeout so that this test runs quickly
+
+const MyComponent = () => {
+  return <Text>My Component</Text>;
+};
+
+test('byTestId returns only native elements', () => {
+  const {
+    getByTestId,
+    getAllByTestId,
+    queryByTestId,
+    queryAllByTestId,
+  } = render(
+    <View>
+      <Text testID="text">Text</Text>
+      <TextInput testID="textInput" />
+      <View testID="view" />
+      <Button testID="button" title="Button" />
+      <MyComponent testID="myComponent" />
+    </View>
+  );
+
+  expect(getByTestId('text')).toBeTruthy();
+  expect(getByTestId('textInput')).toBeTruthy();
+  expect(getByTestId('view')).toBeTruthy();
+  expect(getByTestId('button')).toBeTruthy();
+
+  expect(getAllByTestId('text')).toHaveLength(1);
+  expect(getAllByTestId('textInput')).toHaveLength(1);
+  expect(getAllByTestId('view')).toHaveLength(1);
+  expect(getAllByTestId('button')).toHaveLength(1);
+
+  expect(queryByTestId('myComponent')).toBeFalsy();
+  expect(queryAllByTestId('myComponent')).toHaveLength(0);
+});

--- a/src/__tests__/getByApi.test.js
+++ b/src/__tests__/getByApi.test.js
@@ -28,6 +28,10 @@ test('getByTestId returns only native elements', () => {
   expect(getAllByTestId('view')).toHaveLength(1);
   expect(getAllByTestId('button')).toHaveLength(1);
 
-  expect(() => getByTestId('myComponent')).toThrowError();
-  expect(() => getAllByTestId('myComponent')).toThrowError();
+  expect(() => getByTestId('myComponent')).toThrowError(
+    'No instances found with testID: myComponent'
+  );
+  expect(() => getAllByTestId('myComponent')).toThrowError(
+    'No instances found with testID: myComponent'
+  );
 });

--- a/src/__tests__/getByApi.test.js
+++ b/src/__tests__/getByApi.test.js
@@ -3,8 +3,6 @@ import React from 'react';
 import { View, Text, TextInput, Button } from 'react-native';
 import { render } from '..';
 
-const options = { timeout: 10 }; // Short timeout so that this test runs quickly
-
 const MyComponent = () => {
   return <Text>My Component</Text>;
 };

--- a/src/__tests__/getByApi.test.js
+++ b/src/__tests__/getByApi.test.js
@@ -20,7 +20,7 @@ test('byTestId returns only native elements', () => {
       <Text testID="text">Text</Text>
       <TextInput testID="textInput" />
       <View testID="view" />
-      <Button testID="button" title="Button" />
+      <Button testID="button" title="Button" onPress={jest.fn()} />
       <MyComponent testID="myComponent" />
     </View>
   );

--- a/src/__tests__/getByApi.test.js
+++ b/src/__tests__/getByApi.test.js
@@ -7,13 +7,8 @@ const MyComponent = () => {
   return <Text>My Component</Text>;
 };
 
-test('byTestId returns only native elements', () => {
-  const {
-    getByTestId,
-    getAllByTestId,
-    queryByTestId,
-    queryAllByTestId,
-  } = render(
+test('getByTestId returns only native elements', () => {
+  const { getByTestId, getAllByTestId } = render(
     <View>
       <Text testID="text">Text</Text>
       <TextInput testID="textInput" />
@@ -33,6 +28,6 @@ test('byTestId returns only native elements', () => {
   expect(getAllByTestId('view')).toHaveLength(1);
   expect(getAllByTestId('button')).toHaveLength(1);
 
-  expect(queryByTestId('myComponent')).toBeFalsy();
-  expect(queryAllByTestId('myComponent')).toHaveLength(0);
+  expect(() => getByTestId('myComponent')).toThrowError();
+  expect(() => getAllByTestId('myComponent')).toThrowError();
 });

--- a/src/helpers/findByAPI.js
+++ b/src/helpers/findByAPI.js
@@ -1,7 +1,7 @@
 // @flow
 import waitForElement from '../waitForElement';
 import {
-  fixedGetByTestId,
+  getByTestId,
   getAllByTestId,
   getByText,
   getAllByText,
@@ -31,7 +31,7 @@ const makeFindQuery = <Text, Result>(
 export const findByTestId = (instance: ReactTestInstance) => (
   testId: string,
   waitForOptions: WaitForOptions = {}
-) => makeFindQuery(instance, fixedGetByTestId, testId, waitForOptions);
+) => makeFindQuery(instance, getByTestId, testId, waitForOptions);
 
 export const findAllByTestId = (instance: ReactTestInstance) => (
   testId: string,

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -151,15 +151,6 @@ export const getByProps = (instance: ReactTestInstance, warnFn?: Function) =>
 export const getByTestId = (instance: ReactTestInstance) =>
   function getByTestIdFn(testID: string) {
     try {
-      return instance.findByProps({ testID });
-    } catch (error) {
-      throw new ErrorWithStack(prepareErrorMessage(error), getByTestIdFn);
-    }
-  };
-
-export const fixedGetByTestId = (instance: ReactTestInstance) =>
-  function getByTestIdFn(testID: string) {
-    try {
       const results = getAllByTestId(instance)(testID);
       if (results.length === 1) {
         return results[0];

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -32,9 +32,8 @@ title: Queries
 
 `findAllBy` queries return a promise which resolves to an array when any matching elements are found. The promise is rejected if no elements match after a default timeout of 4500ms.
 
-
 :::info
-`findBy` and `findAllBy` queries accept optional `waitForOptions` object argument which can contain `timeout` and `interval` properies which have the same meaning as respective arguments to [`waitForElement`](https://callstack.github.io/react-native-testing-library/docs/api#waitforelement) function. 
+`findBy` and `findAllBy` queries accept optional `waitForOptions` object argument which can contain `timeout` and `interval` properies which have the same meaning as respective arguments to [`waitForElement`](https://callstack.github.io/react-native-testing-library/docs/api#waitforelement) function.
 :::
 
 ## Queries
@@ -105,11 +104,7 @@ const element = getByTestId('unique-id');
 ```
 
 :::caution
-Please be mindful when using these API and **treat it as an escape hatch**. Your users can't interact with `testID` anyhow, so you may end up writing tests that provide false sense of security. Favor text and accessibility queries instead. 
-:::
-
-:::danger
-Current implementation of `getByTestId` and `queryByTestId` has a serious flaw, which results in finding more IDs than there really would be present in native React host components. Fixing it may break some of your tests so we'll do it in next major release (v2). As a temporary workaround, please use `getAllByTestId('your-id')[0]` or `queryAllByTestId('your-id')[0]` or migrate off testing with testID, which is considered to be an escape hatch.
+Please be mindful when using these API and **treat it as an escape hatch**. Your users can't interact with `testID` anyhow, so you may end up writing tests that provide false sense of security. Favor text and accessibility queries instead.
 :::
 
 ### `ByA11yLabel`, `ByAccessibilityLabel`


### PR DESCRIPTION
### Summary

Existing version of `getByTestId` had a bug (#270) as it returned also non-native elements. This was in contract with `getAllByTestId` which returned only native elements.

### Test plan
Added tests checking `getByTestId` behavior.
