### PR TITLE
docs update for fireEvent.onScroll()

### DIFF
--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -333,6 +333,10 @@ fireEvent.scroll(getByTestId('flat-list'), eventData);
 expect(onEndReached).toHaveBeenCalled();
 ```
 
+:::note
+If you're noticing that components are not being found on a list, even after mocking a scroll event, try changing the [`initialNumToRender`](https://reactnative.dev/docs/flatlist#initialnumtorender) that you have set. If you aren't comfortable changing the code to accept this prop from the unit test, try using an e2e test that might better suit what use case you're attempting to replicate.
+:::
+
 ## `waitFor`
 
 - [`Example code`](https://github.com/callstack/react-native-testing-library/blob/master/src/__tests__/waitFor.test.js)


### PR DESCRIPTION
Hello! 

### Summary

I had an issue where I was trying to test a SectionList component and I was trying to mock a scroll event but after the scroll event fired the component still never was found. I saw the data in the components props but not showing up to the test query. After chatting with Michał on the discord server he mentioned this was a constant issue he had to teach people about and he suggested changing my initialNumToRender prop or use an e2e test to verify. He also mentioned needing to update the docs at some point since he's had to teach this to people on a regular basis so I figured I'd go ahead and do it for him.

Let me know if there is anything I should change or that might be clearer. [link to discord conversation](https://discord.com/channels/426714625279524876/497332049187962892/786993987645997086) 

### Test plan

Should be nothing other than spellchecking and correct terminology.
