### PR TITLE
Add onMoveShouldSetResponder to element enabled checking

### DIFF
--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {
   View,
   TouchableOpacity,
+  PanResponder,
   Pressable,
   Text,
   ScrollView,
@@ -304,4 +305,28 @@ test('is not fooled by non-responder wrapping host elements', () => {
 
   fireEvent.press(screen.getByText('Trigger'));
   expect(handlePress).not.toHaveBeenCalled();
+});
+
+function TestDraggableComponent({ onDrag }) {
+  const responderHandlers = PanResponder.create({
+    onMoveShouldSetPanResponder: (_evt, _gestureState) => true,
+    onPanResponderMove: onDrag,
+  }).panHandlers;
+
+  return (
+    <View {...responderHandlers}>
+      <Text>Trigger</Text>
+    </View>
+  );
+}
+
+test('has only onMove', () => {
+  const handleDrag = jest.fn();
+
+  const screen = render(<TestDraggableComponent onDrag={handleDrag} />);
+
+  fireEvent(screen.getByText('Trigger'), 'responderMove', {
+    touchHistory: { mostRecentTimeStamp: '2', touchBank: [] },
+  });
+  expect(handleDrag).toHaveBeenCalled();
 });

--- a/src/fireEvent.js
+++ b/src/fireEvent.js
@@ -23,7 +23,13 @@ const isEventEnabled = (
 ) => {
   if (isTextInput(element)) return element?.props.editable !== false;
 
-  return touchResponder?.props.onStartShouldSetResponder?.() !== false;
+  const touchStart = touchResponder?.props.onStartShouldSetResponder?.();
+  const touchMove = touchResponder?.props.onMoveShouldSetResponder?.();
+
+  if (touchStart) return true;
+  if (touchMove) return true;
+
+  return touchStart === undefined && touchMove === undefined;
 };
 
 const findEventHandler = (

--- a/src/fireEvent.js
+++ b/src/fireEvent.js
@@ -26,8 +26,7 @@ const isEventEnabled = (
   const touchStart = touchResponder?.props.onStartShouldSetResponder?.();
   const touchMove = touchResponder?.props.onMoveShouldSetResponder?.();
 
-  if (touchStart) return true;
-  if (touchMove) return true;
+  if (touchStart || touchMove) return true;
 
   return touchStart === undefined && touchMove === undefined;
 };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This enables elements that have onMoveShouldSetResponder returning true, but not onStartShouldSetResponder.
Fixes #576 .

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
