### PR TITLE
feat: wrap `waitFor` in (async) act to support async queries without explicit `act` call

### DIFF
--- a/src/waitFor.js
+++ b/src/waitFor.js
@@ -50,7 +50,7 @@ export default async function waitFor<T>(
     result = await waitForInternal(expectation, options);
   });
 
-  //$FlowFixMe: either we have result or `waitFor` there error
+  //$FlowFixMe: either we have result or `waitFor` threw error
   return result;
 }
 

--- a/src/waitFor.js
+++ b/src/waitFor.js
@@ -45,7 +45,7 @@ export default async function waitFor<T>(
 ): Promise<T> {
   let result: T;
 
-  //$FlowFixMe: this is just too complicated for flow
+  //$FlowFixMe: `act` has incorrect typing
   await act(async () => {
     result = await waitForInternal(expectation, options);
   });

--- a/src/waitFor.js
+++ b/src/waitFor.js
@@ -9,9 +9,7 @@ const DEFAULT_INTERVAL = 50;
 
 function checkReactVersionAtLeast(major: number, minor: number): boolean {
   if (React.version === undefined) return false;
-  const [actualMajor, actualMinor] = React.version
-    .split('.')
-    .map(Number);
+  const [actualMajor, actualMinor] = React.version.split('.').map(Number);
 
   return actualMajor > major || (actualMajor === major && actualMinor >= minor);
 }

--- a/src/waitFor.js
+++ b/src/waitFor.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import act from './act';
 import { throwRemovedFunctionError } from './helpers/errors';
 

--- a/src/waitFor.js
+++ b/src/waitFor.js
@@ -1,5 +1,6 @@
 // @flow
 
+import act from './act';
 import { throwRemovedFunctionError } from './helpers/errors';
 
 const DEFAULT_TIMEOUT = 4500;
@@ -10,7 +11,7 @@ export type WaitForOptions = {
   interval?: number,
 };
 
-export default function waitFor<T>(
+function waitForInternal<T>(
   expectation: () => T,
   options?: WaitForOptions
 ): Promise<T> {
@@ -36,6 +37,21 @@ export default function waitFor<T>(
     }
     setTimeout(runExpectation, 0);
   });
+}
+
+export default async function waitFor<T>(
+  expectation: () => T,
+  options?: WaitForOptions
+): Promise<T> {
+  let result: T;
+
+  //$FlowFixMe: this is just too complicated for flow
+  await act(async () => {
+    result = await waitForInternal(expectation, options);
+  });
+
+  //$FlowFixMe: either we have result or `waitFor` there error
+  return result;
 }
 
 export function waitForElement<T>(

--- a/src/waitFor.js
+++ b/src/waitFor.js
@@ -1,10 +1,20 @@
 // @flow
 
+import React from 'react';
 import act from './act';
 import { throwRemovedFunctionError } from './helpers/errors';
 
 const DEFAULT_TIMEOUT = 4500;
 const DEFAULT_INTERVAL = 50;
+
+function checkReactVersionAtLeast(major: number, minor: number): boolean {
+  if (React.version === undefined) return false;
+  const [actualMajor, actualMinor] = React.version
+    .split('.')
+    .map((n) => parseInt(n, 10));
+
+  return actualMajor > major || (actualMajor == major && actualMinor >= minor);
+}
 
 export type WaitForOptions = {
   timeout?: number,
@@ -43,9 +53,13 @@ export default async function waitFor<T>(
   expectation: () => T,
   options?: WaitForOptions
 ): Promise<T> {
+  if (!checkReactVersionAtLeast(16, 9)) {
+    return await waitForInternal(expectation, options);
+  }
+
   let result: T;
 
-  //$FlowFixMe: `act` has incorrect typing
+  //$FlowFixMe: `act` has incorrect flow typing
   await act(async () => {
     result = await waitForInternal(expectation, options);
   });

--- a/src/waitFor.js
+++ b/src/waitFor.js
@@ -54,7 +54,7 @@ export default async function waitFor<T>(
   options?: WaitForOptions
 ): Promise<T> {
   if (!checkReactVersionAtLeast(16, 9)) {
-    return await waitForInternal(expectation, options);
+    return waitForInternal(expectation, options);
   }
 
   let result: T;

--- a/src/waitFor.js
+++ b/src/waitFor.js
@@ -11,7 +11,7 @@ function checkReactVersionAtLeast(major: number, minor: number): boolean {
   if (React.version === undefined) return false;
   const [actualMajor, actualMinor] = React.version
     .split('.')
-    .map((n) => parseInt(n, 10));
+    .map(Number);
 
   return actualMajor > major || (actualMajor == major && actualMinor >= minor);
 }

--- a/src/waitFor.js
+++ b/src/waitFor.js
@@ -13,7 +13,7 @@ function checkReactVersionAtLeast(major: number, minor: number): boolean {
     .split('.')
     .map(Number);
 
-  return actualMajor > major || (actualMajor == major && actualMinor >= minor);
+  return actualMajor > major || (actualMajor === major && actualMinor >= minor);
 }
 
 export type WaitForOptions = {

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -336,6 +336,10 @@ function waitFor<T>(
 
 Waits for non-deterministic periods of time until your element appears or times out. `waitFor` periodically calls `expectation` every `interval` milliseconds to determine whether the element appeared or not.
 
+:::info
+In order to properly use `waitFor` you need at least React >=16.9.0 (featuing async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
+:::
+
 ```jsx
 import { render, waitFor } from 'react-testing-library';
 
@@ -403,4 +407,4 @@ expect(submitButtons).toHaveLength(3); // expect 3 elements
 
 ## `act`
 
-Useful function to help testing components that use hooks API. By default any `render`, `update`, and `fireEvent` calls are wrapped by this function, so there is no need to wrap it manually. This method is re-exported from [`react-test-renderer`](https://github.com/facebook/react/blob/master/packages/react-test-renderer/src/ReactTestRenderer.js#L567]).
+Useful function to help testing components that use hooks API. By default any `render`, `update`, `fireEvent`, and `waitFor` calls are wrapped by this function, so there is no need to wrap it manually. This method is re-exported from [`react-test-renderer`](https://github.com/facebook/react/blob/master/packages/react-test-renderer/src/ReactTestRenderer.js#L567]).

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -337,7 +337,7 @@ function waitFor<T>(
 Waits for non-deterministic periods of time until your element appears or times out. `waitFor` periodically calls `expectation` every `interval` milliseconds to determine whether the element appeared or not.
 
 :::info
-In order to properly use `waitFor` you need at least React >=16.9.0 (featuing async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
+In order to properly use `waitFor` you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
 :::
 
 ```jsx

--- a/website/docs/GettingStarted.md
+++ b/website/docs/GettingStarted.md
@@ -66,6 +66,10 @@ This library has a peerDependencies listing for `react-test-renderer` and, of co
 
 As you may have noticed, it's not tied to React Native at all – you can safely use it in your React components if you feel like not interacting directly with DOM.
 
+:::info
+In order to properly use helpers for async tests (`findBy` queries and `waitFor`) you need at least React >=16.9.0 (featuing async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
+:::
+
 ### Additional Jest matchers
 
 In order to use addtional React Native-specific jest matchers from [@testing-library/jest-native](https://github.com/testing-library/jest-native) package add it to your project:

--- a/website/docs/GettingStarted.md
+++ b/website/docs/GettingStarted.md
@@ -67,7 +67,7 @@ This library has a peerDependencies listing for `react-test-renderer` and, of co
 As you may have noticed, it's not tied to React Native at all – you can safely use it in your React components if you feel like not interacting directly with DOM.
 
 :::info
-In order to properly use helpers for async tests (`findBy` queries and `waitFor`) you need at least React >=16.9.0 (featuing async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
+In order to properly use helpers for async tests (`findBy` queries and `waitFor`) you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
 :::
 
 ### Additional Jest matchers

--- a/website/docs/MigrationV2.md
+++ b/website/docs/MigrationV2.md
@@ -58,6 +58,8 @@ export default function waitFor<T>(
 
 Both changes should improve code readibility.
 
+`waitFor` calls (and hence also `findBy` queries) are now wrapped in `act` by default, so that you should no longer need to use `act` directly in your tests.
+
 :::tip
 You can usually avoid `waitFor` by a proper use of `findBy` asynchronous queries. It will result in more streamlined testing experience.
 :::

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -33,7 +33,7 @@ title: Queries
 `findAllBy` queries return a promise which resolves to an array when any matching elements are found. The promise is rejected if no elements match after a default timeout of 4500ms.
 
 :::info
-In order to properly use `findBy` and `findAllBy` queries you need at least React >=16.9.0 (featuing async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
+In order to properly use `findBy` and `findAllBy` queries you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
 :::
 
 :::info

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -33,6 +33,10 @@ title: Queries
 `findAllBy` queries return a promise which resolves to an array when any matching elements are found. The promise is rejected if no elements match after a default timeout of 4500ms.
 
 :::info
+In order to properly use `findBy` and `findAllBy` queries you need at least React >=16.9.0 (featuing async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
+:::
+
+:::info
 `findBy` and `findAllBy` queries accept optional `waitForOptions` object argument which can contain `timeout` and `interval` properies which have the same meaning as respective options for [`waitFor`](https://callstack.github.io/react-native-testing-library/docs/api#waitfor) function.
 :::
 


### PR DESCRIPTION
## Summary

Wrap `waitFor` in (async) act to support async queries without explicit `act` call. Otherwise there was a problem when async state changes caused by e.g. async `useEffect` uses (fetching data, ...) generated dreded `act` warnings in the console during test runs.

Closes #343 
