### PR TITLE
fix: add container to TypeScript types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -303,6 +303,7 @@ export interface RenderAPI extends Queries {
   unmount(nextElement?: React.ReactElement<any>): void;
   toJSON(): ReactTestRendererJSON | null;
   debug(message?: string): void;
+  container: ReactTestInstance;
 }
 
 export type FireEventFunction = (


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Update the TS types for the new `container` property that was added to the output of `render` in #567.

### Test plan

In a TS project using the current version of @testing-library/react-native (currently 7.1.0), try accessing `container` on the result of a `render` call. A typing error will occur because RenderAPI (the result of `render`) doesn't have a `container` property.

```ts
const bodyText = render(<BodyText>Foo</BodyText>);
expect(bodyText.container).toHaveTextContent('Foo'); // <-- will generate type error
```

With this PR, no error is shown.