### PR TITLE
fix: display stack trace and code frame for findBy error

### DIFF
--- a/src/helpers/errors.js
+++ b/src/helpers/errors.js
@@ -39,6 +39,13 @@ export const createQueryByError = (error: Error, callsite: Function) => {
   throw new ErrorWithStack(error.message, callsite);
 };
 
+export function copyStackTrace(target: Error, stackTraceSource: Error) {
+  target.stack = stackTraceSource.stack.replace(
+    stackTraceSource.message,
+    target.message
+  );
+}
+
 const warned = {};
 
 export function printDeprecationWarning(functionName: string) {

--- a/src/waitFor.js
+++ b/src/waitFor.js
@@ -2,7 +2,11 @@
 
 import * as React from 'react';
 import act from './act';
-import { throwRemovedFunctionError } from './helpers/errors';
+import {
+  ErrorWithStack,
+  throwRemovedFunctionError,
+  copyStackTrace,
+} from './helpers/errors';
 
 const DEFAULT_TIMEOUT = 4500;
 const DEFAULT_INTERVAL = 50;
@@ -26,10 +30,13 @@ function waitForInternal<T>(
   const timeout = options?.timeout ?? DEFAULT_TIMEOUT;
   const interval = options?.interval ?? DEFAULT_INTERVAL;
   const startTime = Date.now();
+  // Being able to display a useful stack trace requires generating it before doing anything async
+  const stackTraceError = new ErrorWithStack('STACK_TRACE_ERROR', waitFor);
 
   return new Promise((resolve, reject) => {
     const rejectOrRerun = (error) => {
       if (Date.now() - startTime >= timeout) {
+        copyStackTrace(error, stackTraceError);
         reject(error);
         return;
       }


### PR DESCRIPTION
# Summary

This fixes https://github.com/callstack/react-native-testing-library/issues/547 with a solution more or less copied from [this file in dom-testing-library](https://github.com/testing-library/dom-testing-library/blob/master/src/wait-for.js).

A useful stack trace and codeframe are now shown for `findBy` failures.


### Test plan

<img width="871" alt="Capture d’écran 2020-10-26 à 18 04 53" src="https://user-images.githubusercontent.com/10573690/97204819-dfbb1a80-17b6-11eb-9fd3-2dafd44de80c.png">

Note that to get the correct codeframe, the repo running the test must be another that uses this repo as a package, this won't work in the internal tests.

I didn't add any test because I'm not sure assertions on the stack trace make sense...

Contrary to the issue above, the stacktrace was already working with `waitFor` for me, so while it should improve the situation for `waitFor` calls too, I can't be sure of it.

### Improving the stack trace more

The stack trace still has 2 useless/internal lines, but I suspect to get rid of these, we must:
- either filter the stack trace string manually
- or rewrite all the `findBy***` helpers to capture the error here

I figured I would open this PR before digging more, since the most important part works :)
