### PR TITLE
fix: correct TS typings for `shallow.debug`

### DIFF
--- a/typings/__tests__/index.test.tsx
+++ b/typings/__tests__/index.test.tsx
@@ -199,6 +199,8 @@ const findAllBy: Promise<ReactTestInstance[]>[] = [
 // debug API
 const debugFn = tree.debug();
 const debugFnWithMessage = tree.debug('my message');
+const shallowDebug = tree.debug.shallow();
+const shallowDebugWithMessage = tree.debug.shallow('my message');
 
 // update API
 tree.update(<View />);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -137,7 +137,10 @@ interface FindByAPI {
     value: string | RegExp,
     waitForOptions?: WaitForOptions
   ) => FindReturn;
-  findByTestId: (testID: string | RegExp, waitForOptions?: WaitForOptions) => FindReturn;
+  findByTestId: (
+    testID: string | RegExp,
+    waitForOptions?: WaitForOptions
+  ) => FindReturn;
   findAllByText: (
     text: string | RegExp,
     waitForOptions?: WaitForOptions
@@ -295,6 +298,11 @@ export interface RenderOptions {
   createNodeMock?: (element: React.ReactElement<any>) => any;
 }
 
+type Debug = {
+  (message?: string);
+  shallow: (message?: string) => void;
+};
+
 type Queries = GetByAPI & QueryByAPI & FindByAPI & A11yAPI;
 
 export interface RenderAPI extends Queries {
@@ -302,7 +310,7 @@ export interface RenderAPI extends Queries {
   rerender(nextElement: React.ReactElement<any>): void;
   unmount(nextElement?: React.ReactElement<any>): void;
   toJSON(): ReactTestRendererJSON | null;
-  debug(message?: string): void;
+  debug: Debug;
   container: ReactTestInstance;
 }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

`debug.shallow()` is something we support, but TS typings were lacking

### Test plan

Added test typings
