### PR TITLE
chore: use files entry instead of npmignore; reduce publish size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-yarn.lock
-__tests__
-__mocks__
-.github
-.circleci
-src
-website

--- a/package.json
+++ b/package.json
@@ -18,6 +18,12 @@
     "test",
     "integration"
   ],
+  "files": [
+    "build/",
+    "typings/index.d.ts",
+    "pure.js",
+    "dont-cleanup-after-each.js"
+  ],
   "devDependencies": {
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",
@@ -69,15 +75,5 @@
       "json"
     ],
     "rootDir": "./src"
-  },
-  "greenkeeper": {
-    "ignore": [
-      "react",
-      "react-test-renderer",
-      "metro-react-native-babel-preset"
-    ]
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

We publish way more than necessary because we forgot to update npmignore. 
With this change publish size goes down from 170kB -> 20.8 kB

### Test plan

I think I included everything necessary for publishing, but please double check after me.

`npm pack`:

<details>

```
npm notice 📦  react-native-testing-library@2.0.0
npm notice === Tarball Contents ===
npm notice 1.1kB  LICENSE
npm notice 6.7kB  build/helpers/a11yAPI.js.flow
npm notice 146B   build/act.js.flow
npm notice 255B   build/cleanup.js.flow
npm notice 318B   build/helpers/debugDeep.js.flow
npm notice 458B   build/helpers/debugShallow.js.flow
npm notice 1.4kB  build/helpers/errors.js.flow
npm notice 2.6kB  build/helpers/findByAPI.js.flow
npm notice 1.9kB  build/fireEvent.js.flow
npm notice 372B   build/flushMicroTasks.js.flow
npm notice 255B   build/helpers/format.js.flow
npm notice 7.9kB  build/helpers/getByAPI.js.flow
npm notice 617B   build/index.js.flow
npm notice 2.3kB  build/helpers/makeQuery.js.flow
npm notice 492B   build/pure.js.flow
npm notice 4.6kB  build/helpers/queryByAPI.js.flow
npm notice 2.4kB  build/render.js.flow
npm notice 739B   build/shallow.js.flow
npm notice 796B   build/types.flow.js.flow
npm notice 1.9kB  build/waitFor.js.flow
npm notice 388B   build/within.js.flow
npm notice 4.0kB  build/helpers/a11yAPI.js
npm notice 291B   build/act.js
npm notice 327B   build/cleanup.js
npm notice 520B   build/helpers/debugDeep.js
npm notice 1.6kB  build/helpers/debugShallow.js
npm notice 43B    dont-cleanup-after-each.js
npm notice 1.8kB  build/helpers/errors.js
npm notice 2.7kB  build/helpers/findByAPI.js
npm notice 1.9kB  build/fireEvent.js
npm notice 469B   build/flushMicroTasks.js
npm notice 1.3kB  build/helpers/format.js
npm notice 9.3kB  build/helpers/getByAPI.js
npm notice 922B   build/index.js
npm notice 2.0kB  build/helpers/makeQuery.js
npm notice 2.7kB  build/pure.js
npm notice 116B   pure.js
npm notice 5.9kB  build/helpers/queryByAPI.js
npm notice 3.3kB  build/render.js
npm notice 1.8kB  build/shallow.js
npm notice 13B    build/types.flow.js
npm notice 3.2kB  build/waitFor.js
npm notice 636B   build/within.js
npm notice 2.3kB  package.json
npm notice 6.3kB  README.md
npm notice 10.4kB typings/index.d.ts
npm notice === Tarball Details ===
npm notice name:          react-native-testing-library
npm notice version:       2.0.0
npm notice filename:      react-native-testing-library-2.0.0.tgz
npm notice package size:  20.8 kB
npm notice unpacked size: 101.4 kB
npm notice shasum:        5e4b63656f69a5297ff7bb515604be7682fc88d9
npm notice integrity:     sha512-4DxVB/ge9+24R[...]UPh+uxz5Vy3PA==
npm notice total files:   46
```

</details>