### PR TITLE
fix(breaking): use real timers internally to fix awaiting with fake timers

### DIFF
--- a/jest/preset.js
+++ b/jest/preset.js
@@ -1,9 +1,10 @@
 const reactNativePreset = require('react-native/jest-preset');
 
-module.exports = Object.assign({}, reactNativePreset, {
+module.exports = {
+  ...reactNativePreset,
   // this is needed to make modern fake timers work
   // because the react-native preset overrides global.Promise
   setupFiles: [require.resolve('./save-promise.js')]
     .concat(reactNativePreset.setupFiles)
     .concat([require.resolve('./restore-promise.js')]),
-});
+};

--- a/jest/preset.js
+++ b/jest/preset.js
@@ -1,0 +1,9 @@
+const reactNativePreset = require('react-native/jest-preset');
+
+module.exports = Object.assign({}, reactNativePreset, {
+  // this is needed to make modern fake timers work
+  // because the react-native preset overrides global.Promise
+  setupFiles: [require.resolve('./save-promise.js')]
+    .concat(reactNativePreset.setupFiles)
+    .concat([require.resolve('./restore-promise.js')]),
+});

--- a/jest/restore-promise.js
+++ b/jest/restore-promise.js
@@ -1,0 +1,1 @@
+global.Promise = global.originalPromise;

--- a/jest/restore-promise.js
+++ b/jest/restore-promise.js
@@ -1,1 +1,1 @@
-global.Promise = global.originalPromise;
+global.Promise = global.$RNTL_ORIGINAL_PROMISE;

--- a/jest/restore-promise.js
+++ b/jest/restore-promise.js
@@ -1,1 +1,1 @@
-global.Promise = global.$RNTL_ORIGINAL_PROMISE;
+global.Promise = global.RNTL_ORIGINAL_PROMISE;

--- a/jest/save-promise.js
+++ b/jest/save-promise.js
@@ -1,0 +1,1 @@
+global.originalPromise = Promise;

--- a/jest/save-promise.js
+++ b/jest/save-promise.js
@@ -1,1 +1,1 @@
-global.$RNTL_ORIGINAL_PROMISE = Promise;
+global.RNTL_ORIGINAL_PROMISE = Promise;

--- a/jest/save-promise.js
+++ b/jest/save-promise.js
@@ -1,1 +1,1 @@
-global.originalPromise = Promise;
+global.$RNTL_ORIGINAL_PROMISE = Promise;

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "build": "rm -rf build; babel src --out-dir build --ignore 'src/__tests__/*'"
   },
   "jest": {
-    "preset": "react-native",
+    "preset": "../jest/preset.js",
     "moduleFileExtensions": [
       "js",
       "json"

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
       "js",
       "json"
     ],
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "testPathIgnorePatterns": ["timerUtils"]
   }
 }

--- a/src/__tests__/timerUtils.js
+++ b/src/__tests__/timerUtils.js
@@ -1,27 +1,14 @@
-import { setTimeout } from '../helpers/getTimerFuncs';
+// @flow
+
+import { setTimeout } from '../helpers/timers';
 
 const TimerMode = {
-  Default: 'default',
   Legacy: 'legacy',
   Modern: 'modern', // broken for now
 };
 
-function setupFakeTimers(fakeTimerType) {
-  switch (fakeTimerType) {
-    case TimerMode.Legacy:
-    case TimerMode.Modern: {
-      jest.useFakeTimers(fakeTimerType);
-      break;
-    }
-    case TimerMode.Default:
-    default: {
-      jest.useFakeTimers();
-    }
-  }
-}
-
-async function sleep(ms) {
+async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export { TimerMode, setupFakeTimers, sleep };
+export { TimerMode, sleep };

--- a/src/__tests__/timerUtils.js
+++ b/src/__tests__/timerUtils.js
@@ -1,0 +1,21 @@
+const FakeTimerTypes = [
+  'default',
+  'legacy',
+  // 'modern', // broken for now
+];
+
+function setupFakeTimers(fakeTimerType) {
+  switch (fakeTimerType) {
+    case 'legacy':
+    case 'modern': {
+      jest.useFakeTimers(fakeTimerType);
+      break;
+    }
+    case 'default':
+    default: {
+      jest.useFakeTimers();
+    }
+  }
+}
+
+export { FakeTimerTypes, setupFakeTimers };

--- a/src/__tests__/timerUtils.js
+++ b/src/__tests__/timerUtils.js
@@ -1,3 +1,5 @@
+import { setTimeout } from '../helpers/getTimerFuncs';
+
 const FakeTimerTypes = [
   'default',
   'legacy',
@@ -18,4 +20,8 @@ function setupFakeTimers(fakeTimerType) {
   }
 }
 
-export { FakeTimerTypes, setupFakeTimers };
+async function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export { FakeTimerTypes, setupFakeTimers, sleep };

--- a/src/__tests__/timerUtils.js
+++ b/src/__tests__/timerUtils.js
@@ -1,19 +1,19 @@
 import { setTimeout } from '../helpers/getTimerFuncs';
 
-const FakeTimerTypes = [
-  'default',
-  'legacy',
-  // 'modern', // broken for now
-];
+const TimerMode = {
+  Default: 'default',
+  Legacy: 'legacy',
+  Modern: 'modern', // broken for now
+};
 
 function setupFakeTimers(fakeTimerType) {
   switch (fakeTimerType) {
-    case 'legacy':
-    case 'modern': {
+    case TimerMode.Legacy:
+    case TimerMode.Modern: {
       jest.useFakeTimers(fakeTimerType);
       break;
     }
-    case 'default':
+    case TimerMode.Default:
     default: {
       jest.useFakeTimers();
     }
@@ -24,4 +24,4 @@ async function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export { FakeTimerTypes, setupFakeTimers, sleep };
+export { TimerMode, setupFakeTimers, sleep };

--- a/src/__tests__/timers.test.js
+++ b/src/__tests__/timers.test.js
@@ -1,0 +1,23 @@
+import waitFor from '../waitFor';
+import { FakeTimerTypes, setupFakeTimers } from './timerUtils';
+
+describe.each(FakeTimerTypes)('%s fake timers tests', (fakeTimerType) => {
+  beforeEach(() => setupFakeTimers(fakeTimerType));
+
+  test('it successfully runs tests', () => {
+    expect(true).toBeTruthy();
+  });
+
+  test('it successfully uses waitFor', async () => {
+    await waitFor(() => {
+      expect(true).toBeTruthy();
+    });
+  });
+
+  test('it successfully uses waitFor with real timers', async () => {
+    jest.useRealTimers();
+    await waitFor(() => {
+      expect(true).toBeTruthy();
+    });
+  });
+});

--- a/src/__tests__/timers.test.js
+++ b/src/__tests__/timers.test.js
@@ -1,23 +1,26 @@
 import waitFor from '../waitFor';
-import { FakeTimerTypes, setupFakeTimers } from './timerUtils';
+import { TimerMode, setupFakeTimers } from './timerUtils';
 
-describe.each(FakeTimerTypes)('%s fake timers tests', (fakeTimerType) => {
-  beforeEach(() => setupFakeTimers(fakeTimerType));
+describe.each([TimerMode.Default, TimerMode.Legacy])(
+  '%s fake timers tests',
+  (fakeTimerType) => {
+    beforeEach(() => setupFakeTimers(fakeTimerType));
 
-  test('it successfully runs tests', () => {
-    expect(true).toBeTruthy();
-  });
-
-  test('it successfully uses waitFor', async () => {
-    await waitFor(() => {
+    test('it successfully runs tests', () => {
       expect(true).toBeTruthy();
     });
-  });
 
-  test('it successfully uses waitFor with real timers', async () => {
-    jest.useRealTimers();
-    await waitFor(() => {
-      expect(true).toBeTruthy();
+    test('it successfully uses waitFor', async () => {
+      await waitFor(() => {
+        expect(true).toBeTruthy();
+      });
     });
-  });
-});
+
+    test('it successfully uses waitFor with real timers', async () => {
+      jest.useRealTimers();
+      await waitFor(() => {
+        expect(true).toBeTruthy();
+      });
+    });
+  }
+);

--- a/src/__tests__/timers.test.js
+++ b/src/__tests__/timers.test.js
@@ -1,10 +1,12 @@
 import waitFor from '../waitFor';
-import { TimerMode, setupFakeTimers } from './timerUtils';
+import { TimerMode } from './timerUtils';
 
-describe.each([TimerMode.Default, TimerMode.Legacy])(
+describe.each([TimerMode.Legacy, TimerMode.Modern])(
   '%s fake timers tests',
   (fakeTimerType) => {
-    beforeEach(() => setupFakeTimers(fakeTimerType));
+    beforeEach(() => {
+      jest.useFakeTimers(fakeTimerType);
+    });
 
     test('it successfully runs tests', () => {
       expect(true).toBeTruthy();

--- a/src/__tests__/timers.test.js
+++ b/src/__tests__/timers.test.js
@@ -1,3 +1,4 @@
+// @flow
 import waitFor from '../waitFor';
 import { TimerMode } from './timerUtils';
 

--- a/src/__tests__/waitFor.test.js
+++ b/src/__tests__/waitFor.test.js
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 import { fireEvent, render, waitFor } from '..';
-import { FakeTimerTypes, setupFakeTimers, sleep } from './timerUtils';
+import { TimerMode, setupFakeTimers, sleep } from './timerUtils';
 
 class Banana extends React.Component<any> {
   changeFresh = () => {
@@ -80,7 +80,7 @@ test('waits for element with custom interval', async () => {
   expect(mockFn).toHaveBeenCalledTimes(3);
 });
 
-test.each(FakeTimerTypes)(
+test.each([TimerMode.Default, TimerMode.Legacy])(
   'waits for element until it stops throwing using %s fake timers',
   async (fakeTimerType) => {
     setupFakeTimers(fakeTimerType);
@@ -96,7 +96,7 @@ test.each(FakeTimerTypes)(
   }
 );
 
-test.each(FakeTimerTypes)(
+test.each([TimerMode.Default, TimerMode.Legacy])(
   'waits for assertion until timeout is met with %s fake timers',
   async (fakeTimerType) => {
     setupFakeTimers(fakeTimerType);
@@ -115,7 +115,7 @@ test.each(FakeTimerTypes)(
   }
 );
 
-test.each(FakeTimerTypes)(
+test.each([TimerMode.Default, TimerMode.Legacy])(
   'awaiting something that succeeds before timeout works with %s fake timers',
   async (fakeTimerType) => {
     setupFakeTimers(fakeTimerType);
@@ -142,7 +142,7 @@ test.each(FakeTimerTypes)(
 // it is included to show that the previous approach of faking modern timers still works
 // the gotcha is that the try catch will fail to catch the final error, which is why we need to stop throwing
 test('non-awaited approach is not affected by fake modern timers', async () => {
-  jest.useFakeTimers('modern');
+  setupFakeTimers(TimerMode.Modern);
 
   let calls = 0;
   const mockFn = jest.fn(() => {

--- a/src/__tests__/waitForElementToBeRemoved.test.js
+++ b/src/__tests__/waitForElementToBeRemoved.test.js
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { render, fireEvent, waitForElementToBeRemoved } from '..';
+import { FakeTimerTypes, setupFakeTimers } from './timerUtils';
 
 const TestSetup = ({ shouldUseDelay = true }) => {
   const [isAdded, setIsAdded] = useState(true);
@@ -130,30 +131,21 @@ test('waits with custom interval', async () => {
   expect(mockFn).toHaveBeenCalledTimes(4);
 });
 
-test('works with legacy fake timers', async () => {
-  jest.useFakeTimers('legacy');
+test.each(FakeTimerTypes)(
+  'works with %s fake timers',
+  async (fakeTimerType) => {
+    setupFakeTimers(fakeTimerType);
 
-  const mockFn = jest.fn(() => <View />);
+    const mockFn = jest.fn(() => <View />);
 
-  waitForElementToBeRemoved(() => mockFn(), {
-    timeout: 400,
-    interval: 200,
-  });
-
-  jest.advanceTimersByTime(400);
-  expect(mockFn).toHaveBeenCalledTimes(4);
-});
-
-test('works with fake timers', async () => {
-  jest.useFakeTimers('modern');
-
-  const mockFn = jest.fn(() => <View />);
-
-  waitForElementToBeRemoved(() => mockFn(), {
-    timeout: 400,
-    interval: 200,
-  });
-
-  jest.advanceTimersByTime(400);
-  expect(mockFn).toHaveBeenCalledTimes(4);
-});
+    try {
+      await waitForElementToBeRemoved(() => mockFn(), {
+        timeout: 400,
+        interval: 200,
+      });
+    } catch (e) {
+      // Suppress expected error
+    }
+    expect(mockFn).toHaveBeenCalledTimes(4);
+  }
+);

--- a/src/__tests__/waitForElementToBeRemoved.test.js
+++ b/src/__tests__/waitForElementToBeRemoved.test.js
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { render, fireEvent, waitForElementToBeRemoved } from '..';
-import { FakeTimerTypes, setupFakeTimers } from './timerUtils';
+import { TimerMode, setupFakeTimers } from './timerUtils';
 
 const TestSetup = ({ shouldUseDelay = true }) => {
   const [isAdded, setIsAdded] = useState(true);
@@ -131,7 +131,7 @@ test('waits with custom interval', async () => {
   expect(mockFn).toHaveBeenCalledTimes(4);
 });
 
-test.each(FakeTimerTypes)(
+test.each([TimerMode.Default, TimerMode.Legacy])(
   'works with %s fake timers',
   async (fakeTimerType) => {
     setupFakeTimers(fakeTimerType);

--- a/src/__tests__/waitForElementToBeRemoved.test.js
+++ b/src/__tests__/waitForElementToBeRemoved.test.js
@@ -146,6 +146,8 @@ test.each([TimerMode.Legacy, TimerMode.Modern])(
     } catch (e) {
       // Suppress expected error
     }
-    expect(mockFn).toHaveBeenCalledTimes(2);
+
+    // waitForElementToBeRemoved runs an initial call of the expectation
+    expect(mockFn).toHaveBeenCalledTimes(4);
   }
 );

--- a/src/__tests__/waitForElementToBeRemoved.test.js
+++ b/src/__tests__/waitForElementToBeRemoved.test.js
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { render, fireEvent, waitForElementToBeRemoved } from '..';
-import { TimerMode, setupFakeTimers } from './timerUtils';
+import { TimerMode } from './timerUtils';
 
 const TestSetup = ({ shouldUseDelay = true }) => {
   const [isAdded, setIsAdded] = useState(true);
@@ -121,7 +121,7 @@ test('waits with custom interval', async () => {
 
   try {
     await waitForElementToBeRemoved(() => mockFn(), {
-      timeout: 400,
+      timeout: 600,
       interval: 200,
     });
   } catch (e) {
@@ -131,10 +131,10 @@ test('waits with custom interval', async () => {
   expect(mockFn).toHaveBeenCalledTimes(4);
 });
 
-test.each([TimerMode.Default, TimerMode.Legacy])(
+test.each([TimerMode.Legacy, TimerMode.Modern])(
   'works with %s fake timers',
   async (fakeTimerType) => {
-    setupFakeTimers(fakeTimerType);
+    jest.useFakeTimers(fakeTimerType);
 
     const mockFn = jest.fn(() => <View />);
 
@@ -146,6 +146,6 @@ test.each([TimerMode.Default, TimerMode.Legacy])(
     } catch (e) {
       // Suppress expected error
     }
-    expect(mockFn).toHaveBeenCalledTimes(4);
+    expect(mockFn).toHaveBeenCalledTimes(2);
   }
 );

--- a/src/flushMicroTasks.js
+++ b/src/flushMicroTasks.js
@@ -1,6 +1,6 @@
 // @flow
 import { printDeprecationWarning } from './helpers/errors';
-import { setImmediate } from './helpers/getTimerFuncs';
+import { setImmediate } from './helpers/timers';
 
 type Thenable<T> = { then: (() => T) => mixed };
 

--- a/src/flushMicroTasks.js
+++ b/src/flushMicroTasks.js
@@ -1,5 +1,6 @@
 // @flow
 import { printDeprecationWarning } from './helpers/errors';
+import { setImmediate } from './helpers/getTimerFuncs';
 
 type Thenable<T> = { then: (() => T) => mixed };
 

--- a/src/helpers/getTimerFuncs.js
+++ b/src/helpers/getTimerFuncs.js
@@ -21,7 +21,6 @@ function runWithRealTimers(callback) {
 }
 
 function getJestFakeTimersType() {
-  // istanbul ignore if
   if (
     typeof jest === 'undefined' ||
     typeof globalObj.setTimeout === 'undefined'
@@ -52,13 +51,11 @@ function getJestFakeTimersType() {
 }
 
 // we only run our tests in node, and setImmediate is supported in node.
-// istanbul ignore next
 function setImmediatePolyfill(fn) {
   return globalObj.setTimeout(fn, 0);
 }
 
 function getTimeFunctions() {
-  // istanbul ignore next
   return {
     clearTimeoutFn: globalObj.clearTimeout,
     setImmediateFn: globalObj.setImmediate || setImmediatePolyfill,

--- a/src/helpers/getTimerFuncs.js
+++ b/src/helpers/getTimerFuncs.js
@@ -1,0 +1,77 @@
+/* eslint-disable no-undef */
+
+// Contents of this file sourced directly from https://github.com/testing-library/dom-testing-library/blob/master/src/helpers.js
+
+const globalObj = typeof window === 'undefined' ? global : window;
+
+// Currently this fn only supports jest timers, but it could support other test runners in the future.
+function runWithRealTimers(callback) {
+  const fakeTimersType = getJestFakeTimersType();
+  if (fakeTimersType) {
+    jest.useRealTimers();
+  }
+
+  const callbackReturnValue = callback();
+
+  if (fakeTimersType) {
+    jest.useFakeTimers(fakeTimersType);
+  }
+
+  return callbackReturnValue;
+}
+
+function getJestFakeTimersType() {
+  // istanbul ignore if
+  if (
+    typeof jest === 'undefined' ||
+    typeof globalObj.setTimeout === 'undefined'
+  ) {
+    return null;
+  }
+
+  if (
+    typeof globalObj.setTimeout._isMockFunction !== 'undefined' &&
+    globalObj.setTimeout._isMockFunction
+  ) {
+    return 'legacy';
+  }
+
+  if (
+    typeof globalObj.setTimeout.clock !== 'undefined' &&
+    typeof jest.getRealSystemTime !== 'undefined'
+  ) {
+    try {
+      // jest.getRealSystemTime is only supported for Jest's `modern` fake timers and otherwise throws
+      jest.getRealSystemTime();
+      return 'modern';
+    } catch {
+      // not using Jest's modern fake timers
+    }
+  }
+  return null;
+}
+
+// we only run our tests in node, and setImmediate is supported in node.
+// istanbul ignore next
+function setImmediatePolyfill(fn) {
+  return globalObj.setTimeout(fn, 0);
+}
+
+function getTimeFunctions() {
+  // istanbul ignore next
+  return {
+    clearTimeoutFn: globalObj.clearTimeout,
+    setImmediateFn: globalObj.setImmediate || setImmediatePolyfill,
+    setTimeoutFn: globalObj.setTimeout,
+  };
+}
+
+const { clearTimeoutFn, setImmediateFn, setTimeoutFn } = runWithRealTimers(
+  getTimeFunctions
+);
+
+export {
+  clearTimeoutFn as clearTimeout,
+  setImmediateFn as setImmediate,
+  setTimeoutFn as setTimeout,
+};

--- a/src/waitFor.js
+++ b/src/waitFor.js
@@ -52,6 +52,7 @@ function waitForInternal<T>(
     const overallTimeoutTimer = setTimeout(handleTimeout, timeout);
 
     const usingFakeTimers = jestFakeTimersAreEnabled();
+
     if (usingFakeTimers) {
       checkExpectation();
       // this is a dangerous rule to disable because it could lead to an
@@ -59,6 +60,7 @@ function waitForInternal<T>(
       // setting finished inside `onDone` which will be called when we're done
       // waiting or when we've timed out.
       // eslint-disable-next-line no-unmodified-loop-condition
+      let fakeTimeRemaining = timeout;
       while (!finished) {
         if (!jestFakeTimersAreEnabled()) {
           const error = new Error(
@@ -70,6 +72,14 @@ function waitForInternal<T>(
           reject(error);
           return;
         }
+
+        // when fake timers are used we want to simulate the interval time passing
+        if (fakeTimeRemaining <= 0) {
+          return;
+        } else {
+          fakeTimeRemaining -= interval;
+        }
+
         // we *could* (maybe should?) use `advanceTimersToNextTimer` but it's
         // possible that could make this loop go on forever if someone is using
         // third party code that's setting up recursive timers so rapidly that

--- a/src/waitFor.js
+++ b/src/waitFor.js
@@ -1,4 +1,5 @@
 // @flow
+/* globals jest */
 
 import * as React from 'react';
 import act from './act';
@@ -7,9 +8,14 @@ import {
   throwRemovedFunctionError,
   copyStackTrace,
 } from './helpers/errors';
-import { setTimeout } from './helpers/getTimerFuncs';
+import {
+  setTimeout,
+  clearTimeout,
+  setImmediate,
+  jestFakeTimersAreEnabled,
+} from './helpers/timers';
 
-const DEFAULT_TIMEOUT = 4500;
+const DEFAULT_TIMEOUT = 1000;
 const DEFAULT_INTERVAL = 50;
 
 function checkReactVersionAtLeast(major: number, minor: number): boolean {
@@ -22,40 +28,149 @@ function checkReactVersionAtLeast(major: number, minor: number): boolean {
 export type WaitForOptions = {
   timeout?: number,
   interval?: number,
+  stackTraceError?: ErrorWithStack,
 };
 
 function waitForInternal<T>(
   expectation: () => T,
-  options?: WaitForOptions
+  {
+    timeout = DEFAULT_TIMEOUT,
+    interval = DEFAULT_INTERVAL,
+    stackTraceError,
+  }: WaitForOptions
 ): Promise<T> {
-  const timeout = options?.timeout ?? DEFAULT_TIMEOUT;
-  let interval = options?.interval ?? DEFAULT_INTERVAL;
-  // Being able to display a useful stack trace requires generating it before doing anything async
-  const stackTraceError = new ErrorWithStack('STACK_TRACE_ERROR', waitFor);
+  if (typeof expectation !== 'function') {
+    throw new TypeError('Received `expectation` arg must be a function');
+  }
 
-  if (interval < 1) interval = 1;
-  const maxTries = Math.ceil(timeout / interval);
-  let tries = 0;
+  // eslint-disable-next-line no-async-promise-executor
+  return new Promise(async (resolve, reject) => {
+    let lastError, intervalId;
+    let finished = false;
+    let promiseStatus = 'idle';
 
-  return new Promise((resolve, reject) => {
-    const rejectOrRerun = (error) => {
-      if (tries > maxTries) {
-        copyStackTrace(error, stackTraceError);
-        reject(error);
-        return;
+    const overallTimeoutTimer = setTimeout(handleTimeout, timeout);
+
+    const usingFakeTimers = jestFakeTimersAreEnabled();
+    if (usingFakeTimers) {
+      checkExpectation();
+      // this is a dangerous rule to disable because it could lead to an
+      // infinite loop. However, eslint isn't smart enough to know that we're
+      // setting finished inside `onDone` which will be called when we're done
+      // waiting or when we've timed out.
+      // eslint-disable-next-line no-unmodified-loop-condition
+      while (!finished) {
+        if (!jestFakeTimersAreEnabled()) {
+          const error = new Error(
+            `Changed from using fake timers to real timers while using waitFor. This is not allowed and will result in very strange behavior. Please ensure you're awaiting all async things your test is doing before changing to real timers. For more info, please go to https://github.com/testing-library/dom-testing-library/issues/830`
+          );
+          if (stackTraceError) {
+            copyStackTrace(error, stackTraceError);
+          }
+          reject(error);
+          return;
+        }
+        // we *could* (maybe should?) use `advanceTimersToNextTimer` but it's
+        // possible that could make this loop go on forever if someone is using
+        // third party code that's setting up recursive timers so rapidly that
+        // the user's timer's don't get a chance to resolve. So we'll advance
+        // by an interval instead. (We have a test for this case).
+        jest.advanceTimersByTime(interval);
+
+        // It's really important that checkExpectation is run *before* we flush
+        // in-flight promises. To be honest, I'm not sure why, and I can't quite
+        // think of a way to reproduce the problem in a test, but I spent
+        // an entire day banging my head against a wall on this.
+        checkExpectation();
+
+        // In this rare case, we *need* to wait for in-flight promises
+        // to resolve before continuing. We don't need to take advantage
+        // of parallelization so we're fine.
+        // https://stackoverflow.com/a/59243586/971592
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => setImmediate(resolve));
       }
-      setTimeout(runExpectation, interval);
-    };
-    function runExpectation() {
-      tries += 1;
-      try {
-        const result = Promise.resolve(expectation());
+    } else {
+      intervalId = setInterval(checkRealTimersCallback, interval);
+      checkExpectation();
+    }
+
+    function onDone(error, result) {
+      finished = true;
+      clearTimeout(overallTimeoutTimer);
+
+      if (!usingFakeTimers) {
+        clearInterval(intervalId);
+      }
+
+      if (error) {
+        reject(error);
+      } else {
+        // $FlowIgnore[incompatible-return] error and result are mutually exclusive
         resolve(result);
-      } catch (error) {
-        rejectOrRerun(error);
       }
     }
-    setTimeout(runExpectation, 0);
+
+    function checkRealTimersCallback() {
+      if (jestFakeTimersAreEnabled()) {
+        const error = new Error(
+          `Changed from using real timers to fake timers while using waitFor. This is not allowed and will result in very strange behavior. Please ensure you're awaiting all async things your test is doing before changing to fake timers. For more info, please go to https://github.com/testing-library/dom-testing-library/issues/830`
+        );
+        if (stackTraceError) {
+          copyStackTrace(error, stackTraceError);
+        }
+        return reject(error);
+      } else {
+        return checkExpectation();
+      }
+    }
+
+    function checkExpectation() {
+      if (promiseStatus === 'pending') return;
+      try {
+        const result = expectation();
+
+        // $FlowIgnore[incompatible-type]
+        if (typeof result?.then === 'function') {
+          promiseStatus = 'pending';
+          // eslint-disable-next-line promise/catch-or-return
+          result.then(
+            (resolvedValue) => {
+              promiseStatus = 'resolved';
+              onDone(null, resolvedValue);
+              return;
+            },
+            (rejectedValue) => {
+              promiseStatus = 'rejected';
+              lastError = rejectedValue;
+              return;
+            }
+          );
+        } else {
+          onDone(null, result);
+        }
+        // If `callback` throws, wait for the next mutation, interval, or timeout.
+      } catch (error) {
+        // Save the most recent callback error to reject the promise with it in the event of a timeout
+        lastError = error;
+      }
+    }
+
+    function handleTimeout() {
+      let error;
+      if (lastError) {
+        error = lastError;
+        if (stackTraceError) {
+          copyStackTrace(error, stackTraceError);
+        }
+      } else {
+        error = new Error('Timed out in waitFor.');
+        if (stackTraceError) {
+          copyStackTrace(error, stackTraceError);
+        }
+      }
+      onDone(error, null);
+    }
   });
 }
 
@@ -63,15 +178,19 @@ export default async function waitFor<T>(
   expectation: () => T,
   options?: WaitForOptions
 ): Promise<T> {
+  // Being able to display a useful stack trace requires generating it before doing anything async
+  const stackTraceError = new ErrorWithStack('STACK_TRACE_ERROR', waitFor);
+  const optionsWithStackTrace = { stackTraceError, ...options };
+
   if (!checkReactVersionAtLeast(16, 9)) {
-    return waitForInternal(expectation, options);
+    return waitForInternal(expectation, optionsWithStackTrace);
   }
 
   let result: T;
 
   //$FlowFixMe: `act` has incorrect flow typing
   await act(async () => {
-    result = await waitForInternal(expectation, options);
+    result = await waitForInternal(expectation, optionsWithStackTrace);
   });
 
   //$FlowFixMe: either we have result or `waitFor` threw error

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -366,8 +366,6 @@ test('waiting for an Banana to be ready', async () => {
 In order to properly use `waitFor` you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
 :::
 
-If you're using Jest's [Timer Mocks](https://jestjs.io/docs/en/timer-mocks#docsNav), remember not to await the return of `waitFor` as it will stall your tests.
-
 ## `waitForElementToBeRemoved`
 
 - [`Example code`](https://github.com/callstack/react-native-testing-library/blob/master/src/__tests__/waitForElementToBeRemoved.test.js)
@@ -403,8 +401,6 @@ You can use any of `getBy`, `getAllBy`, `queryBy` and `queryAllBy` queries for `
 :::info
 In order to properly use `waitForElementToBeRemoved` you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
 :::
-
-If you're using Jest's [Timer Mocks](https://jestjs.io/docs/en/timer-mocks#docsNav), remember not to await the return of `waitFor` as it will stall your tests.
 
 ## `within`, `getQueriesForElement`
 


### PR DESCRIPTION
### Summary

If you use Timer Mocks in your tests and `waitFor` then you cannot `await` this as the timers internal to `waitFor` would be replaced by the mock timers and thus never resolve. This PR borrows techniques from [wait-for-expect](https://github.com/TheBrainFamily/wait-for-expect/blob/master/src/helpers.ts#L6-L30) and [@testing-library/dom](https://github.com/testing-library/dom-testing-library/blob/master/src/helpers.js#L1-L65) to detect if fake timers are in-use, switch back to real timers for a specific call, then re-instate the fake timers using the timer implementation that was present before.

This implementation also ensures that any mocks of `Date` or `Date.now` will not affect `waitFor`.

Outstanding work: update the docs if this lands.

fixes #506 

### Test plan

Added multiple tests to ensure this works. Unfortunately there are [problems](https://github.com/facebook/react-native/issues/29303) when awaiting a promise that uses 'modern' timers (the default in jest 27) and the react-native preset polyfilling Promise.

NOTE: `jest.useFakeTimers('modern')` and awaiting a promise in the context of react-native will timeout

There is a way to fix this, but it requires patching the `@jest/fake-timers` library as described [here](https://github.com/facebook/jest/issues/10221#issuecomment-654687396).
