### PR TITLE
docs: Port 'How Should I Query?' guide from Native Testing Library

### DIFF
--- a/website/docs/HowShouldIQuery.md
+++ b/website/docs/HowShouldIQuery.md
@@ -8,11 +8,13 @@ title: How Should I Query?
 Based on the [Guiding Principles](https://testing-library.com/docs/guiding-principles), your test should resemble how users interact with your code (component, page, etc.) as much as possible. With this in mind, we recommend this order of priority:
 
 1. **Queries Accessible to Everyone** queries that reflect the experience of visual users as well as those that use assistive technology
-   - [`getByText`](api-queries#bytext): This is the number 1 method a user finds any visible text. You'll probably use this one a lot.
+   - [`getByText`](api-queries#bytext): This is the number 1 method a user finds any visible text on interactive and non-interactive elements.
    - [`getByDisplayValue`](api-queries#bydisplayvalue): Useful for the current value of a `TextInput`.
    - [`getByPlaceholderText`](api-queries#byplaceholdertext): Only useful for targeting a placeholder of a `TextInput`.
    - [`getByLabelText`](api-queries#bya11ylabel-byaccessibilitylabel-bylabeltext): This can be used to query every element that is exposed in the accessibility tree as a label, usually when there's no visible text.
    - [`getByHintText`](api-queries#bya11yhint-byaccessibilityhint-byhinttext): This can be used to query every element that is exposed in the accessibility tree as a hint. Make sure it also has a label set.
+   - [`getByAccessibilityState`](api-queries#bya11ystate-byaccessibilitystate): This can be used to query every element that is exposed in the accessibility tree as a state of an interactive element, like a checkbox.
+   - [`getByAccessibilityValue`](api-queries#bya11value-byaccessibilityvalue): This can be used to query every element that is exposed in the accessibility tree as a value on a range, like a slider.
 2. **Queries Users Can Infer**
    - [`getByRole`](api-queries#bya11yrole-byaccessibilityrole-byrole): This can be used to query every element that is exposed in the accessibility tree as a role, like buttons or images.
 3. **Test IDs**

--- a/website/docs/HowShouldIQuery.md
+++ b/website/docs/HowShouldIQuery.md
@@ -1,0 +1,19 @@
+---
+id: how-should-i-query
+title: How Should I Query?
+---
+
+## Priority
+
+Whatever you do, try to make your tests resemble real use cases. You'll only be confident with your tests if they work the way your users do. With that in mind, we recommend this order of priority:
+
+1. **Queries Users Can Interact With**
+   - [`getByLabelText`](http://localhost:3000/react-native-testing-library/docs/api-queries#bya11ylabel-byaccessibilitylabel-bylabeltext): Your disabled users are counting on you, so this should likely be everywhere for their sake 😉 use it often, and if you aren't, maybe ask yourself why.
+   - [`getByHintText`](http://localhost:3000/react-native-testing-library/docs/api-queries#bya11yhint-byaccessibilityhint-byhinttext): You should probably have an accessibility label that you can select by, but if for some reason you set this instead, it's safe to use.
+   - [`getByPlaceholderText`](http://localhost:3000/react-native-testing-library/docs/api-queries#byplaceholdertext): Great for targeting a `TextInput` element to verify its content.
+   - [`getByText`](http://localhost:3000/react-native-testing-library/docs/api-queries#bytext): Great for finding a `Text`, `Button`, or `Touchable` node. You'll probably use this one a lot.
+   - [`getByDisplayValue`](http://localhost:3000/react-native-testing-library/docs/api-queries#bydisplayvalue): This is good because a user can see the value they type into a `TextInput` or whether a `Switch` is on or off.
+2. **Queries Users Can Interact With**
+   - [`getByRole`](http://localhost:3000/react-native-testing-library/docs/api-queries#bya11yrole-byaccessibilityrole-byrole): If your app screens have good hierarchy, this may be a decent option for finding your elements.
+3. **Queries Users Don't Even Know About**
+   - [`getByTestId`](http://localhost:3000/react-native-testing-library/docs/api-queries#bytestid): The user cannot see (or hear) these, so this is only recommended for cases where you can't match by text or it doesn't make sense

--- a/website/docs/HowShouldIQuery.md
+++ b/website/docs/HowShouldIQuery.md
@@ -8,12 +8,12 @@ title: How Should I Query?
 Whatever you do, try to make your tests resemble real use cases. You'll only be confident with your tests if they work the way your users do. With that in mind, we recommend this order of priority:
 
 1. **Queries Users Can Interact With**
-   - [`getByLabelText`](http://localhost:3000/react-native-testing-library/docs/api-queries#bya11ylabel-byaccessibilitylabel-bylabeltext): Your disabled users are counting on you, so this should likely be everywhere for their sake 😉 use it often, and if you aren't, maybe ask yourself why.
-   - [`getByHintText`](http://localhost:3000/react-native-testing-library/docs/api-queries#bya11yhint-byaccessibilityhint-byhinttext): You should probably have an accessibility label that you can select by, but if for some reason you set this instead, it's safe to use.
-   - [`getByPlaceholderText`](http://localhost:3000/react-native-testing-library/docs/api-queries#byplaceholdertext): Great for targeting a `TextInput` element to verify its content.
-   - [`getByText`](http://localhost:3000/react-native-testing-library/docs/api-queries#bytext): Great for finding a `Text`, `Button`, or `Touchable` node. You'll probably use this one a lot.
-   - [`getByDisplayValue`](http://localhost:3000/react-native-testing-library/docs/api-queries#bydisplayvalue): This is good because a user can see the value they type into a `TextInput` or whether a `Switch` is on or off.
+   - [`getByLabelText`](api-queries#bya11ylabel-byaccessibilitylabel-bylabeltext): Your disabled users are counting on you, so this should likely be everywhere for their sake 😉 use it often, and if you aren't, maybe ask yourself why.
+   - [`getByHintText`](api-queries#bya11yhint-byaccessibilityhint-byhinttext): You should probably have an accessibility label that you can select by, but if for some reason you set this instead, it's safe to use.
+   - [`getByPlaceholderText`](api-queries#byplaceholdertext): Great for targeting a `TextInput` element to verify its content.
+   - [`getByText`](api-queries#bytext): Great for finding a `Text`, `Button`, or `Touchable` node. You'll probably use this one a lot.
+   - [`getByDisplayValue`](api-queries#bydisplayvalue): This is good because a user can see the value they type into a `TextInput` or whether a `Switch` is on or off.
 2. **Queries Users Can Interact With**
-   - [`getByRole`](http://localhost:3000/react-native-testing-library/docs/api-queries#bya11yrole-byaccessibilityrole-byrole): If your app screens have good hierarchy, this may be a decent option for finding your elements.
+   - [`getByRole`](api-queries#bya11yrole-byaccessibilityrole-byrole): If your app screens have good hierarchy, this may be a decent option for finding your elements.
 3. **Queries Users Don't Even Know About**
-   - [`getByTestId`](http://localhost:3000/react-native-testing-library/docs/api-queries#bytestid): The user cannot see (or hear) these, so this is only recommended for cases where you can't match by text or it doesn't make sense
+   - [`getByTestId`](api-queries#bytestid): The user cannot see (or hear) these, so this is only recommended for cases where you can't match by text or it doesn't make sense

--- a/website/docs/HowShouldIQuery.md
+++ b/website/docs/HowShouldIQuery.md
@@ -13,7 +13,7 @@ Whatever you do, try to make your tests resemble real use cases. You'll only be 
    - [`getByPlaceholderText`](api-queries#byplaceholdertext): Great for targeting a `TextInput` element to verify its content.
    - [`getByText`](api-queries#bytext): Great for finding a `Text`, `Button`, or `Touchable` node. You'll probably use this one a lot.
    - [`getByDisplayValue`](api-queries#bydisplayvalue): This is good because a user can see the value they type into a `TextInput` or whether a `Switch` is on or off.
-2. **Queries Users Can Interact With**
+2. **Queries Users Can Infer**
    - [`getByRole`](api-queries#bya11yrole-byaccessibilityrole-byrole): If your app screens have good hierarchy, this may be a decent option for finding your elements.
 3. **Queries Users Don't Even Know About**
    - [`getByTestId`](api-queries#bytestid): The user cannot see (or hear) these, so this is only recommended for cases where you can't match by text or it doesn't make sense

--- a/website/docs/HowShouldIQuery.md
+++ b/website/docs/HowShouldIQuery.md
@@ -5,15 +5,15 @@ title: How Should I Query?
 
 ## Priority
 
-Whatever you do, try to make your tests resemble real use cases. You'll only be confident with your tests if they work the way your users do. With that in mind, we recommend this order of priority:
+Based on the [Guiding Principles](https://testing-library.com/docs/guiding-principles), your test should resemble how users interact with your code (component, page, etc.) as much as possible. With this in mind, we recommend this order of priority:
 
-1. **Queries Users Can Interact With**
-   - [`getByLabelText`](api-queries#bya11ylabel-byaccessibilitylabel-bylabeltext): Your disabled users are counting on you, so this should likely be everywhere for their sake 😉 use it often, and if you aren't, maybe ask yourself why.
-   - [`getByHintText`](api-queries#bya11yhint-byaccessibilityhint-byhinttext): You should probably have an accessibility label that you can select by, but if for some reason you set this instead, it's safe to use.
-   - [`getByPlaceholderText`](api-queries#byplaceholdertext): Great for targeting a `TextInput` element to verify its content.
-   - [`getByText`](api-queries#bytext): Great for finding a `Text`, `Button`, or `Touchable` node. You'll probably use this one a lot.
-   - [`getByDisplayValue`](api-queries#bydisplayvalue): This is good because a user can see the value they type into a `TextInput` or whether a `Switch` is on or off.
+1. **Queries Accessible to Everyone** queries that reflect the experience of visual users as well as those that use assistive technology
+   - [`getByText`](api-queries#bytext): This is the number 1 method a user finds any visible text. You'll probably use this one a lot.
+   - [`getByDisplayValue`](api-queries#bydisplayvalue): Useful for the current value of a `TextInput`.
+   - [`getByPlaceholderText`](api-queries#byplaceholdertext): Only useful for targeting a placeholder of a `TextInput`.
+   - [`getByLabelText`](api-queries#bya11ylabel-byaccessibilitylabel-bylabeltext): This can be used to query every element that is exposed in the accessibility tree as a label, usually when there's no visible text.
+   - [`getByHintText`](api-queries#bya11yhint-byaccessibilityhint-byhinttext): This can be used to query every element that is exposed in the accessibility tree as a hint. Make sure it also has a label set.
 2. **Queries Users Can Infer**
-   - [`getByRole`](api-queries#bya11yrole-byaccessibilityrole-byrole): If your app screens have good hierarchy, this may be a decent option for finding your elements.
-3. **Queries Users Don't Even Know About**
+   - [`getByRole`](api-queries#bya11yrole-byaccessibilityrole-byrole): This can be used to query every element that is exposed in the accessibility tree as a role, like buttons or images.
+3. **Test IDs**
    - [`getByTestId`](api-queries#bytestid): The user cannot see (or hear) these, so this is only recommended for cases where you can't match by text or it doesn't make sense

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -2,7 +2,7 @@ module.exports = {
   docs: {
     Introduction: ['getting-started'],
     'API Reference': ['api', 'api-queries'],
-    Guides: ['migration-v7', 'migration-v2'],
+    Guides: ['migration-v7', 'migration-v2', 'how-should-i-query'],
     Examples: ['react-navigation', 'redux-integration'],
   },
 };


### PR DESCRIPTION
### Summary

This PR ports the  'How Should I Query?' guide from this page: https://www.native-testing-library.com/docs/guide-queries.
The 'Manual Queries' section is not included since the `findAll` method is not supported by the current version of the library.
Fixes #512 

Also these methods were not documented in the original guide, maybe we could add them:
- `ByA11yStates`, `ByAccessibilityStates`
- `ByA11yState`, `ByAccessibilityState`
- `ByA11Value`, `ByAccessibilityValue`

Wdyt?

### Test plan

Tested using `yarn start` in the `website/` directory.