### PR TITLE
Enable partial matching

### DIFF
--- a/src/__tests__/getByApi.test.js
+++ b/src/__tests__/getByApi.test.js
@@ -50,3 +50,10 @@ test('supports a regex matcher', () => {
   expect(getByTestId(/view/)).toBeTruthy();
   expect(getAllByTestId(/text/)).toHaveLength(2);
 });
+
+test('throws when no text matching is found', () => {
+  const { getByText } = render(<Text>Hello</Text>);
+  expect(() => getByText('SomethingElse')).toThrowError(
+    'No instances found with text: SomethingElse'
+  );
+});

--- a/src/__tests__/queryByApi.test.js
+++ b/src/__tests__/queryByApi.test.js
@@ -114,3 +114,32 @@ test('queryByText nested deep <CustomText> in <Text>', () => {
     ).queryByText('Hello World!')
   ).toBeTruthy();
 });
+
+test('queryByText subset of longer text', () => {
+  expect(
+    render(<Text>This is a long text</Text>).queryByText('long text')
+  ).toBeTruthy();
+});
+
+test('queryAllByText does not match several times the same text', () => {
+  const allMatched = render(
+    <Text nativeID="1">
+      Start
+      <Text nativeID="2">This is a long text</Text>
+    </Text>
+  ).queryAllByText('long text');
+  expect(allMatched.length).toBe(1);
+  expect(allMatched[0].props.nativeID).toBe('2');
+});
+
+test('queryAllByText matches all the matching nodes', () => {
+  const allMatched = render(
+    <Text nativeID="1">
+      Start
+      <Text nativeID="2">This is a long text</Text>
+      <Text nativeID="3">This is another long text</Text>
+    </Text>
+  ).queryAllByText('long text');
+  expect(allMatched.length).toBe(2);
+  expect(allMatched.map((node) => node.props.nativeID)).toEqual(['2', '3']);
+});

--- a/src/helpers/queryByAPI.js
+++ b/src/helpers/queryByAPI.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import {
   getByTestId,
-  getByText,
+  nonErroringGetByText,
   getByPlaceholderText,
   getByDisplayValue,
   getAllByTestId,
@@ -23,7 +23,7 @@ import {
 export const queryByText = (instance: ReactTestInstance) =>
   function queryByTextFn(text: string | RegExp) {
     try {
-      return getByText(instance)(text);
+      return nonErroringGetByText(instance)(text);
     } catch (error) {
       return createQueryByError(error, queryByTextFn);
     }


### PR DESCRIPTION
### Summary
Follow up of #489, I'm trying to make the migration from `@5.X` to `@7.X` in a fairly large project. Another missed breaking change is that the current implementation doesn't permit "partial matches", as is `render(<Text>Hello World</Text>).getByText('Hello')` will throw. We have a lot of tests relying on this pattern (which is also the way web behaves). In this PR I fixed that.

*This is technically a breaking change* since some people might rely on `getByText` throwing in this case. But I do believe that we should seek for an API as close as possible from `@testing-library/react`.

### Test plan
I added several tests that should cover the different edge cases related to this change.
