### PR TITLE
fix: Return closest Text matching a query

### DIFF
--- a/src/__tests__/queryByApi.test.js
+++ b/src/__tests__/queryByApi.test.js
@@ -74,6 +74,21 @@ test('queryByText with nested Text components return the closest Text', () => {
   expect(getByText('My text').props.nativeID).toBe('2');
 });
 
+test('queryByText with nested Text components each with text return the lowest one', () => {
+  const NestedTexts = () => (
+    <Text nativeID="1">
+      bob
+      <Text nativeID="2">My text</Text>
+    </Text>
+  );
+
+  const { getByText } = render(<NestedTexts />);
+
+  expect(getByText('My text').props.nativeID).toBe('2');
+});
+
+
+
 test('queryByText nested <CustomText> in <Text>', () => {
   const CustomText = ({ children }) => {
     return <Text>{children}</Text>;

--- a/src/__tests__/queryByApi.test.js
+++ b/src/__tests__/queryByApi.test.js
@@ -69,9 +69,9 @@ test('queryByText with nested Text components return the closest Text', () => {
     </Text>
   );
 
-  const { getByText } = render(<NestedTexts />);
+  const { queryByText } = render(<NestedTexts />);
 
-  expect(getByText('My text').props.nativeID).toBe('2');
+  expect(queryByText('My text')?.props.nativeID).toBe('2');
 });
 
 test('queryByText with nested Text components each with text return the lowest one', () => {
@@ -82,9 +82,9 @@ test('queryByText with nested Text components each with text return the lowest o
     </Text>
   );
 
-  const { getByText } = render(<NestedTexts />);
+  const { queryByText } = render(<NestedTexts />);
 
-  expect(getByText('My text').props.nativeID).toBe('2');
+  expect(queryByText('My text')?.props.nativeID).toBe('2');
 });
 
 test('queryByText nested <CustomText> in <Text>', () => {

--- a/src/__tests__/queryByApi.test.js
+++ b/src/__tests__/queryByApi.test.js
@@ -87,8 +87,6 @@ test('queryByText with nested Text components each with text return the lowest o
   expect(getByText('My text').props.nativeID).toBe('2');
 });
 
-
-
 test('queryByText nested <CustomText> in <Text>', () => {
   const CustomText = ({ children }) => {
     return <Text>{children}</Text>;

--- a/src/__tests__/queryByApi.test.js
+++ b/src/__tests__/queryByApi.test.js
@@ -49,17 +49,17 @@ test('queryByText not found', () => {
 });
 
 test('queryByText nested text across multiple <Text> in <Text>', () => {
-  expect(
-    render(
-      <Text>
-        Hello{' '}
-        <Text>
-          World
-          <Text>!{true}</Text>
-        </Text>
+  const { queryByText } = render(
+    <Text nativeID="1">
+      Hello{' '}
+      <Text nativeID="2">
+        World
+        <Text>!{true}</Text>
       </Text>
-    ).queryByText('Hello World!')
-  ).toBeTruthy();
+    </Text>
+  );
+
+  expect(queryByText('Hello World!')?.props.nativeID).toBe('1');
 });
 
 test('queryByText with nested Text components return the closest Text', () => {

--- a/src/__tests__/queryByApi.test.js
+++ b/src/__tests__/queryByApi.test.js
@@ -48,7 +48,7 @@ test('queryByText not found', () => {
   ).toBeFalsy();
 });
 
-test('queryByText nested multiple <Text> in <Text>', () => {
+test('queryByText nested text across multiple <Text> in <Text>', () => {
   expect(
     render(
       <Text>
@@ -62,6 +62,18 @@ test('queryByText nested multiple <Text> in <Text>', () => {
   ).toBeTruthy();
 });
 
+test('queryByText with nested Text components return the closest Text', () => {
+  const NestedTexts = () => (
+    <Text nativeID="1">
+      <Text nativeID="2">My text</Text>
+    </Text>
+  );
+
+  const { getByText } = render(<NestedTexts />);
+
+  expect(getByText('My text').props.nativeID).toBe('2');
+});
+
 test('queryByText nested <CustomText> in <Text>', () => {
   const CustomText = ({ children }) => {
     return <Text>{children}</Text>;
@@ -71,6 +83,20 @@ test('queryByText nested <CustomText> in <Text>', () => {
     render(
       <Text>
         Hello <CustomText>World!</CustomText>
+      </Text>
+    ).queryByText('Hello World!')
+  ).toBeTruthy();
+});
+
+test('queryByText nested deep <CustomText> in <Text>', () => {
+  const CustomText = ({ children }) => {
+    return <Text>{children}</Text>;
+  };
+
+  expect(
+    render(
+      <Text>
+        <CustomText>Hello</CustomText> <CustomText>World!</CustomText>
       </Text>
     ).queryByText('Hello World!')
   ).toBeTruthy();

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -44,6 +44,18 @@ const getChildrenAsText = (children, TextComponent, textContent = []) => {
     }
 
     if (child?.props?.children) {
+      // This means that down in the tree of a <TextComponent /> there's another TextComponent that
+      // contains a string, but the parent itself doesn't contain any other string
+      // We should then match against this child, since querying aims to always return the element
+      // the closest to the target text. For instance in this example we don't want
+      // getChildrenAsText to match on the Text of nativeID "1", but the one of nativeID "2"
+      // <Text nativeID="1">
+      //   <Text nativeID="2">My text</Text>
+      // </Text>
+      if (filterNodeByType(child, TextComponent) && textContent.length === 0) {
+        return;
+      }
+
       getChildrenAsText(child.props.children, TextComponent, textContent);
     }
   });

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -47,7 +47,7 @@ const getChildrenAsText = (children, TextComponent, textContent = []) => {
       // Bail on traversing text children down the tree if current node (child)
       // has no text. In such situations, react-test-renderer will traverse down
       // this tree in a separate call and run this query again. As a result, the
-      // query will match a deeper text node that may have text some content.
+      // query will match the deepest text node that matches requested text.
       if (filterNodeByType(child, TextComponent) && textContent.length === 0) {
         return;
       }

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -44,14 +44,10 @@ const getChildrenAsText = (children, TextComponent, textContent = []) => {
     }
 
     if (child?.props?.children) {
-      // This means that down in the tree of a <TextComponent /> there's another TextComponent that
-      // contains a string, but the parent itself doesn't contain any other string
-      // We should then match against this child, since querying aims to always return the element
-      // the closest to the target text. For instance in this example we don't want
-      // getChildrenAsText to match on the Text of nativeID "1", but the one of nativeID "2"
-      // <Text nativeID="1">
-      //   <Text nativeID="2">My text</Text>
-      // </Text>
+      // Bail on traversing text children down the tree if current node (child)
+      // has no text. In such situations, react-test-renderer will traverse down
+      // this tree in a separate call and run this query again. As a result, the
+      // query will match a deeper text node that may have text some content.
       if (filterNodeByType(child, TextComponent) && textContent.length === 0) {
         return;
       }


### PR DESCRIPTION
### Summary
When using `getByText()` on a component using nested `Text`s, it should match the closest one.
```jsx
<Text id={1}>
  <Text id={2}>My text</Text>
</Text>
```

I've found this bug when trying to upgrade from `@5.X` to `@7.X`, this breaks one of my tests where an `onPress` handler is attached to the lower Text, and since `getByText` returns  its parent, using `fireEvent.press(getByText('My text'))` doesn't work.

### Test plan

The added tests should show the covered case. I added an another test to be sure I would not introduce a regression.
