### PR TITLE
(Nearly) Empty migration doc for ver. 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ The [public API](https://callstack.github.io/react-native-testing-library/docs/a
 - [`within`](https://callstack.github.io/react-native-testing-library/docs/api#within) - creates a queries object scoped for given element.
 - [`flushMicrotasksQueue`](https://callstack.github.io/react-native-testing-library/docs/api#flushmicrotasksqueue) - waits for microtasks queue to flush.
 
-**Note to users who are more familiar with `react-testing-library`:** This API does not expose `cleanup` because it doesn't interact with the DOM. There's nothing to clean up.
+## Migration Guides
+
+- [Migration to 2.0](https://callstack.github.io/react-native-testing-library/docs/migration20)
 
 ## Made with ❤️ at Callstack
 

--- a/src/__tests__/findByApi.test.js
+++ b/src/__tests__/findByApi.test.js
@@ -55,4 +55,4 @@ test('findBy queries work asynchronously', async () => {
   );
   await expect(findByDisplayValue('Display Value')).resolves.toBeTruthy();
   await expect(findAllByDisplayValue('Display Value')).resolves.toHaveLength(1);
-}, 10000);
+}, 20000);

--- a/website/docs/Migration20.md
+++ b/website/docs/Migration20.md
@@ -12,5 +12,5 @@ In version `1.x` `getByTestId` and `queryByTestId` could return non-native eleme
 If you relied on setting `testID` for your custom components, you should probably set them on the root element of the returned JSX.
 
 :::caution
-In general, you should avoid `byTestId` queries when possible and rather use queries that check things that can been seen by the user (e.g. `byTest`, `byPlaceholder`, etc) or accessability queries (e.g. `byA11yHint`, `byA11yLabel`, etc).
+In general, you should avoid `byTestId` queries when possible and rather use queries that check things that can been seen by the user (e.g. `byText`, `byPlaceholder`, etc) or accessability queries (e.g. `byA11yHint`, `byA11yLabel`, etc).
 :::

--- a/website/docs/Migration20.md
+++ b/website/docs/Migration20.md
@@ -1,6 +1,11 @@
-# Migration to 2.0
+---
+id: migration20
+title: Migration to 2.0
+---
 
-### Some `byTestId` queries behavior changes
+This guides describes major steps involved in migrating your testing code from using React Native Testing Library version `1.x` to version `2.0`.
+
+## Some `byTestId` queries behavior changes
 
 In version `1.x` `getByTestId` and `queryByTestId` could return non-native elements in tests. This was in contrast with other query functions: `getAllByTestId`, `queryAllByTestId`, `findByTestId` and `findAllByTestId` which returned only elements that would be rendered to native components (e.g. `View`, `Text`, etc).
 

--- a/website/docs/MigrationTo20.md
+++ b/website/docs/MigrationTo20.md
@@ -1,0 +1,11 @@
+# Migration to 2.0
+
+### Some `byTestId` queries behavior changes
+
+In version `1.x` `getByTestId` and `queryByTestId` could return non-native elements in tests. This was in contrast with other query functions: `getAllByTestId`, `queryAllByTestId`, `findByTestId` and `findAllByTestId` which returned only elements that would be rendered to native components (e.g. `View`, `Text`, etc).
+
+If you relied on setting `testID` for your custom components, you should probably set them on the root element of the returned JSX.
+
+:::caution
+In general, you should avoid `byTestId` queries when possible and rather use queries that check things that can been seen by the user (e.g. `byTest`, `byPlaceholder`, etc) or accessability queries (e.g. `byA11yHint`, `byA11yLabel`, etc).
+:::

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -2,6 +2,7 @@ module.exports = {
   docs: {
     Introduction: ['getting-started'],
     'API Reference': ['api', 'api-queries'],
+    Guides: ['migration20'],
     Examples: ['react-navigation', 'redux-integration'],
   },
 };


### PR DESCRIPTION
### Summary

(Nearly) empty migration doc for ver. 2.0. It contains only `getByTestId` notes that I have already written for respective bug.