### PR TITLE
fix: fire event should not throw for disabled handler

### DIFF
--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -173,7 +173,7 @@ test('should not fire on disabled TouchableOpacity', () => {
     </TouchableOpacity>
   );
 
-  expect(() => fireEvent.press(screen.getByText('Trigger'))).not.toThrow();
+  fireEvent.press(screen.getByText('Trigger'));
   expect(handlePress).not.toHaveBeenCalled();
 });
 
@@ -185,7 +185,7 @@ test('should not fire on disabled Pressable', () => {
     </Pressable>
   );
 
-  expect(() => fireEvent.press(screen.getByText('Trigger'))).not.toThrow();
+  fireEvent.press(screen.getByText('Trigger'));
   expect(handlePress).not.toHaveBeenCalled();
 });
 

--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -168,9 +168,11 @@ test('event with multiple handler parameters', () => {
 test('should not fire on disabled TouchableOpacity', () => {
   const handlePress = jest.fn();
   const screen = render(
-    <TouchableOpacity onPress={handlePress} disabled={true}>
-      <Text>Trigger</Text>
-    </TouchableOpacity>
+    <View>
+      <TouchableOpacity onPress={handlePress} disabled={true}>
+        <Text>Trigger</Text>
+      </TouchableOpacity>
+    </View>
   );
 
   fireEvent.press(screen.getByText('Trigger'));
@@ -180,9 +182,11 @@ test('should not fire on disabled TouchableOpacity', () => {
 test('should not fire on disabled Pressable', () => {
   const handlePress = jest.fn();
   const screen = render(
-    <Pressable onPress={handlePress} disabled={true}>
-      <Text>Trigger</Text>
-    </Pressable>
+    <View>
+      <Pressable onPress={handlePress} disabled={true}>
+        <Text>Trigger</Text>
+      </Pressable>
+    </View>
   );
 
   fireEvent.press(screen.getByText('Trigger'));

--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -173,9 +173,7 @@ test('should not fire on disabled TouchableOpacity', () => {
     </TouchableOpacity>
   );
 
-  expect(() => fireEvent.press(screen.getByText('Trigger'))).toThrow(
-    'No handler function found for event: "press"'
-  );
+  expect(() => fireEvent.press(screen.getByText('Trigger'))).not.toThrow();
   expect(handlePress).not.toHaveBeenCalled();
 });
 
@@ -187,9 +185,7 @@ test('should not fire on disabled Pressable', () => {
     </Pressable>
   );
 
-  expect(() => fireEvent.press(screen.getByText('Trigger'))).toThrow(
-    'No handler function found for event: "press"'
-  );
+  expect(() => fireEvent.press(screen.getByText('Trigger'))).not.toThrow();
   expect(handlePress).not.toHaveBeenCalled();
 });
 

--- a/src/fireEvent.js
+++ b/src/fireEvent.js
@@ -20,12 +20,14 @@ const findEventHandler = (
 
   // Do not bubble event to the root element
   if (element.parent === null || element.parent.parent === null) {
-    if (hasHandler) return null;
-    else
+    if (hasHandler) {
+      return null;
+    } else {
       throw new ErrorWithStack(
         `No handler function found for event: "${eventName}"`,
         callsite || invokeEvent
       );
+    }
   }
 
   return findEventHandler(


### PR DESCRIPTION
### Summary

Fixes #469 

RNTL has a check that throws error when event handler missing. This is intended to inform developer that there is a mismatch between test assertions and components under test. This PR fixes a cases when this check throws error while component has a disabled event handler.

### Test plan
* updated tests for present & disabled handler not to throw
* we already have test for missing handler (not disabled), and for success cases
