### PR TITLE
Support react-native-web in accessibilityLabel queries

### DIFF
--- a/src/helpers/a11yAPI.js
+++ b/src/helpers/a11yAPI.js
@@ -3,6 +3,9 @@ import type { A11yRole, A11yStates, A11yState, A11yValue } from '../types.flow';
 import type { WaitForOptions } from '../waitFor';
 import makeQuery from './makeQuery';
 
+// eslint-disable-next-line
+const { Platform } = require('react-native');
+
 type GetReturn = ReactTestInstance;
 type GetAllReturn = Array<ReactTestInstance>;
 type QueryReturn = ReactTestInstance | null;
@@ -98,10 +101,11 @@ export function matchObject<T: {}>(prop?: T, matcher: T): boolean {
     : false;
 }
 
+const isWeb = Platform.OS === 'web';
 const a11yAPI = (instance: ReactTestInstance): A11yAPI =>
   ({
     ...makeQuery(
-      'accessibilityLabel',
+      isWeb ? 'aria-label' : 'accessibilityLabel',
       {
         getBy: ['getByA11yLabel', 'getByAccessibilityLabel'],
         getAllBy: ['getAllByA11yLabel', 'getAllByAccessibilityLabel'],


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Because react-native-web uses "aria-label" instead of "accessibilityLabel", accessibilityLabel queries were failing to get elements. **NOTE:** If this approach is ok, I can check the remaining a11y queries and add support for them too.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Run tests with react-native-web. I'm using jest-expo/web preset for that.