### PR TITLE
fix: non-responder wrapping host elements ignore disabled prop

### DIFF
--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -290,7 +290,7 @@ function TestChildTouchableComponent({ onPress, someProp }) {
         <Text>Trigger</Text>
       </TouchableOpacity>
     </View>
-  )
+  );
 }
 
 test('is not fooled by non-responder wrapping host elements', () => {

--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -282,3 +282,26 @@ test('is not fooled by non-native disabled prop', () => {
   fireEvent.press(screen.getByText('Trigger Test'));
   expect(handlePress).toHaveBeenCalledTimes(1);
 });
+
+function TestChildTouchableComponent({ onPress, someProp }) {
+  return (
+    <View>
+      <TouchableOpacity onPress={onPress} disabled={someProp}>
+        <Text>Trigger</Text>
+      </TouchableOpacity>
+    </View>
+  )
+}
+
+test('is not fooled by non-responder wrapping host elements', () => {
+  const handlePress = jest.fn();
+
+  const screen = render(
+    <View>
+      <TestChildTouchableComponent onPress={handlePress} someProp={true} />
+    </View>
+  );
+
+  fireEvent.press(screen.getByText('Trigger'));
+  expect(handlePress).not.toHaveBeenCalled();
+});

--- a/src/fireEvent.js
+++ b/src/fireEvent.js
@@ -12,14 +12,15 @@ const findEventHandler = (
   element: ReactTestInstance,
   eventName: string,
   callsite?: any,
-  nearestHostDescendent?: ReactTestInstance,
+  nearestHostResponderDescendent?: ReactTestInstance,
   hasDescendandHandler?: boolean
 ) => {
   const handler = getEventHandler(element, eventName);
   const hasHandler = handler != null || hasDescendandHandler;
 
   const isHostComponent = typeof element.type === 'string';
-  const hostElement = isHostComponent ? element : nearestHostDescendent;
+  const hostElement = isHostComponent ? element : nearestHostResponderDescendent;
+  const isHostElementResponder = hostElement ? (isTextInputComponent(hostElement) || !!hostElement?.props.onStartShouldSetResponder) : false;
 
   const isEventEnabled = isTextInputComponent(element)
     ? element.props.editable !== false
@@ -43,7 +44,7 @@ const findEventHandler = (
     element.parent,
     eventName,
     callsite,
-    hostElement,
+    isHostElementResponder ? hostElement : (nearestHostResponderDescendent || element),
     hasHandler
   );
 };

--- a/src/fireEvent.js
+++ b/src/fireEvent.js
@@ -19,8 +19,13 @@ const findEventHandler = (
   const hasHandler = handler != null || hasDescendandHandler;
 
   const isHostComponent = typeof element.type === 'string';
-  const hostElement = isHostComponent ? element : nearestHostResponderDescendent;
-  const isHostElementResponder = hostElement ? (isTextInputComponent(hostElement) || !!hostElement?.props.onStartShouldSetResponder) : false;
+  const hostElement = isHostComponent
+    ? element
+    : nearestHostResponderDescendent;
+  const isHostElementResponder = hostElement
+    ? isTextInputComponent(hostElement) ||
+      !!hostElement?.props.onStartShouldSetResponder
+    : false;
 
   const isEventEnabled = isTextInputComponent(element)
     ? element.props.editable !== false
@@ -44,7 +49,9 @@ const findEventHandler = (
     element.parent,
     eventName,
     callsite,
-    isHostElementResponder ? hostElement : (nearestHostResponderDescendent || element),
+    isHostElementResponder
+      ? hostElement
+      : nearestHostResponderDescendent || element,
     hasHandler
   );
 };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Effectively, wrapping a disabled `Touchable` with a non-responder host element (plain old `View`) will ignore the `disabled` prop. In the example below (same as spec file), `fireEvent.press(screen.getByText('Trigger'));` should not trigger the `handlePress` mock function as the `TestChildTouchableComponent` TouchableOpacity is disabled. Since the wrapping `View` in `TestChildTouchableComponent` is a host element it is then considered the `nearestHostDescendant`. Since it is not disabled then the event will eventually trigger.

The solution was to only pass host elements that are responders as `nearestHostDescendant`'s

```
function TestChildTouchableComponent({ onPress, someProp }) {
  return (
    <View>
      <TouchableOpacity onPress={onPress} disabled={someProp}>
        <Text>Trigger</Text>
      </TouchableOpacity>
    </View>
  );
}

test('is not fooled by non-responder wrapping host elements', () => {
  const handlePress = jest.fn();

  const screen = render(
    <View>
      <TestChildTouchableComponent onPress={handlePress} someProp={true} />
    </View>
  );

  fireEvent.press(screen.getByText('Trigger'));
  expect(handlePress).not.toHaveBeenCalled();
});