### PR TITLE
Add a @ts-ignore for AccessibilityStates to support types for RN0.62+

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   AccessibilityState,
+  // @ts-ignore AccessibilityStates was deprecated in RN0.62 https://reactnative.dev/blog/2020/03/26/version-0.62#breaking-changes
   AccessibilityStates,
   AccessibilityRole,
 } from 'react-native';


### PR DESCRIPTION
### Summary

Fixes https://github.com/callstack/react-native-testing-library/issues/413

Adding a `@ts-ignore` for a prop that was [removed](https://reactnative.dev/blog/2020/03/26/version-0.62#breaking-changes) in RN0.62
