### PR TITLE
Adding `getByTextWithType`

### DIFF
--- a/src/__tests__/__snapshots__/render.test.js.snap
+++ b/src/__tests__/__snapshots__/render.test.js.snap
@@ -57,6 +57,12 @@ exports[`debug 1`] = `
     Second Text
   </Text>
   <Text>
+    multiple
+  </Text>
+  <Text>
+    multiple
+  </Text>
+  <Text>
     0
   </Text>
 </View>"
@@ -119,6 +125,12 @@ exports[`debug changing component: bananaFresh button message should now be "fre
     Second Text
   </Text>
   <Text>
+    multiple
+  </Text>
+  <Text>
+    multiple
+  </Text>
+  <Text>
     0
   </Text>
 </View>"
@@ -165,6 +177,12 @@ exports[`debug: shallow 1`] = `
     testID=\\"duplicateText\\"
   >
     Second Text
+  </Text>
+  <Text>
+    multiple
+  </Text>
+  <Text>
+    multiple
   </Text>
   <Text>
     0
@@ -215,6 +233,12 @@ exports[`debug: shallow with message 1`] = `
     testID=\\"duplicateText\\"
   >
     Second Text
+  </Text>
+  <Text>
+    multiple
+  </Text>
+  <Text>
+    multiple
   </Text>
   <Text>
     0
@@ -279,6 +303,12 @@ exports[`debug: with message 1`] = `
     testID=\\"duplicateText\\"
   >
     Second Text
+  </Text>
+  <Text>
+    multiple
+  </Text>
+  <Text>
+    multiple
   </Text>
   <Text>
     0

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -1,6 +1,7 @@
 // @flow
 import React from 'react';
 import {
+  Button,
   View,
   Text,
   TextInput,
@@ -73,6 +74,8 @@ class Banana extends React.Component<any, any> {
         </MyButton>
         <Text testID="duplicateText">First Text</Text>
         <Text testID="duplicateText">Second Text</Text>
+        <Text>multiple</Text>
+        <Text>multiple</Text>
         <Text>{test}</Text>
       </View>
     );
@@ -133,6 +136,9 @@ test('getByText, queryByText', () => {
 
   expect(sameButton.props.children).toBe('not fresh');
   expect(() => getByText('InExistent')).toThrow('No instances found');
+  expect(() => getByText('multiple')).toThrow(
+    'Expected 1 but found 2 instances'
+  );
 
   const zeroText = getByText('0');
 
@@ -163,6 +169,103 @@ test('getByText, queryByText with children as Array', () => {
     3,
     ' bananas in the bunch',
   ]);
+});
+
+const MyText = (props) => <Text {...props} />;
+
+const Component = () => {
+  return (
+    <View>
+      <Button testID="b1" title="wow" />
+      <Button testID="b2" title="wow" />
+      <Button testID="b3" title="amazing" />
+      <Text testID="t1">wow</Text>
+      <Text testID="t2">amazing</Text>
+      <MyText testID="m1">wow</MyText>
+      <MyText testID="m2">amazing</MyText>
+    </View>
+  );
+};
+
+test('getByTextWithType', () => {
+  const { getByTextWithType, getByText, getAllByText } = render(<Component />);
+
+  // sanity checks
+  expect(getAllByText('wow')).toHaveLength(4);
+  expect(getAllByText('amazing')).toHaveLength(3);
+  expect(() => getByText('non-existent')).toThrow('No instances found');
+
+  // find Buttons
+  expect(getByTextWithType('amazing', Button).type).toBe(Button);
+  expect(getByTextWithType('amazing', Button).props.testID).toBe('b3');
+  expect(getByTextWithType('amazing', Button).props.title).toBe('amazing');
+
+  expect(() => getByTextWithType('wow', Button).type).toThrow(
+    'Expected 1 but found 2 instances'
+  );
+  expect(() => getByTextWithType('non-existent', Button)).toThrow(
+    'No instances found'
+  );
+
+  // Text is also inside a Button, so looking for a Text with "wow" returns 3 instances:
+  // the two Buttons plus the one Text
+  expect(() => getByTextWithType('wow', Text).type).toThrow(
+    'Expected 1 but found 4 instances'
+  );
+  expect(() => getByTextWithType('amazing', Text).type).toThrow(
+    'Expected 1 but found 3 instances'
+  );
+
+  // If we are using "higher level" component to look for our text, we can be more accurate
+  expect(getByTextWithType('amazing', MyText).type).toBe(MyText);
+  expect(getByTextWithType('amazing', MyText).props.testID).toBe('m2');
+  expect(getByTextWithType('amazing', MyText).props.children).toBe('amazing');
+});
+
+test('getAllByTextWithType', () => {
+  const { getAllByTextWithType } = render(<Component />);
+
+  // find Buttons
+  expect(getAllByTextWithType('wow', Button)).toHaveLength(2);
+  expect(getAllByTextWithType('wow', Button)[0].type).toBe(Button);
+  expect(getAllByTextWithType('wow', Button)[0].props.testID).toBe('b1');
+  expect(getAllByTextWithType('wow', Button)[0].props.title).toBe('wow');
+  expect(getAllByTextWithType('wow', Button)[1].type).toBe(Button);
+  expect(getAllByTextWithType('wow', Button)[1].props.testID).toBe('b2');
+  expect(getAllByTextWithType('wow', Button)[1].props.title).toBe('wow');
+
+  expect(getAllByTextWithType('amazing', Button)).toHaveLength(1);
+  expect(getAllByTextWithType('amazing', Button)[0].type).toBe(Button);
+  expect(getAllByTextWithType('amazing', Button)[0].props.testID).toBe('b3');
+  expect(getAllByTextWithType('amazing', Button)[0].props.title).toBe(
+    'amazing'
+  );
+
+  expect(() => getAllByTextWithType('non-existent', Button)).toThrow(
+    'No instances found'
+  );
+
+  // Text is also inside a Button, so looking for a Text with "wow" returns 3 instances:
+  // the two Buttons plus the one Text
+  expect(getAllByTextWithType('wow', Text)).toHaveLength(4);
+  expect(getAllByTextWithType('amazing', Text)).toHaveLength(3);
+  expect(getAllByTextWithType('amazing', Text)[0].props.children).toBe(
+    'amazing'
+  );
+  expect(getAllByTextWithType('amazing', Text)[1].props.children).toBe(
+    'amazing'
+  );
+  expect(getAllByTextWithType('amazing', Text)[2].props.children).toBe(
+    'amazing'
+  );
+
+  // If we are using "higher level" component to look for our text, we can be more accurate
+  expect(getAllByTextWithType('amazing', MyText)).toHaveLength(1);
+  expect(getAllByTextWithType('amazing', MyText)[0].type).toBe(MyText);
+  expect(getAllByTextWithType('amazing', MyText)[0].props.testID).toBe('m2');
+  expect(getAllByTextWithType('amazing', MyText)[0].props.children).toBe(
+    'amazing'
+  );
 });
 
 test('getAllByText, queryAllByText', () => {

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -104,6 +104,50 @@ export const getByText = (instance: ReactTestInstance) =>
     }
   };
 
+export const getByTextWithType = (instance: ReactTestInstance) =>
+  function getByTextWithTypeFn(
+    text: string | RegExp,
+    type: React.ComponentType<any>
+  ) {
+    const nodes = instance.findAll((node) => getNodeByText(node, text));
+    let found = [];
+    for (const node of nodes) {
+      let n = node;
+      while (n !== null) {
+        if (n.type === type) {
+          found.push(n);
+          break;
+        }
+
+        n = n.parent;
+      }
+    }
+
+    if (found.length === 0) {
+      throw new ErrorWithStack(
+        `No instances found with text: "${String(text)}" with type: ${String(
+          type.name
+        )}`,
+        getByTextWithTypeFn
+      );
+    } else if (found.length > 1) {
+      throw new ErrorWithStack(
+        `Expected 1 but found ${found.length} instances`,
+        getByTextWithTypeFn
+      );
+    }
+
+    return found[0];
+  };
+
+const printParents = (node: ReactTestInstance) => {
+  let n = node;
+  while (n !== null) {
+    console.log({ node: n, type: n.type });
+    n = n.parent;
+  }
+};
+
 export const getByPlaceholderText = (instance: ReactTestInstance) =>
   function getByPlaceholderTextFn(placeholder: string | RegExp) {
     try {
@@ -158,6 +202,37 @@ export const getAllByText = (instance: ReactTestInstance) =>
       );
     }
     return results;
+  };
+
+export const getAllByTextWithType = (instance: ReactTestInstance) =>
+  function getAllByTextWithTypeFn(
+    text: string | RegExp,
+    type: React.ComponentType<any>
+  ) {
+    const nodes = instance.findAll((node) => getNodeByText(node, text));
+    let found = [];
+    for (const node of nodes) {
+      let n = node;
+      while (n !== null) {
+        if (n.type === type) {
+          found.push(n);
+          break;
+        }
+
+        n = n.parent;
+      }
+    }
+
+    if (found.length === 0) {
+      throw new ErrorWithStack(
+        `No instances found with text: "${String(text)}" with type: ${String(
+          type.name
+        )}`,
+        getAllByTextWithTypeFn
+      );
+    }
+
+    return found;
   };
 
 export const getAllByPlaceholderText = (instance: ReactTestInstance) =>
@@ -244,10 +319,12 @@ export const UNSAFE_getAllByProps = (instance: ReactTestInstance) =>
 
 export const getByAPI = (instance: ReactTestInstance) => ({
   getByText: getByText(instance),
+  getByTextWithType: getByTextWithType(instance),
   getByPlaceholderText: getByPlaceholderText(instance),
   getByDisplayValue: getByDisplayValue(instance),
   getByTestId: getByTestId(instance),
   getAllByText: getAllByText(instance),
+  getAllByTextWithType: getAllByTextWithType(instance),
   getAllByPlaceholderText: getAllByPlaceholderText(instance),
   getAllByDisplayValue: getAllByDisplayValue(instance),
   getAllByTestId: getAllByTestId(instance),

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -140,14 +140,6 @@ export const getByTextWithType = (instance: ReactTestInstance) =>
     return found[0];
   };
 
-const printParents = (node: ReactTestInstance) => {
-  let n = node;
-  while (n !== null) {
-    console.log({ node: n, type: n.type });
-    n = n.parent;
-  }
-};
-
 export const getByPlaceholderText = (instance: ReactTestInstance) =>
   function getByPlaceholderTextFn(placeholder: string | RegExp) {
     try {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -16,6 +16,7 @@ type FindAllReturn = Promise<ReactTestInstance[]>;
 
 interface GetByAPI {
   getByText: (text: string | RegExp) => ReactTestInstance;
+  getByTextWithType: <P>(text: string | RegExp, type: React.ComponentType<P>) => ReactTestInstance;
   getByPlaceholderText: (placeholder: string | RegExp) => ReactTestInstance;
   getByDisplayValue: (value: string | RegExp) => ReactTestInstance;
   getByTestId: (testID: string | RegExp) => ReactTestInstance;


### PR DESCRIPTION
# Summary

This PR adds a much-needed query function by us called `getByTextWithType`.

We have found that we often need to look for a string inside a specific component that contains it. For example, a component like `Header` that contains a few texts or our own `Button` component. In our tests we want to be able to find that `Header` or `Button` component, so our options are `UNSAFE_getAllByType` and get all the `Button`s and reference the one we want to test by index, which feels too fragile, or `getAllByText` and then run up the parent stack to find the `Button` for each, which feels like the tests do too much "extra" work.

This new query will solve this problem. It is called like so: `getByTextWithType('some text', Button)` (same for the `*All*` variation). It works the same as the rest of the `get*` and `getAll*` queries for returns and throws, and it will return the `Button` component that contains a text with `'some text'` in it.

The way it works is basically it looks for all texts, same as `getAllByText` and then runs up the parent stack to see if there is a node with type `Button` (the second argument in general). If is exists, then it's a successful result. If not, it is ignored.

It could be part of `get*ByText` with an optional second argument for type, but I didn't want to compicate this PR. I'm happy to do that though if people feel it makes it simpler.

### Test plan

I have added tests for both new queries as well as a couple extra sanity check tests. The tests should make usage and results pretty clear.
