### PR TITLE
Clarify additional waitFor documentation

### DIFF
--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -392,7 +392,7 @@ You can use any of `getBy`, `getAllBy`, `queryBy` and `queryAllBy` queries for `
 In order to properly use `waitForElementToBeRemoved` you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
 :::
 
-If you're using Jest's [Timer Mocks](https://jestjs.io/docs/en/timer-mocks#docsNav), remember not to use `async/await` syntax as it will stall your tests.
+If you're using Jest's [Timer Mocks](https://jestjs.io/docs/en/timer-mocks#docsNav), remember not to await the return of `waitFor` as it will stall your tests.
 
 ## `within`, `getQueriesForElement`
 


### PR DESCRIPTION
Update documentation to explicitly state that one should not await the return or resolution of a `waitFor` call when relying upon timer mocks.

Update additional documentation overlooked in #538.
