### PR TITLE
chore: update React imports

### DIFF
--- a/examples/reactnavigation/src/AppNavigator.js
+++ b/examples/reactnavigation/src/AppNavigator.js
@@ -1,5 +1,5 @@
 import 'react-native-gesture-handler';
-import React from 'react';
+import * as React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
 
 import HomeScreen from './screens/HomeScreen';

--- a/examples/reactnavigation/src/__tests__/AppNavigator.test.js
+++ b/examples/reactnavigation/src/__tests__/AppNavigator.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { render, fireEvent } from '@testing-library/react-native';
 

--- a/examples/reactnavigation/src/screens/DetailsScreen.js
+++ b/examples/reactnavigation/src/screens/DetailsScreen.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Text, StyleSheet, View } from 'react-native';
 
 export default function DetailsScreen(props) {

--- a/examples/reactnavigation/src/screens/HomeScreen.js
+++ b/examples/reactnavigation/src/screens/HomeScreen.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   Text,
   View,

--- a/examples/redux/App.js
+++ b/examples/redux/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { StyleSheet, View, StatusBar } from 'react-native';
 import { Provider } from 'react-redux';
 import configureStore from './store';

--- a/examples/redux/components/AddTodo.js
+++ b/examples/redux/components/AddTodo.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Button, StyleSheet, Text, View, TextInput } from 'react-native';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';

--- a/examples/redux/components/AddTodo.test.js
+++ b/examples/redux/components/AddTodo.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Provider } from 'react-redux';
 import { fireEvent, render } from '@testing-library/react-native';
 import configureStore from '../store';

--- a/examples/redux/components/TodoElem.js
+++ b/examples/redux/components/TodoElem.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { StyleSheet, Button, Text, View } from 'react-native';
 
 export default function TodoElem({ todo, onDelete }) {

--- a/examples/redux/components/TodoList.js
+++ b/examples/redux/components/TodoList.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { FlatList, Text } from 'react-native';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';

--- a/examples/redux/components/TodoList.test.js
+++ b/examples/redux/components/TodoList.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { Provider } from 'react-redux';
 import { fireEvent, render } from '@testing-library/react-native';
 import configureStore from '../store';

--- a/src/__tests__/a11yAPI.test.js
+++ b/src/__tests__/a11yAPI.test.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { TouchableOpacity, Text } from 'react-native';
 import { render } from '..';
 

--- a/src/__tests__/act.test.js
+++ b/src/__tests__/act.test.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { Text } from 'react-native';
 import ReactTestRenderer from 'react-test-renderer';
 import act from '../act';

--- a/src/__tests__/auto-cleanup-skip.test.js
+++ b/src/__tests__/auto-cleanup-skip.test.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { View } from 'react-native';
 
 let render;

--- a/src/__tests__/auto-cleanup.test.js
+++ b/src/__tests__/auto-cleanup.test.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { View } from 'react-native';
 import { render } from '..';
 

--- a/src/__tests__/cleanup.test.js
+++ b/src/__tests__/cleanup.test.js
@@ -1,6 +1,6 @@
 // @flow
 /* eslint-disable react/no-multi-comp */
-import React from 'react';
+import * as React from 'react';
 import { View } from 'react-native';
 import { cleanup, render } from '../pure';
 

--- a/src/__tests__/findByApi.test.js
+++ b/src/__tests__/findByApi.test.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { View, Text, TextInput } from 'react-native';
 import { render } from '..';
 

--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {
   View,
   TouchableOpacity,

--- a/src/__tests__/getByApi.test.js
+++ b/src/__tests__/getByApi.test.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { View, Text, TextInput, Button } from 'react-native';
 import { render } from '..';
 

--- a/src/__tests__/jest-native.test.js
+++ b/src/__tests__/jest-native.test.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { StyleSheet, View, Button, Text, TextInput } from 'react-native';
 import { render } from '..';
 import '@testing-library/jest-native/extend-expect';

--- a/src/__tests__/queryByApi.test.js
+++ b/src/__tests__/queryByApi.test.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { Text, Image } from 'react-native';
 import { render } from '..';
 

--- a/src/__tests__/questionsBoard.test.js
+++ b/src/__tests__/questionsBoard.test.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {
   View,
   TouchableOpacity,

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {
   View,
   Text,

--- a/src/__tests__/waitFor.test.js
+++ b/src/__tests__/waitFor.test.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { render, fireEvent, waitFor } from '..';
 

--- a/src/__tests__/within.test.js
+++ b/src/__tests__/within.test.js
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { View, Text, TextInput } from 'react-native';
 import { render, within, getQueriesForElement } from '..';
 

--- a/website/docs/ReactNavigation.md
+++ b/website/docs/ReactNavigation.md
@@ -17,7 +17,7 @@ Create an [`./AppNavigator.js`](https://github.com/callstack/react-native-testin
 
 ```jsx
 import 'react-native-gesture-handler';
-import React from 'react';
+import * as React from 'react';
 import { createStackNavigator } from '@react-navigation/stack';
 
 import HomeScreen from './screens/HomeScreen';
@@ -40,7 +40,7 @@ export default function Navigation() {
 Create your two screens which we will transition to and from them. The homescreen, found in [`./screens/HomeScreen.js`](https://github.com/callstack/react-native-testing-library/blob/master/examples/reactnavigation/src/screens/HomeScreen.js), contains a list of elements presented in a list view. On tap of any of these items will move to the details screen with the item number:
 
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import {
   Text,
   View,
@@ -96,7 +96,7 @@ The details screen, found in [`./screens/DetailsScreen.js`](https://github.com/c
 
 ```jsx
 // ./screens/DetailsScreen.js
-import React from 'react';
+import * as React from 'react';
 import { Text, StyleSheet, View } from 'react-native';
 
 export default function DetailsScreen(props) {
@@ -152,7 +152,7 @@ For this example, we are going to test out two things. The first thing is that t
 Let's add a [`AppNavigator.test.js`](https://github.com/callstack/react-native-testing-library/blob/master/examples/reactnavigation/src/__tests__/AppNavigator.js) file in `src/__tests__` directory:
 
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { render, fireEvent } from '@testing-library/react-native';
 

--- a/website/docs/ReduxIntegration.md
+++ b/website/docs/ReduxIntegration.md
@@ -16,7 +16,7 @@ Our test is on the components that either dispatch actions on the redux store or
 For `./components/AddTodo.test.js`
 
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import { Provider } from 'react-redux';
 import { cleanup, fireEvent, render } from '@testing-library/react-native';
 import configureStore from '../store';
@@ -63,7 +63,7 @@ describe('AddTodo component test', () => {
 For the `./components/TodoList.js`
 
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import { Provider } from 'react-redux';
 import { fireEvent, render } from '@testing-library/react-native';
 import configureStore from '../store';

--- a/website/src/components/Feature.js
+++ b/website/src/components/Feature.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import useBaseUrl from '@docusaurus/useBaseUrl';

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import classnames from 'classnames';
 import Layout from '@theme/Layout';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';


### PR DESCRIPTION
### Summary

React won't have a default export in the future, so replacing it with the `import * as React from 'react'` prepares library for that.

Closes #627 

### Test plan

CI
