### PR TITLE
Clarify waitFor documentation in regards to timer mocks

### DIFF
--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -354,7 +354,7 @@ test('waiting for an Banana to be ready', async () => {
 In order to properly use `waitFor` you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
 :::
 
-If you're using Jest's [Timer Mocks](https://jestjs.io/docs/en/timer-mocks#docsNav), remember not to use `async/await` syntax as it will stall your tests.
+If you're using Jest's [Timer Mocks](https://jestjs.io/docs/en/timer-mocks#docsNav), remember not to await the return of `waitFor` as it will stall your tests.
 
 ## `waitForElementToBeRemoved`
 


### PR DESCRIPTION
Update documentation to explicitly state that one should not await the return or resolution of a `waitFor` call when relying upon timer mocks.
