### PR TITLE
docs: adjust ByTestId misleading warnings; add guidelines about accessibilityHint

### DIFF
--- a/website/docs/MigrationV2.md
+++ b/website/docs/MigrationV2.md
@@ -113,10 +113,6 @@ In v2 we fixed this inconsistency, which may result in failing tests, if you rel
 - replace `testID` with proper `accessibilityHint` or `accessibilityLabel` if it benefits the user
 - use safe queries like `*ByText` or `*ByA11yHint`
 
-:::caution
-In general, you should avoid `*byTestId` queries when possible. Use queries that check things that the user can interact with. Like `*ByText` or `*ByPlaceholderText` or accessibility queries (e.g. `*ByA11yHint`, `*ByA11yLabel`).
-:::
-
 ## Deprecated `flushMicrotasksQueue`
 
 We have deprecated `flushMicrotasksQueue` and plan to remove it in the next major. We have better alternatives available for helping you write async tests – `findBy` async queries and `waitFor` helper.

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -107,6 +107,10 @@ const { getByTestId } = render(<MyComponent />);
 const element = getByTestId('unique-id');
 ```
 
+:::info
+In the spirit of [the guiding principles](https://testing-library.com/docs/guiding-principles), it is recommended to use this only after the other queries don't work for your use case. Using `testID` attributes do not resemble how your software is used and should be avoided if possible. That said, they are way better than querying based on View hierarchy and are particularly useful for end-to-end testing on real devices, e.g. using Detox. Learn more from the blog post ["Making your UI tests resilient to change"](https://kentcdodds.com/blog/making-your-ui-tests-resilient-to-change).
+:::
+
 ### `ByA11yLabel`, `ByAccessibilityLabel`, `ByLabelText`
 
 > getByA11yLabel, getAllByA11yLabel, queryByA11yLabel, queryAllByA11yLabel, findByA11yLabel, findAllByA11yLabel
@@ -136,6 +140,10 @@ import { render } from '@testing-library/react-native';
 const { getByA11yHint } = render(<MyComponent />);
 const element = getByA11yHint('Plays a song');
 ```
+
+:::info
+Please consult [Apple guidelines on how `accessibilityHint` should be used](https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint).
+:::
 
 ### `ByA11yStates`, `ByAccessibilityStates`
 

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -107,10 +107,6 @@ const { getByTestId } = render(<MyComponent />);
 const element = getByTestId('unique-id');
 ```
 
-:::caution
-Please be mindful when using these API and **treat it as an escape hatch**. Your users can't interact with `testID` anyhow, so you may end up writing tests that provide false sense of security. Favor text and accessibility queries instead.
-:::
-
 ### `ByA11yLabel`, `ByAccessibilityLabel`, `ByLabelText`
 
 > getByA11yLabel, getAllByA11yLabel, queryByA11yLabel, queryAllByA11yLabel, findByA11yLabel, findAllByA11yLabel
@@ -138,7 +134,7 @@ Returns a `ReactTestInstance` with matching `accessibilityHint` prop.
 import { render } from '@testing-library/react-native';
 
 const { getByA11yHint } = render(<MyComponent />);
-const element = getByA11yHint('my-hint');
+const element = getByA11yHint('Plays a song');
 ```
 
 ### `ByA11yStates`, `ByAccessibilityStates`

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -122,8 +122,8 @@ Returns a `ReactTestInstance` with matching `accessibilityLabel` prop.
 ```jsx
 import { render } from '@testing-library/react-native';
 
-const { getByA11yLabel } = render(<MyComponent />);
-const element = getByA11yLabel('my-label');
+const { getByLabelText } = render(<MyComponent />);
+const element = getByLabelText('my-label');
 ```
 
 ### `ByA11yHint`, `ByAccessibilityHint`, `ByHintText`
@@ -137,8 +137,8 @@ Returns a `ReactTestInstance` with matching `accessibilityHint` prop.
 ```jsx
 import { render } from '@testing-library/react-native';
 
-const { getByA11yHint } = render(<MyComponent />);
-const element = getByA11yHint('Plays a song');
+const { getByHintText } = render(<MyComponent />);
+const element = getByHintText('Plays a song');
 ```
 
 :::info

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -108,7 +108,7 @@ const element = getByTestId('unique-id');
 ```
 
 :::info
-In the spirit of [the guiding principles](https://testing-library.com/docs/guiding-principles), it is recommended to use this only after the other queries don't work for your use case. Using `testID` attributes do not resemble how your software is used and should be avoided if possible. That said, they are way better than querying based on View hierarchy and are particularly useful for end-to-end testing on real devices, e.g. using Detox. Learn more from the blog post ["Making your UI tests resilient to change"](https://kentcdodds.com/blog/making-your-ui-tests-resilient-to-change).
+In the spirit of [the guiding principles](https://testing-library.com/docs/guiding-principles), it is recommended to use this only after the other queries don't work for your use case. Using `testID` attributes do not resemble how your software is used and should be avoided if possible. However, they are particularly useful for end-to-end testing on real devices, e.g. using Detox and it's an encouraged technique to use there. Learn more from the blog post ["Making your UI tests resilient to change"](https://kentcdodds.com/blog/making-your-ui-tests-resilient-to-change).
 :::
 
 ### `ByA11yLabel`, `ByAccessibilityLabel`, `ByLabelText`


### PR DESCRIPTION
### Summary

This PR is inspired by the discussion happening here https://github.com/wix/Detox/issues/2313.

There's no need for us to recommend users whether they should avoid `ByTestId` queries or not. In fact, I noticed that developers tend to take our recommendations seriously and, maybe due to lack of better ideas, use `accessibilityHint` the same way as `testID`, which is even worse for the users, as they get some rubbish developer metadata instead of actual feedback. 

For reference, here's Apple guideline on how and when `accessibilityHint` should be used: https://developer.apple.com/documentation/objectivec/nsobject/1615093-accessibilityhint. I've adjusted our example accordingly, so it doesn't spread misleading information.

### Test plan

Docs
