### PR TITLE
chore: test website build on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,10 @@ aliases:
     branches:
       only:
         - master
+  - &filter-ignore-master
+    branches:
+      ignore:
+        - master
 
 defaults: &defaults
   docker:
@@ -54,6 +58,13 @@ jobs:
       - store_artifacts:
           path: coverage
           destination: coverage
+  test-website:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/react-native-testing-library
+      - run: |
+          cd website && yarn install && yarn build
   deploy-website:
     <<: *defaults
     steps:
@@ -80,6 +91,11 @@ workflows:
       - tests:
           requires:
             - install-dependencies
+      - test-website:
+          requires:
+            - install-dependencies
+          # docusuarus build is running when deploying website as well
+          filters: *filter-ignore-master
       - deploy-website:
           requires:
             - install-dependencies


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Docusaurus performs some checks when building, it's worth to run `build` before it reaches master and catch the errors early.

### Test plan

CI
