### PR TITLE
Update API.md

### DIFF
--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -106,10 +106,6 @@ optional message
 </View>
 ```
 
-#### `debug.shallow`
-
-Pretty prints shallowly rendered component passed to `render` with optional message on top.
-
 ### `toJSON`
 
 ```ts


### PR DESCRIPTION
Shallow is removed since migration to v2.0. Mentioned [here](https://callstack.github.io/react-native-testing-library/docs/migration-v2#removed-global-shallow-function)
Also no method is available after calling `debug()`. VSCode also shows error when trying to call `shallow()` after `.debug` or `.debug()`

<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
Resolved misunderstanding in API. 
### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
![image](https://user-images.githubusercontent.com/42899786/97483458-1da77280-1960-11eb-9c77-e30a524a8050.png)
![image](https://user-images.githubusercontent.com/42899786/97483493-26984400-1960-11eb-8702-4010cd867df8.png)
![image](https://user-images.githubusercontent.com/42899786/97483526-32840600-1960-11eb-9145-5f768f36c12a.png)

