### PR TITLE
Add support for react-native-web in getAllByTestId

### DIFF
--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -172,17 +172,26 @@ export const getAllByDisplayValue = (instance: ReactTestInstance) =>
 
 export const getAllByTestId = (instance: ReactTestInstance) =>
   function getAllByTestIdFn(testID: string): ReactTestInstance[] {
-    const results = instance
+    let results = instance
       .findAllByProps({ testID })
       .filter((element) => typeof element.type === 'string');
-
-    if (results.length === 0) {
-      throw new ErrorWithStack(
-        `No instances found with testID: ${String(testID)}`,
-        getAllByTestIdFn
-      );
+    
+    if (results.length !== 0) {
+      return results;
     }
-    return results;
+    
+    results = instance
+      .findAllByProps({ "data-testid": testID })
+      .filter((element) => typeof element.type === 'string');
+    
+    if (results.length !== 0) {
+      return results;
+    }
+
+    throw new ErrorWithStack(
+      `No instances found with testID: ${String(testID)}`,
+      getAllByTestIdFn
+    );
   };
 
 export const UNSAFE_getByType = (instance: ReactTestInstance) =>


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Because react-native-web uses "data-testid" instead of "testID", getAllByTestId was failing to get elements. This PR fixes it by looking for "data-testid" too.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Run tests with react-native-web. I'm using jest-expo/web preset for that.
