### PR TITLE
feat: add text match options a.k.a string precision API

### DIFF
--- a/src/__tests__/findByApi.test.js
+++ b/src/__tests__/findByApi.test.js
@@ -18,19 +18,19 @@ test('findBy queries work asynchronously', async () => {
   } = render(<View />);
   await expect(findByTestId('aTestId', options)).rejects.toBeTruthy();
   await expect(findAllByTestId('aTestId', options)).rejects.toBeTruthy();
-  await expect(findByText('Some Text', options)).rejects.toBeTruthy();
-  await expect(findAllByText('Some Text', options)).rejects.toBeTruthy();
+  await expect(findByText('Some Text', {}, options)).rejects.toBeTruthy();
+  await expect(findAllByText('Some Text', {}, options)).rejects.toBeTruthy();
   await expect(
-    findByPlaceholderText('Placeholder Text', options)
+    findByPlaceholderText('Placeholder Text', {}, options)
   ).rejects.toBeTruthy();
   await expect(
-    findAllByPlaceholderText('Placeholder Text', options)
+    findAllByPlaceholderText('Placeholder Text', {}, options)
   ).rejects.toBeTruthy();
   await expect(
-    findByDisplayValue('Display Value', options)
+    findByDisplayValue('Display Value', {}, options)
   ).rejects.toBeTruthy();
   await expect(
-    findAllByDisplayValue('Display Value', options)
+    findAllByDisplayValue('Display Value', {}, options)
   ).rejects.toBeTruthy();
 
   setTimeout(

--- a/src/__tests__/getByApi.test.js
+++ b/src/__tests__/getByApi.test.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import { View, Text, TextInput, Button } from 'react-native';
-import { render } from '..';
+import { render, getDefaultNormalizer } from '..';
 
 const MyComponent = () => {
   return <Text>My Component</Text>;
@@ -123,7 +123,7 @@ describe('Supports normalization', () => {
     expect(getByText('Text and whitespace')).toBeTruthy();
   });
 
-  test('trim and collapseWhitespace is customizable by queryOptions param', () => {
+  test('trim and collapseWhitespace is customizable by getDefaultNormalizer param', () => {
     const testTextWithWhitespace = `  Text     and
         
         
@@ -136,8 +136,10 @@ describe('Supports normalization', () => {
 
     expect(
       getByText(testTextWithWhitespace, {
-        trim: false,
-        collapseWhitespace: false,
+        normalizer: getDefaultNormalizer({
+          trim: false,
+          collapseWhitespace: false,
+        }),
       })
     ).toBeTruthy();
   });

--- a/src/__tests__/getByApi.test.js
+++ b/src/__tests__/getByApi.test.js
@@ -108,3 +108,54 @@ describe('Supports a TextMatch options', () => {
     expect(getAllByText('detail', { exact: false })).toHaveLength(2);
   });
 });
+
+describe('Supports normalization', () => {
+  test('trims and collapses whitespace by default', () => {
+    const { getByText } = render(
+      <View>
+        <Text>{`  Text     and
+        
+        
+        whitespace`}</Text>
+      </View>
+    );
+
+    expect(getByText('Text and whitespace')).toBeTruthy();
+  });
+
+  test('trim and collapseWhitespace is customizable by queryOptions param', () => {
+    const testTextWithWhitespace = `  Text     and
+        
+        
+        whitespace`;
+    const { getByText } = render(
+      <View>
+        <Text>{testTextWithWhitespace}</Text>
+      </View>
+    );
+
+    expect(
+      getByText(testTextWithWhitespace, {
+        trim: false,
+        collapseWhitespace: false,
+      })
+    ).toBeTruthy();
+  });
+
+  test('normalizer function is customisable', () => {
+    const testText = 'A TO REMOVE text';
+    const normalizerFn = (textToNormalize: string) =>
+      textToNormalize.replace('TO REMOVE ', '');
+    const { getByText } = render(
+      <View>
+        <Text>{testText}</Text>
+      </View>
+    );
+
+    expect(
+      getByText('A text', {
+        normalizer: normalizerFn,
+      })
+    ).toBeTruthy();
+  });
+});

--- a/src/__tests__/getByApi.test.js
+++ b/src/__tests__/getByApi.test.js
@@ -50,3 +50,61 @@ test('supports a regex matcher', () => {
   expect(getByTestId(/view/)).toBeTruthy();
   expect(getAllByTestId(/text/)).toHaveLength(2);
 });
+
+describe('Supports a TextMatch options', () => {
+  test('getByText, getAllByText', () => {
+    const { getByText, getAllByText } = render(
+      <View>
+        <Text testID="text">Text and details</Text>
+        <Button
+          testID="button"
+          title="Button and a detail"
+          onPress={jest.fn()}
+        />
+      </View>
+    );
+
+    expect(getByText('details', { exact: false })).toBeTruthy();
+    expect(getAllByText('detail', { exact: false })).toHaveLength(2);
+  });
+
+  test('getByPlaceholderText, getAllByPlaceholderText', () => {
+    const { getByPlaceholderText, getAllByPlaceholderText } = render(
+      <View>
+        <TextInput placeholder={'Placeholder with details'} />
+        <TextInput placeholder={'Placeholder with a DETAIL'} />
+      </View>
+    );
+
+    expect(getByPlaceholderText('details', { exact: false })).toBeTruthy();
+    expect(getAllByPlaceholderText('detail', { exact: false })).toHaveLength(2);
+  });
+
+  test('getByDisplayValue, getAllByDisplayValue', () => {
+    const { getByDisplayValue, getAllByDisplayValue } = render(
+      <View>
+        <TextInput value={'Value with details'} />
+        <TextInput value={'Value with a detail'} />
+      </View>
+    );
+
+    expect(getByDisplayValue('details', { exact: false })).toBeTruthy();
+    expect(getAllByDisplayValue('detail', { exact: false })).toHaveLength(2);
+  });
+
+  test('with TextMatch option exact === false text search is NOT case sensitive', () => {
+    const { getByText, getAllByText } = render(
+      <View>
+        <Text testID="text">Text and details</Text>
+        <Button
+          testID="button"
+          title="Button and a DeTAil"
+          onPress={jest.fn()}
+        />
+      </View>
+    );
+
+    expect(getByText('DeTaIlS', { exact: false })).toBeTruthy();
+    expect(getAllByText('detail', { exact: false })).toHaveLength(2);
+  });
+});

--- a/src/__tests__/queryByApi.test.js
+++ b/src/__tests__/queryByApi.test.js
@@ -89,17 +89,28 @@ test('queryByText with nested Text components each with text return the lowest o
   expect(queryByText('My text')?.props.nativeID).toBe('2');
 });
 
-test('queryByText with nested Text components each with text return the top one when using not-exact text match', () => {
-  const NestedTexts = () => (
+test('queryByText with nested Text components: not-exact text match returns the most deeply nested common component', () => {
+  const { queryByText: queryByTextFirstCase } = render(
     <Text nativeID="1">
       bob
-      <Text nativeID="2">My text</Text>
+      <Text nativeID="2">My </Text>
+      <Text nativeID="3">text</Text>
     </Text>
   );
 
-  const { queryByText } = render(<NestedTexts />);
+  const { queryByText: queryByTextSecondCase } = render(
+    <Text nativeID="1">
+      bob
+      <Text nativeID="2">My text for test</Text>
+    </Text>
+  );
 
-  expect(queryByText('My text', { exact: false })?.props.nativeID).toBe('1');
+  expect(
+    queryByTextFirstCase('My text', { exact: false })?.props.nativeID
+  ).toBe('1');
+  expect(
+    queryByTextSecondCase('My text', { exact: false })?.props.nativeID
+  ).toBe('2');
 });
 
 test('queryByText nested <CustomText> in <Text>', () => {

--- a/src/__tests__/queryByApi.test.js
+++ b/src/__tests__/queryByApi.test.js
@@ -60,6 +60,7 @@ test('queryByText nested text across multiple <Text> in <Text>', () => {
   );
 
   expect(queryByText('Hello World!')?.props.nativeID).toBe('1');
+  expect(queryByText('hello Wo', { exact: false })?.props.nativeID).toBe('1');
 });
 
 test('queryByText with nested Text components return the closest Text', () => {
@@ -72,6 +73,7 @@ test('queryByText with nested Text components return the closest Text', () => {
   const { queryByText } = render(<NestedTexts />);
 
   expect(queryByText('My text')?.props.nativeID).toBe('2');
+  expect(queryByText('My text', { exact: false })?.props.nativeID).toBe('2');
 });
 
 test('queryByText with nested Text components each with text return the lowest one', () => {
@@ -85,6 +87,19 @@ test('queryByText with nested Text components each with text return the lowest o
   const { queryByText } = render(<NestedTexts />);
 
   expect(queryByText('My text')?.props.nativeID).toBe('2');
+});
+
+test('queryByText with nested Text components each with text return the top one when using not-exact text match', () => {
+  const NestedTexts = () => (
+    <Text nativeID="1">
+      bob
+      <Text nativeID="2">My text</Text>
+    </Text>
+  );
+
+  const { queryByText } = render(<NestedTexts />);
+
+  expect(queryByText('My text', { exact: false })?.props.nativeID).toBe('1');
 });
 
 test('queryByText nested <CustomText> in <Text>', () => {

--- a/src/helpers/findByAPI.js
+++ b/src/helpers/findByAPI.js
@@ -20,83 +20,83 @@ const makeFindQuery = <Text, Result>(
     instance: ReactTestInstance
   ) => (text: Text, options?: TextMatchOptions) => Result,
   text: Text,
-  waitForOptions: WaitForOptions,
-  queryOptions?: TextMatchOptions
+  queryOptions?: TextMatchOptions,
+  waitForOptions: WaitForOptions
 ): Promise<Result> =>
   waitFor(() => getQuery(instance)(text, queryOptions), waitForOptions);
 
 export const findByTestId = (instance: ReactTestInstance) => (
   testId: string | RegExp,
   waitForOptions: WaitForOptions = {}
-) => makeFindQuery(instance, getByTestId, testId, waitForOptions);
+) => makeFindQuery(instance, getByTestId, testId, {}, waitForOptions);
 
 export const findAllByTestId = (instance: ReactTestInstance) => (
   testId: string | RegExp,
   waitForOptions: WaitForOptions = {}
-) => makeFindQuery(instance, getAllByTestId, testId, waitForOptions);
+) => makeFindQuery(instance, getAllByTestId, testId, {}, waitForOptions);
 
 export const findByText = (instance: ReactTestInstance) => (
   text: string | RegExp,
-  waitForOptions: WaitForOptions = {},
-  queryOptions?: TextMatchOptions
-) => makeFindQuery(instance, getByText, text, waitForOptions, queryOptions);
+  queryOptions?: TextMatchOptions,
+  waitForOptions: WaitForOptions = {}
+) => makeFindQuery(instance, getByText, text, queryOptions, waitForOptions);
 
 export const findAllByText = (instance: ReactTestInstance) => (
   text: string | RegExp,
-  waitForOptions: WaitForOptions = {},
-  queryOptions?: TextMatchOptions
-) => makeFindQuery(instance, getAllByText, text, waitForOptions, queryOptions);
+  queryOptions?: TextMatchOptions,
+  waitForOptions: WaitForOptions = {}
+) => makeFindQuery(instance, getAllByText, text, queryOptions, waitForOptions);
 
 export const findByPlaceholderText = (instance: ReactTestInstance) => (
   placeholder: string | RegExp,
-  waitForOptions: WaitForOptions = {},
-  queryOptions?: TextMatchOptions
+  queryOptions?: TextMatchOptions,
+  waitForOptions: WaitForOptions = {}
 ) =>
   makeFindQuery(
     instance,
     getByPlaceholderText,
     placeholder,
-    waitForOptions,
-    queryOptions
+    queryOptions,
+    waitForOptions
   );
 
 export const findAllByPlaceholderText = (instance: ReactTestInstance) => (
   placeholder: string | RegExp,
-  waitForOptions: WaitForOptions = {},
-  queryOptions?: TextMatchOptions
+  queryOptions?: TextMatchOptions,
+  waitForOptions: WaitForOptions = {}
 ) =>
   makeFindQuery(
     instance,
     getAllByPlaceholderText,
     placeholder,
-    waitForOptions,
-    queryOptions
+    queryOptions,
+    waitForOptions
   );
 
 export const findByDisplayValue = (instance: ReactTestInstance) => (
   value: string | RegExp,
-  waitForOptions: WaitForOptions = {},
-  queryOptions?: TextMatchOptions
+  queryOptions?: TextMatchOptions,
+  waitForOptions: WaitForOptions = {}
 ) =>
   makeFindQuery(
     instance,
     getByDisplayValue,
     value,
-    waitForOptions,
-    queryOptions
+    queryOptions,
+    waitForOptions
   );
 
 export const findAllByDisplayValue = (instance: ReactTestInstance) => (
   value: string | RegExp,
-  waitForOptions: WaitForOptions = {},
-  queryOptions?: TextMatchOptions
+  queryOptions?: TextMatchOptions,
+  waitForOptions: WaitForOptions = {}
 ) =>
   makeFindQuery(
     instance,
     getAllByDisplayValue,
     value,
-    waitForOptions,
-    queryOptions
+    queryOptions,
+    waitForOptions
   );
 
 export const findByAPI = (instance: ReactTestInstance) => ({

--- a/src/helpers/findByAPI.js
+++ b/src/helpers/findByAPI.js
@@ -21,9 +21,9 @@ const makeFindQuery = <Text, Result>(
   ) => (text: Text, options?: TextMatchOptions) => Result,
   text: Text,
   waitForOptions: WaitForOptions,
-  textMatchOptions?: TextMatchOptions
+  queryOptions?: TextMatchOptions
 ): Promise<Result> =>
-  waitFor(() => getQuery(instance)(text, textMatchOptions), waitForOptions);
+  waitFor(() => getQuery(instance)(text, queryOptions), waitForOptions);
 
 export const findByTestId = (instance: ReactTestInstance) => (
   testId: string | RegExp,
@@ -38,66 +38,65 @@ export const findAllByTestId = (instance: ReactTestInstance) => (
 export const findByText = (instance: ReactTestInstance) => (
   text: string | RegExp,
   waitForOptions: WaitForOptions = {},
-  textMatchOptions?: TextMatchOptions
-) => makeFindQuery(instance, getByText, text, waitForOptions, textMatchOptions);
+  queryOptions?: TextMatchOptions
+) => makeFindQuery(instance, getByText, text, waitForOptions, queryOptions);
 
 export const findAllByText = (instance: ReactTestInstance) => (
   text: string | RegExp,
   waitForOptions: WaitForOptions = {},
-  textMatchOptions?: TextMatchOptions
-) =>
-  makeFindQuery(instance, getAllByText, text, waitForOptions, textMatchOptions);
+  queryOptions?: TextMatchOptions
+) => makeFindQuery(instance, getAllByText, text, waitForOptions, queryOptions);
 
 export const findByPlaceholderText = (instance: ReactTestInstance) => (
   placeholder: string | RegExp,
   waitForOptions: WaitForOptions = {},
-  textMatchOptions?: TextMatchOptions
+  queryOptions?: TextMatchOptions
 ) =>
   makeFindQuery(
     instance,
     getByPlaceholderText,
     placeholder,
     waitForOptions,
-    textMatchOptions
+    queryOptions
   );
 
 export const findAllByPlaceholderText = (instance: ReactTestInstance) => (
   placeholder: string | RegExp,
   waitForOptions: WaitForOptions = {},
-  textMatchOptions?: TextMatchOptions
+  queryOptions?: TextMatchOptions
 ) =>
   makeFindQuery(
     instance,
     getAllByPlaceholderText,
     placeholder,
     waitForOptions,
-    textMatchOptions
+    queryOptions
   );
 
 export const findByDisplayValue = (instance: ReactTestInstance) => (
   value: string | RegExp,
   waitForOptions: WaitForOptions = {},
-  textMatchOptions?: TextMatchOptions
+  queryOptions?: TextMatchOptions
 ) =>
   makeFindQuery(
     instance,
     getByDisplayValue,
     value,
     waitForOptions,
-    textMatchOptions
+    queryOptions
   );
 
 export const findAllByDisplayValue = (instance: ReactTestInstance) => (
   value: string | RegExp,
   waitForOptions: WaitForOptions = {},
-  textMatchOptions?: TextMatchOptions
+  queryOptions?: TextMatchOptions
 ) =>
   makeFindQuery(
     instance,
     getAllByDisplayValue,
     value,
     waitForOptions,
-    textMatchOptions
+    queryOptions
   );
 
 export const findByAPI = (instance: ReactTestInstance) => ({

--- a/src/helpers/findByAPI.js
+++ b/src/helpers/findByAPI.js
@@ -12,13 +12,18 @@ import {
   getAllByDisplayValue,
 } from './getByAPI';
 import { throwRenamedFunctionError } from './errors';
+import type { TextMatchOptions } from './getByAPI';
 
 const makeFindQuery = <Text, Result>(
   instance: ReactTestInstance,
-  getQuery: (instance: ReactTestInstance) => (text: Text) => Result,
+  getQuery: (
+    instance: ReactTestInstance
+  ) => (text: Text, options?: TextMatchOptions) => Result,
   text: Text,
-  waitForOptions: WaitForOptions
-): Promise<Result> => waitFor(() => getQuery(instance)(text), waitForOptions);
+  waitForOptions: WaitForOptions,
+  textMatchOptions?: TextMatchOptions
+): Promise<Result> =>
+  waitFor(() => getQuery(instance)(text, textMatchOptions), waitForOptions);
 
 export const findByTestId = (instance: ReactTestInstance) => (
   testId: string | RegExp,
@@ -32,34 +37,68 @@ export const findAllByTestId = (instance: ReactTestInstance) => (
 
 export const findByText = (instance: ReactTestInstance) => (
   text: string | RegExp,
-  waitForOptions: WaitForOptions = {}
-) => makeFindQuery(instance, getByText, text, waitForOptions);
+  waitForOptions: WaitForOptions = {},
+  textMatchOptions?: TextMatchOptions
+) => makeFindQuery(instance, getByText, text, waitForOptions, textMatchOptions);
 
 export const findAllByText = (instance: ReactTestInstance) => (
   text: string | RegExp,
-  waitForOptions: WaitForOptions = {}
-) => makeFindQuery(instance, getAllByText, text, waitForOptions);
+  waitForOptions: WaitForOptions = {},
+  textMatchOptions?: TextMatchOptions
+) =>
+  makeFindQuery(instance, getAllByText, text, waitForOptions, textMatchOptions);
 
 export const findByPlaceholderText = (instance: ReactTestInstance) => (
   placeholder: string | RegExp,
-  waitForOptions: WaitForOptions = {}
-) => makeFindQuery(instance, getByPlaceholderText, placeholder, waitForOptions);
+  waitForOptions: WaitForOptions = {},
+  textMatchOptions?: TextMatchOptions
+) =>
+  makeFindQuery(
+    instance,
+    getByPlaceholderText,
+    placeholder,
+    waitForOptions,
+    textMatchOptions
+  );
 
 export const findAllByPlaceholderText = (instance: ReactTestInstance) => (
   placeholder: string | RegExp,
-  waitForOptions: WaitForOptions = {}
+  waitForOptions: WaitForOptions = {},
+  textMatchOptions?: TextMatchOptions
 ) =>
-  makeFindQuery(instance, getAllByPlaceholderText, placeholder, waitForOptions);
+  makeFindQuery(
+    instance,
+    getAllByPlaceholderText,
+    placeholder,
+    waitForOptions,
+    textMatchOptions
+  );
 
 export const findByDisplayValue = (instance: ReactTestInstance) => (
   value: string | RegExp,
-  waitForOptions: WaitForOptions = {}
-) => makeFindQuery(instance, getByDisplayValue, value, waitForOptions);
+  waitForOptions: WaitForOptions = {},
+  textMatchOptions?: TextMatchOptions
+) =>
+  makeFindQuery(
+    instance,
+    getByDisplayValue,
+    value,
+    waitForOptions,
+    textMatchOptions
+  );
 
 export const findAllByDisplayValue = (instance: ReactTestInstance) => (
   value: string | RegExp,
-  waitForOptions: WaitForOptions = {}
-) => makeFindQuery(instance, getAllByDisplayValue, value, waitForOptions);
+  waitForOptions: WaitForOptions = {},
+  textMatchOptions?: TextMatchOptions
+) =>
+  makeFindQuery(
+    instance,
+    getAllByDisplayValue,
+    value,
+    waitForOptions,
+    textMatchOptions
+  );
 
 export const findByAPI = (instance: ReactTestInstance) => ({
   findByTestId: findByTestId(instance),

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -14,8 +14,6 @@ import {
 export type TextMatchOptions = {
   exact?: boolean,
   normalizer?: NormalizerFn,
-  trim?: boolean,
-  collapseWhitespace?: boolean,
 };
 
 const filterNodeByType = (node, type) => node.type === type;
@@ -29,10 +27,8 @@ const getNodeByText = (node, text, options?: TextMatchOptions = {}) => {
       const textChildren = getChildrenAsText(node.props.children, Text);
       if (textChildren) {
         const textToTest = textChildren.join('');
-        const { exact, normalizer, trim, collapseWhitespace } = options;
+        const { exact, normalizer } = options;
         const normalizerFn = makeNormalizer({
-          trim,
-          collapseWhitespace,
           normalizer,
         });
         return matches(textToTest, text, normalizerFn, exact);
@@ -80,10 +76,8 @@ const getTextInputNodeByPlaceholderText = (
   try {
     // eslint-disable-next-line
     const { TextInput } = require('react-native');
-    const { exact, normalizer, trim, collapseWhitespace } = options;
+    const { exact, normalizer } = options;
     const normalizerFn = makeNormalizer({
-      trim,
-      collapseWhitespace,
       normalizer,
     });
     return (
@@ -103,10 +97,8 @@ const getTextInputNodeByDisplayValue = (
   try {
     // eslint-disable-next-line
     const { TextInput } = require('react-native');
-    const { exact, normalizer, trim, collapseWhitespace } = options;
+    const { exact, normalizer } = options;
     const normalizerFn = makeNormalizer({
-      trim,
-      collapseWhitespace,
       normalizer,
     });
     return (

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -117,9 +117,32 @@ const getNodeByTestId = (node, testID) => {
 };
 
 export const getByText = (instance: ReactTestInstance) =>
-  function getByTextFn(text: string | RegExp, options?: TextMatchOptions) {
+  function getByTextFn(
+    text: string | RegExp,
+    options: TextMatchOptions = { exact: true }
+  ) {
     try {
-      return instance.find((node) => getNodeByText(node, text, options));
+      const matches = instance.findAll((node) =>
+        getNodeByText(node, text, options)
+      );
+
+      if (matches.length === 0) {
+        throw new ErrorWithStack(
+          `No instances found with text: ${String(text)}`,
+          getByTextFn
+        );
+      }
+
+      if (options.exact && matches.length > 1) {
+        throw new ErrorWithStack(
+          `Expected 1 but found ${
+            matches.length
+          } instances matching text ${String(text)}`,
+          getByTextFn
+        );
+      }
+      // when using exact === false we want to return last match (most deeply nested in component tree)
+      return matches[matches.length - 1];
     } catch (error) {
       throw new ErrorWithStack(prepareErrorMessage(error), getByTextFn);
     }

--- a/src/helpers/queryByAPI.js
+++ b/src/helpers/queryByAPI.js
@@ -19,29 +19,36 @@ import {
   throwRemovedFunctionError,
   throwRenamedFunctionError,
 } from './errors';
+import type { TextMatchOptions } from './getByAPI';
 
 export const queryByText = (instance: ReactTestInstance) =>
-  function queryByTextFn(text: string | RegExp) {
+  function queryByTextFn(text: string | RegExp, options?: TextMatchOptions) {
     try {
-      return getByText(instance)(text);
+      return getByText(instance)(text, options);
     } catch (error) {
       return createQueryByError(error, queryByTextFn);
     }
   };
 
 export const queryByPlaceholderText = (instance: ReactTestInstance) =>
-  function queryByPlaceholderTextFn(placeholder: string | RegExp) {
+  function queryByPlaceholderTextFn(
+    placeholder: string | RegExp,
+    options?: TextMatchOptions
+  ) {
     try {
-      return getByPlaceholderText(instance)(placeholder);
+      return getByPlaceholderText(instance)(placeholder, options);
     } catch (error) {
       return createQueryByError(error, queryByPlaceholderTextFn);
     }
   };
 
 export const queryByDisplayValue = (instance: ReactTestInstance) =>
-  function queryByDisplayValueFn(value: string | RegExp) {
+  function queryByDisplayValueFn(
+    value: string | RegExp,
+    options?: TextMatchOptions
+  ) {
     try {
-      return getByDisplayValue(instance)(value);
+      return getByDisplayValue(instance)(value, options);
     } catch (error) {
       return createQueryByError(error, queryByDisplayValueFn);
     }
@@ -57,30 +64,33 @@ export const queryByTestId = (instance: ReactTestInstance) =>
   };
 
 export const queryAllByText = (instance: ReactTestInstance) => (
-  text: string | RegExp
+  text: string | RegExp,
+  options?: TextMatchOptions
 ) => {
   try {
-    return getAllByText(instance)(text);
+    return getAllByText(instance)(text, options);
   } catch (error) {
     return [];
   }
 };
 
 export const queryAllByPlaceholderText = (instance: ReactTestInstance) => (
-  placeholder: string | RegExp
+  placeholder: string | RegExp,
+  options?: TextMatchOptions
 ) => {
   try {
-    return getAllByPlaceholderText(instance)(placeholder);
+    return getAllByPlaceholderText(instance)(placeholder, options);
   } catch (error) {
     return [];
   }
 };
 
 export const queryAllByDisplayValue = (instance: ReactTestInstance) => (
-  value: string | RegExp
+  value: string | RegExp,
+  options?: TextMatchOptions
 ) => {
   try {
-    return getAllByDisplayValue(instance)(value);
+    return getAllByDisplayValue(instance)(value, options);
   } catch (error) {
     return [];
   }

--- a/src/helpers/queryByAPI.js
+++ b/src/helpers/queryByAPI.js
@@ -22,9 +22,12 @@ import {
 import type { TextMatchOptions } from './getByAPI';
 
 export const queryByText = (instance: ReactTestInstance) =>
-  function queryByTextFn(text: string | RegExp, options?: TextMatchOptions) {
+  function queryByTextFn(
+    text: string | RegExp,
+    queryOptions?: TextMatchOptions
+  ) {
     try {
-      return getByText(instance)(text, options);
+      return getByText(instance)(text, queryOptions);
     } catch (error) {
       return createQueryByError(error, queryByTextFn);
     }
@@ -33,10 +36,10 @@ export const queryByText = (instance: ReactTestInstance) =>
 export const queryByPlaceholderText = (instance: ReactTestInstance) =>
   function queryByPlaceholderTextFn(
     placeholder: string | RegExp,
-    options?: TextMatchOptions
+    queryOptions?: TextMatchOptions
   ) {
     try {
-      return getByPlaceholderText(instance)(placeholder, options);
+      return getByPlaceholderText(instance)(placeholder, queryOptions);
     } catch (error) {
       return createQueryByError(error, queryByPlaceholderTextFn);
     }
@@ -45,10 +48,10 @@ export const queryByPlaceholderText = (instance: ReactTestInstance) =>
 export const queryByDisplayValue = (instance: ReactTestInstance) =>
   function queryByDisplayValueFn(
     value: string | RegExp,
-    options?: TextMatchOptions
+    queryOptions?: TextMatchOptions
   ) {
     try {
-      return getByDisplayValue(instance)(value, options);
+      return getByDisplayValue(instance)(value, queryOptions);
     } catch (error) {
       return createQueryByError(error, queryByDisplayValueFn);
     }
@@ -65,10 +68,10 @@ export const queryByTestId = (instance: ReactTestInstance) =>
 
 export const queryAllByText = (instance: ReactTestInstance) => (
   text: string | RegExp,
-  options?: TextMatchOptions
+  queryOptions?: TextMatchOptions
 ) => {
   try {
-    return getAllByText(instance)(text, options);
+    return getAllByText(instance)(text, queryOptions);
   } catch (error) {
     return [];
   }
@@ -76,10 +79,10 @@ export const queryAllByText = (instance: ReactTestInstance) => (
 
 export const queryAllByPlaceholderText = (instance: ReactTestInstance) => (
   placeholder: string | RegExp,
-  options?: TextMatchOptions
+  queryOptions?: TextMatchOptions
 ) => {
   try {
-    return getAllByPlaceholderText(instance)(placeholder, options);
+    return getAllByPlaceholderText(instance)(placeholder, queryOptions);
   } catch (error) {
     return [];
   }
@@ -87,10 +90,10 @@ export const queryAllByPlaceholderText = (instance: ReactTestInstance) => (
 
 export const queryAllByDisplayValue = (instance: ReactTestInstance) => (
   value: string | RegExp,
-  options?: TextMatchOptions
+  queryOptions?: TextMatchOptions
 ) => {
   try {
-    return getAllByDisplayValue(instance)(value, options);
+    return getAllByDisplayValue(instance)(value, queryOptions);
   } catch (error) {
     return [];
   }

--- a/src/matches.js
+++ b/src/matches.js
@@ -47,10 +47,7 @@ function makeNormalizer({
   normalizer,
 }: NormalizerInput = {}): NormalizerFn {
   if (normalizer) {
-    if (
-      typeof trim !== 'undefined' ||
-      typeof collapseWhitespace !== 'undefined'
-    ) {
+    if (trim !== undefined || collapseWhitespace !== undefined) {
       throw new Error(
         'trim and collapseWhitespace are not supported with a normalizer. ' +
           'If you want to use the default trim and collapseWhitespace logic in your normalizer, ' +

--- a/src/matches.js
+++ b/src/matches.js
@@ -21,10 +21,15 @@ function matches(
   }
 }
 
+type NormalizerConfig = {
+  trim?: boolean,
+  collapseWhitespace?: boolean,
+};
+
 function getDefaultNormalizer({
   trim = true,
   collapseWhitespace = true,
-}: NormalizerInput = {}): NormalizerFn {
+}: NormalizerConfig = {}): NormalizerFn {
   return (text: string) => {
     let normalizedText = text;
     normalizedText = trim ? normalizedText.trim() : normalizedText;
@@ -36,29 +41,11 @@ function getDefaultNormalizer({
 }
 
 type NormalizerInput = {
-  trim?: boolean,
-  collapseWhitespace?: boolean,
   normalizer?: NormalizerFn,
 };
 
-function makeNormalizer({
-  trim,
-  collapseWhitespace,
-  normalizer,
-}: NormalizerInput = {}): NormalizerFn {
-  if (normalizer) {
-    if (trim !== undefined || collapseWhitespace !== undefined) {
-      throw new Error(
-        'trim and collapseWhitespace are not supported with a normalizer. ' +
-          'If you want to use the default trim and collapseWhitespace logic in your normalizer, ' +
-          'use "getDefaultNormalizer({trim, collapseWhitespace})" and compose that into your normalizer'
-      );
-    }
-
-    return normalizer;
-  } else {
-    return getDefaultNormalizer({ trim, collapseWhitespace });
-  }
+function makeNormalizer({ normalizer }: NormalizerInput = {}): NormalizerFn {
+  return normalizer ? normalizer : getDefaultNormalizer();
 }
 
 export { matches, getDefaultNormalizer, makeNormalizer };

--- a/src/matches.js
+++ b/src/matches.js
@@ -1,0 +1,67 @@
+// @flow
+export type NormalizerFn = (textToNormalize: string) => string;
+
+function matches(
+  textToMatch: string,
+  matcher: string | RegExp,
+  normalizer: NormalizerFn,
+  exact?: boolean = true
+) {
+  if (typeof textToMatch !== 'string') {
+    return false;
+  }
+
+  const normalizedText = normalizer(textToMatch);
+  if (typeof matcher === 'string') {
+    return exact
+      ? normalizedText === matcher
+      : normalizedText.toLowerCase().includes(matcher.toLowerCase());
+  } else {
+    return matcher.test(normalizedText);
+  }
+}
+
+function getDefaultNormalizer({
+  trim = true,
+  collapseWhitespace = true,
+}: NormalizerInput = {}): NormalizerFn {
+  return (text: string) => {
+    let normalizedText = text;
+    normalizedText = trim ? normalizedText.trim() : normalizedText;
+    normalizedText = collapseWhitespace
+      ? normalizedText.replace(/\s+/g, ' ')
+      : normalizedText;
+    return normalizedText;
+  };
+}
+
+type NormalizerInput = {
+  trim?: boolean,
+  collapseWhitespace?: boolean,
+  normalizer?: NormalizerFn,
+};
+
+function makeNormalizer({
+  trim,
+  collapseWhitespace,
+  normalizer,
+}: NormalizerInput = {}): NormalizerFn {
+  if (normalizer) {
+    if (
+      typeof trim !== 'undefined' ||
+      typeof collapseWhitespace !== 'undefined'
+    ) {
+      throw new Error(
+        'trim and collapseWhitespace are not supported with a normalizer. ' +
+          'If you want to use the default trim and collapseWhitespace logic in your normalizer, ' +
+          'use "getDefaultNormalizer({trim, collapseWhitespace})" and compose that into your normalizer'
+      );
+    }
+
+    return normalizer;
+  } else {
+    return getDefaultNormalizer({ trim, collapseWhitespace });
+  }
+}
+
+export { matches, getDefaultNormalizer, makeNormalizer };

--- a/src/pure.js
+++ b/src/pure.js
@@ -8,6 +8,7 @@ import shallow from './shallow';
 import waitFor, { waitForElement } from './waitFor';
 import waitForElementToBeRemoved from './waitForElementToBeRemoved';
 import { within, getQueriesForElement } from './within';
+import { getDefaultNormalizer } from './matches'
 
 export { act };
 export { cleanup };
@@ -18,3 +19,4 @@ export { shallow };
 export { waitFor, waitForElement };
 export { waitForElementToBeRemoved };
 export { within, getQueriesForElement };
+export { getDefaultNormalizer };

--- a/src/pure.js
+++ b/src/pure.js
@@ -8,7 +8,7 @@ import shallow from './shallow';
 import waitFor, { waitForElement } from './waitFor';
 import waitForElementToBeRemoved from './waitForElementToBeRemoved';
 import { within, getQueriesForElement } from './within';
-import { getDefaultNormalizer } from './matches'
+import { getDefaultNormalizer } from './matches';
 
 export { act };
 export { cleanup };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -341,12 +341,10 @@ type NormalizerFn = (textToNormalize: string) => string;
 type NormalizerConfig = {
   trim?: boolean,
   collapseWhitespace?: boolean,
-}
+};
 type TextMatchOptions = {
   exact?: boolean,
   normalizer?: NormalizerFn,
-  trim?: boolean,
-  collapseWhitespace?: boolean,
 };
 
 type WaitForOptions = {
@@ -374,7 +372,7 @@ export declare const getQueriesForElement: (
   instance: ReactTestInstance
 ) => Queries;
 
-export declare const getDefaultNormalizer: (normalizerConfig: NormalizerConfig) => NormalizerFn
+export declare const getDefaultNormalizer: (normalizerConfig: NormalizerConfig) => NormalizerFn;
 
 /**
  * @deprecated This function has been removed. Please use `waitFor` function.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -15,16 +15,17 @@ type FindReturn = Promise<ReactTestInstance>;
 type FindAllReturn = Promise<ReactTestInstance[]>;
 
 interface GetByAPI {
-  getByText: (text: string | RegExp) => ReactTestInstance;
-  getByPlaceholderText: (placeholder: string | RegExp) => ReactTestInstance;
-  getByDisplayValue: (value: string | RegExp) => ReactTestInstance;
+  getByText: (text: string | RegExp, options?: TextMatchOptions) => ReactTestInstance;
+  getByPlaceholderText: (placeholder: string | RegExp, options?: TextMatchOptions) => ReactTestInstance;
+  getByDisplayValue: (value: string | RegExp, options?: TextMatchOptions) => ReactTestInstance;
   getByTestId: (testID: string | RegExp) => ReactTestInstance;
   getAllByTestId: (testID: string | RegExp) => Array<ReactTestInstance>;
-  getAllByText: (text: string | RegExp) => Array<ReactTestInstance>;
+  getAllByText: (text: string | RegExp, options?: TextMatchOptions) => Array<ReactTestInstance>;
   getAllByPlaceholderText: (
-    placeholder: string | RegExp
+    placeholder: string | RegExp,
+    options?: TextMatchOptions,
   ) => Array<ReactTestInstance>;
-  getAllByDisplayValue: (value: string | RegExp) => Array<ReactTestInstance>;
+  getAllByDisplayValue: (value: string | RegExp, options?: TextMatchOptions) => Array<ReactTestInstance>;
 
   // Unsafe aliases
   UNSAFE_getByType: <P>(type: React.ComponentType<P>) => ReactTestInstance;
@@ -64,19 +65,22 @@ interface GetByAPI {
 }
 
 interface QueryByAPI {
-  queryByText: (name: string | RegExp) => ReactTestInstance | null;
+  queryByText: (name: string | RegExp, options?: TextMatchOptions) => ReactTestInstance | null;
   queryByPlaceholderText: (
-    placeholder: string | RegExp
+    placeholder: string | RegExp,
+    options?: TextMatchOptions,
   ) => ReactTestInstance | null;
-  queryByDisplayValue: (value: string | RegExp) => ReactTestInstance | null;
+  queryByDisplayValue: (value: string | RegExp, options?: TextMatchOptions) => ReactTestInstance | null;
   queryByTestId: (testID: string | RegExp) => ReactTestInstance | null;
   queryAllByTestId: (testID: string | RegExp) => Array<ReactTestInstance> | [];
-  queryAllByText: (text: string | RegExp) => Array<ReactTestInstance> | [];
+  queryAllByText: (text: string | RegExp, options?: TextMatchOptions) => Array<ReactTestInstance> | [];
   queryAllByPlaceholderText: (
-    placeholder: string | RegExp
+    placeholder: string | RegExp,
+    options?: TextMatchOptions,
   ) => Array<ReactTestInstance> | [];
   queryAllByDisplayValue: (
-    value: string | RegExp
+    value: string | RegExp,
+    options?: TextMatchOptions,
   ) => Array<ReactTestInstance> | [];
 
   // Unsafe aliases
@@ -127,28 +131,34 @@ interface QueryByAPI {
 interface FindByAPI {
   findByText: (
     text: string | RegExp,
-    waitForOptions?: WaitForOptions
+    waitForOptions?: WaitForOptions,
+    options?: TextMatchOptions,
   ) => FindReturn;
   findByPlaceholderText: (
     placeholder: string | RegExp,
-    waitForOptions?: WaitForOptions
+    waitForOptions?: WaitForOptions,
+    options?: TextMatchOptions,
   ) => FindReturn;
   findByDisplayValue: (
     value: string | RegExp,
-    waitForOptions?: WaitForOptions
+    waitForOptions?: WaitForOptions,
+    options?: TextMatchOptions,
   ) => FindReturn;
   findByTestId: (testID: string | RegExp, waitForOptions?: WaitForOptions) => FindReturn;
   findAllByText: (
     text: string | RegExp,
-    waitForOptions?: WaitForOptions
+    waitForOptions?: WaitForOptions,
+    options?: TextMatchOptions,
   ) => FindAllReturn;
   findAllByPlaceholderText: (
     placeholder: string | RegExp,
-    waitForOptions?: WaitForOptions
+    waitForOptions?: WaitForOptions,
+    options?: TextMatchOptions,
   ) => FindAllReturn;
   findAllByDisplayValue: (
     value: string | RegExp,
-    waitForOptions?: WaitForOptions
+    waitForOptions?: WaitForOptions,
+    options?: TextMatchOptions,
   ) => FindAllReturn;
   findAllByTestId: (
     testID: string | RegExp,
@@ -324,6 +334,10 @@ export declare const render: (
 
 export declare const cleanup: () => void;
 export declare const fireEvent: FireEventAPI;
+
+type TextMatchOptions = {
+  exact: boolean,
+};
 
 type WaitForOptions = {
   timeout?: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -14,18 +14,20 @@ type QueryAllReturn = Array<ReactTestInstance> | [];
 type FindReturn = Promise<ReactTestInstance>;
 type FindAllReturn = Promise<ReactTestInstance[]>;
 
+type TextMatch = string | RegExp
+
 interface GetByAPI {
-  getByText: (text: string | RegExp, options?: TextMatchOptions) => ReactTestInstance;
-  getByPlaceholderText: (placeholder: string | RegExp, options?: TextMatchOptions) => ReactTestInstance;
-  getByDisplayValue: (value: string | RegExp, options?: TextMatchOptions) => ReactTestInstance;
-  getByTestId: (testID: string | RegExp) => ReactTestInstance;
-  getAllByTestId: (testID: string | RegExp) => Array<ReactTestInstance>;
-  getAllByText: (text: string | RegExp, options?: TextMatchOptions) => Array<ReactTestInstance>;
+  getByText: (text: TextMatch, options?: TextMatchOptions) => ReactTestInstance;
+  getByPlaceholderText: (placeholder: TextMatch, options?: TextMatchOptions) => ReactTestInstance;
+  getByDisplayValue: (value: TextMatch, options?: TextMatchOptions) => ReactTestInstance;
+  getByTestId: (testID: TextMatch) => ReactTestInstance;
+  getAllByTestId: (testID: TextMatch) => Array<ReactTestInstance>;
+  getAllByText: (text: TextMatch, options?: TextMatchOptions) => Array<ReactTestInstance>;
   getAllByPlaceholderText: (
-    placeholder: string | RegExp,
+    placeholder: TextMatch,
     options?: TextMatchOptions,
   ) => Array<ReactTestInstance>;
-  getAllByDisplayValue: (value: string | RegExp, options?: TextMatchOptions) => Array<ReactTestInstance>;
+  getAllByDisplayValue: (value: TextMatch, options?: TextMatchOptions) => Array<ReactTestInstance>;
 
   // Unsafe aliases
   UNSAFE_getByType: <P>(type: React.ComponentType<P>) => ReactTestInstance;
@@ -65,21 +67,21 @@ interface GetByAPI {
 }
 
 interface QueryByAPI {
-  queryByText: (name: string | RegExp, options?: TextMatchOptions) => ReactTestInstance | null;
+  queryByText: (name: TextMatch, options?: TextMatchOptions) => ReactTestInstance | null;
   queryByPlaceholderText: (
-    placeholder: string | RegExp,
+    placeholder: TextMatch,
     options?: TextMatchOptions,
   ) => ReactTestInstance | null;
-  queryByDisplayValue: (value: string | RegExp, options?: TextMatchOptions) => ReactTestInstance | null;
-  queryByTestId: (testID: string | RegExp) => ReactTestInstance | null;
-  queryAllByTestId: (testID: string | RegExp) => Array<ReactTestInstance> | [];
-  queryAllByText: (text: string | RegExp, options?: TextMatchOptions) => Array<ReactTestInstance> | [];
+  queryByDisplayValue: (value: TextMatch, options?: TextMatchOptions) => ReactTestInstance | null;
+  queryByTestId: (testID: TextMatch) => ReactTestInstance | null;
+  queryAllByTestId: (testID: TextMatch) => Array<ReactTestInstance> | [];
+  queryAllByText: (text: TextMatch, options?: TextMatchOptions) => Array<ReactTestInstance> | [];
   queryAllByPlaceholderText: (
-    placeholder: string | RegExp,
+    placeholder: TextMatch,
     options?: TextMatchOptions,
   ) => Array<ReactTestInstance> | [];
   queryAllByDisplayValue: (
-    value: string | RegExp,
+    value: TextMatch,
     options?: TextMatchOptions,
   ) => Array<ReactTestInstance> | [];
 
@@ -130,38 +132,38 @@ interface QueryByAPI {
 
 interface FindByAPI {
   findByText: (
-    text: string | RegExp,
+    text: TextMatch,
     waitForOptions?: WaitForOptions,
     options?: TextMatchOptions,
   ) => FindReturn;
   findByPlaceholderText: (
-    placeholder: string | RegExp,
+    placeholder: TextMatch,
     waitForOptions?: WaitForOptions,
     options?: TextMatchOptions,
   ) => FindReturn;
   findByDisplayValue: (
-    value: string | RegExp,
+    value: TextMatch,
     waitForOptions?: WaitForOptions,
     options?: TextMatchOptions,
   ) => FindReturn;
-  findByTestId: (testID: string | RegExp, waitForOptions?: WaitForOptions) => FindReturn;
+  findByTestId: (testID: TextMatch, waitForOptions?: WaitForOptions) => FindReturn;
   findAllByText: (
-    text: string | RegExp,
+    text: TextMatch,
     waitForOptions?: WaitForOptions,
     options?: TextMatchOptions,
   ) => FindAllReturn;
   findAllByPlaceholderText: (
-    placeholder: string | RegExp,
+    placeholder: TextMatch,
     waitForOptions?: WaitForOptions,
     options?: TextMatchOptions,
   ) => FindAllReturn;
   findAllByDisplayValue: (
-    value: string | RegExp,
+    value: TextMatch,
     waitForOptions?: WaitForOptions,
     options?: TextMatchOptions,
   ) => FindAllReturn;
   findAllByTestId: (
-    testID: string | RegExp,
+    testID: TextMatch,
     waitForOptions?: WaitForOptions
   ) => FindAllReturn;
 }
@@ -176,54 +178,54 @@ export type A11yValue = {
 
 type A11yAPI = {
   // Label
-  getByA11yLabel: (matcher: string | RegExp) => GetReturn;
-  getByLabelText: (matcher: string | RegExp) => GetReturn;
-  getAllByA11yLabel: (matcher: string | RegExp) => GetAllReturn;
-  getAllByLabelText: (matcher: string | RegExp) => GetAllReturn;
-  queryByA11yLabel: (matcher: string | RegExp) => QueryReturn;
-  queryByLabelText: (matcher: string | RegExp) => QueryReturn;
-  queryAllByA11yLabel: (matcher: string | RegExp) => QueryAllReturn;
-  queryAllByLabelText: (matcher: string | RegExp) => QueryAllReturn;
+  getByA11yLabel: (matcher: TextMatch) => GetReturn;
+  getByLabelText: (matcher: TextMatch) => GetReturn;
+  getAllByA11yLabel: (matcher: TextMatch) => GetAllReturn;
+  getAllByLabelText: (matcher: TextMatch) => GetAllReturn;
+  queryByA11yLabel: (matcher: TextMatch) => QueryReturn;
+  queryByLabelText: (matcher: TextMatch) => QueryReturn;
+  queryAllByA11yLabel: (matcher: TextMatch) => QueryAllReturn;
+  queryAllByLabelText: (matcher: TextMatch) => QueryAllReturn;
   findByA11yLabel: (
-    matcher: string | RegExp,
+    matcher: TextMatch,
     waitForOptions?: WaitForOptions
   ) => FindReturn;
   findByLabelText: (
-    matcher: string | RegExp,
+    matcher: TextMatch,
     waitForOptions?: WaitForOptions
   ) => FindReturn;
   findAllByA11yLabel: (
-    matcher: string | RegExp,
+    matcher: TextMatch,
     waitForOptions?: WaitForOptions
   ) => FindAllReturn;
   findAllByLabelText: (
-    matcher: string | RegExp,
+    matcher: TextMatch,
     waitForOptions?: WaitForOptions
   ) => FindAllReturn;
 
   // Hint
-  getByA11yHint: (matcher: string | RegExp) => GetReturn;
-  getByHintText: (matcher: string | RegExp) => GetReturn;
-  getAllByA11yHint: (matcher: string | RegExp) => GetAllReturn;
-  getAllByHintText: (matcher: string | RegExp) => GetAllReturn;
-  queryByA11yHint: (matcher: string | RegExp) => QueryReturn;
-  queryByHintText: (matcher: string | RegExp) => QueryReturn;
-  queryAllByA11yHint: (matcher: string | RegExp) => QueryAllReturn;
-  queryAllByHintText: (matcher: string | RegExp) => QueryAllReturn;
+  getByA11yHint: (matcher: TextMatch) => GetReturn;
+  getByHintText: (matcher: TextMatch) => GetReturn;
+  getAllByA11yHint: (matcher: TextMatch) => GetAllReturn;
+  getAllByHintText: (matcher: TextMatch) => GetAllReturn;
+  queryByA11yHint: (matcher: TextMatch) => QueryReturn;
+  queryByHintText: (matcher: TextMatch) => QueryReturn;
+  queryAllByA11yHint: (matcher: TextMatch) => QueryAllReturn;
+  queryAllByHintText: (matcher: TextMatch) => QueryAllReturn;
   findByA11yHint: (
-    matcher: string | RegExp,
+    matcher: TextMatch,
     waitForOptions?: WaitForOptions
   ) => FindReturn;
   findByHintText: (
-    matcher: string | RegExp,
+    matcher: TextMatch,
     waitForOptions?: WaitForOptions
   ) => FindReturn;
   findAllByA11yHint: (
-    matcher: string | RegExp,
+    matcher: TextMatch,
     waitForOptions?: WaitForOptions
   ) => FindAllReturn;
   findAllByHintText: (
-    matcher: string | RegExp,
+    matcher: TextMatch,
     waitForOptions?: WaitForOptions
   ) => FindAllReturn;
 
@@ -335,8 +337,12 @@ export declare const render: (
 export declare const cleanup: () => void;
 export declare const fireEvent: FireEventAPI;
 
+type NormalizerFn = (textToNormalize: string) => string;
 type TextMatchOptions = {
-  exact: boolean,
+  exact?: boolean,
+  normalizer?: NormalizerFn,
+  trim?: boolean,
+  collapseWhitespace?: boolean,
 };
 
 type WaitForOptions = {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -338,6 +338,10 @@ export declare const cleanup: () => void;
 export declare const fireEvent: FireEventAPI;
 
 type NormalizerFn = (textToNormalize: string) => string;
+type NormalizerConfig = {
+  trim?: boolean,
+  collapseWhitespace?: boolean,
+}
 type TextMatchOptions = {
   exact?: boolean,
   normalizer?: NormalizerFn,
@@ -369,6 +373,8 @@ export declare const within: (instance: ReactTestInstance) => Queries;
 export declare const getQueriesForElement: (
   instance: ReactTestInstance
 ) => Queries;
+
+export declare const getDefaultNormalizer: (normalizerConfig: NormalizerConfig) => NormalizerFn
 
 /**
  * @deprecated This function has been removed. Please use `waitFor` function.

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -205,7 +205,8 @@ const element = getByA11yValue({ min: 40 });
 
 ## TextMatch
 
-Some APIs accept an object containing options affecting precision of string matching as the last argument:
+
+Several APIs accept a `TextMatch` which can be a `string` or `regex`.
 
 ```typescript
 type TextMatchOptions = {

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -53,6 +53,9 @@ type ReactTestInstance = {
 };
 ```
 
+### Options
+Query first argument can be a **string** or a **regex**. Some queries accept optional argument which change string matching behaviour. See [TextMatch](api-queries#textmatch) for more info.
+
 ### `ByText`
 
 > getByText, getAllByText, queryByText, queryAllByText, findByText, findAllByText
@@ -198,6 +201,53 @@ import { render } from '@testing-library/react-native';
 const { getByA11yValue } = render(<Component />);
 const element = getByA11yValue({ min: 40 });
 ```
+
+## TextMatch
+Some APIs accept an object containing options affecting precision of string matching as the last argument:
+
+```typescript
+type TextMatchOptions = {
+  exact: boolean,
+};
+```
+
+`exact` option defaults to `true` but if you want to search for a text slice or make text matching case-insensitive you can override it. That being said we advise you to use regex in more complex scenarios.
+
+### Examples
+
+Given the following render:
+```jsx
+const { getByText } = render(<Text>Hello World</Text>);
+```
+
+Will **find a match**:
+
+```js
+// Matching a string:
+getByText('Hello World'); // full string match
+getByText('llo Worl', { exact: false }); // substring match
+getByText('hello world', { exact: false }); // ignore case-sensitivity
+
+// Matching a regex:
+getByText(/World/); // substring match
+getByText(/world/i); // substring match, ignore case
+getByText(/^hello world$/i); // full string match, ignore case-sensitivity
+getByText(/Hello W?oRlD/i); // advanced regex
+```
+
+Will **NOT find a match**
+
+```js
+// substring does not match
+getByText('llo Worl');
+// full string does not match
+getByText('Goodbye World');
+
+// case-sensitive regex with different case
+getByText(/hello world/);
+```
+
+
 
 ## Unit testing helpers
 


### PR DESCRIPTION
### Summary
As mentioned in #514 current implementation lacked options for text matching customisation. This PR bridges this gap and provides smoother migration experience for users coming from native-testing-library.

### Things that need further discussion
This is a basic implementation with just one option allowing to opt-in for a partial and/or case-insensitive string match. NTL had another option for text normalisation customisation which this PR currently lacks. It's up for debate if we need this feature. 

Another thing to consider is API consistency: to avoid pushing breaking change to existing RNTL users I've put TextSearchOptions param as the last one (even in findBy* queries, coming after waitFor options; in NTL findBy* queries this param was coming second to last, before waitFor options).