### PR TITLE
chore(breaking): rename to @testing-library/react-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ Supported and used by [Rally Health](https://www.rallyhealth.com/careers-home).
 
 <!-- badges -->
 
-[version-badge]: https://img.shields.io/npm/v/react-native-testing-library.svg?style=flat-square
-[package]: https://www.npmjs.com/package/react-native-testing-library
+[version-badge]: https://img.shields.io/npm/v/@testing-library/react-native.svg?style=flat-square
+[package]: https://www.npmjs.com/package/@testing-library/react-native
 [prs-welcome-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square
 [prs-welcome]: http://makeapullrequest.com
 [chat-badge]: https://img.shields.io/discord/426714625279524876.svg?style=flat-square&colorB=758ED3

--- a/examples/reactnavigation/package.json
+++ b/examples/reactnavigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-navigation-example",
-  "description": "Testing react-navigation with react-native-testing-library",
+  "description": "Testing React Navigation with RNTL",
   "version": "0.0.1",
   "private": true,
   "scripts": {
@@ -24,7 +24,7 @@
     "babel-jest": "^25.4.0",
     "jest": "^25.4.0",
     "metro-react-native-babel-preset": "^0.59.0",
-    "react-native-testing-library": "^1.13.0",
+    "@testing-library/react-native": "^7.0.0-rc.0",
     "react-test-renderer": "^16.13.1"
   }
 }

--- a/examples/reactnavigation/src/__tests__/AppNavigator.test.js
+++ b/examples/reactnavigation/src/__tests__/AppNavigator.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
-import { render, fireEvent } from 'react-native-testing-library';
+import { render, fireEvent } from '@testing-library/react-native';
 
 import AppNavigator from '../AppNavigator';
 

--- a/examples/redux/components/AddTodo.test.js
+++ b/examples/redux/components/AddTodo.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { fireEvent, render } from 'react-native-testing-library';
+import { fireEvent, render } from '@testing-library/react-native';
 import configureStore from '../store';
 import AddTodo from './AddTodo';
 

--- a/examples/redux/components/TodoList.test.js
+++ b/examples/redux/components/TodoList.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { fireEvent, render } from 'react-native-testing-library';
+import { fireEvent, render } from '@testing-library/react-native';
 import configureStore from '../store';
 import TodoList from './TodoList';
 

--- a/examples/redux/package.json
+++ b/examples/redux/package.json
@@ -16,7 +16,7 @@
     "babel-jest": "~25.2.6",
     "jest": "~25.2.6",
     "metro-react-native-babel-preset": "^0.59.0",
-    "react-native-testing-library": "^1.13.2",
+    "@testing-library/react-native": "^7.0.0-rc.0",
     "react-test-renderer": "~16.9.0"
   },
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "react-native-testing-library",
-  "version": "2.1.1",
-  "description": "Simple React Native testing utilities helping you write better tests with less effort",
+  "name": "@testing-library/react-native",
+  "version": "7.0.0-rc.0",
+  "description": "Simple and complete React Native testing utilities that encourage good testing practices.",
   "main": "build/index.js",
   "typings": "./typings/index.d.ts",
   "repository": {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -7,7 +7,7 @@ const siteConfig = {
   url: 'https://callstack.github.io', // Your website URL
   baseUrl: '/react-native-testing-library/', // Base URL for your project
   // Used for publishing and more
-  projectName: 'react-native-testing-library',
+  projectName: '@testing-library/react-native',
   organizationName: 'callstack',
   favicon: 'img/owl.png',
 


### PR DESCRIPTION
### Summary

Rename the library 🚀 .
Left a few references to `react-native-testing-library` because we keep the documentation and repo URLs untouched. Ref-links for traffic also stay unchanged.

### Test plan

Release a release candidate once this is merged.
