### PR TITLE
Finish refactoring queries using new query builder makeQueries

### DIFF
--- a/src/__tests__/byTestId.test.js
+++ b/src/__tests__/byTestId.test.js
@@ -129,6 +129,13 @@ test('getByTestId, queryByTestId', () => {
 
   expect(getByTestId('bananaFresh')).toBe(component);
   expect(queryByTestId('InExistent')).toBeNull();
+
+  expect(() => getByTestId('duplicateText')).toThrow(
+    'Found multiple elements with testID: duplicateText'
+  );
+  expect(() => queryByTestId('duplicateText')).toThrow(
+    'Found multiple elements with testID: duplicateText'
+  );
 });
 
 test('getAllByTestId, queryAllByTestId', () => {

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -202,12 +202,14 @@ test('getByDisplayValue, queryByDisplayValue', () => {
 
   expect(sameInput.props.value).toBe(INPUT_FRESHNESS);
   expect(() => getByDisplayValue('no value')).toThrow(
-    'No instances found with display value "no value"'
+    'Unable to find an element with displayValue: no value'
   );
 
   expect(queryByDisplayValue(/custom/i)).toBe(input);
   expect(queryByDisplayValue('no value')).toBeNull();
-  expect(() => queryByDisplayValue(/fresh/i)).toThrow('Expected 1 but found 2');
+  expect(() => queryByDisplayValue(/fresh/i)).toThrow(
+    'Found multiple elements with display value: /fresh/i'
+  );
 });
 
 test('getByDisplayValue, queryByDisplayValue get element by default value only when value is undefined', () => {
@@ -227,7 +229,9 @@ test('getAllByDisplayValue, queryAllByDisplayValue', () => {
   const inputs = getAllByDisplayValue(/fresh/i);
 
   expect(inputs).toHaveLength(2);
-  expect(() => getAllByDisplayValue('no value')).toThrow('No instances found');
+  expect(() => getAllByDisplayValue('no value')).toThrow(
+    'Unable to find an element with displayValue: no value'
+  );
 
   expect(queryAllByDisplayValue(/fresh/i)).toEqual(inputs);
   expect(queryAllByDisplayValue('no value')).toHaveLength(0);

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -108,14 +108,16 @@ test('getByText, queryByText', () => {
 
   expect(sameButton.props.children).toBe('not fresh');
   expect(() => getByText('InExistent')).toThrow(
-    'No instances found with text "InExistent"'
+    'Unable to find an element with text: InExistent'
   );
 
   const zeroText = getByText('0');
 
   expect(queryByText(/change/i)).toBe(button);
   expect(queryByText('InExistent')).toBeNull();
-  expect(() => queryByText(/fresh/)).toThrow('Expected 1 but found 3');
+  expect(() => queryByText(/fresh/)).toThrow(
+    'Found multiple elements with text: /fresh/'
+  );
   expect(queryByText('0')).toBe(zeroText);
 });
 
@@ -147,7 +149,9 @@ test('getAllByText, queryAllByText', () => {
   const buttons = getAllByText(/fresh/i);
 
   expect(buttons).toHaveLength(3);
-  expect(() => getAllByText('InExistent')).toThrow('No instances found');
+  expect(() => getAllByText('InExistent')).toThrow(
+    'Unable to find an element with text: InExistent'
+  );
 
   expect(queryAllByText(/fresh/i)).toEqual(buttons);
   expect(queryAllByText('InExistent')).toHaveLength(0);

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -167,13 +167,13 @@ test('getByPlaceholderText, queryByPlaceholderText', () => {
 
   expect(sameInput.props.placeholder).toBe(PLACEHOLDER_FRESHNESS);
   expect(() => getByPlaceholderText('no placeholder')).toThrow(
-    'No instances found with placeholder "no placeholder"'
+    'Unable to find an element with placeholder: no placeholder'
   );
 
   expect(queryByPlaceholderText(/add/i)).toBe(input);
   expect(queryByPlaceholderText('no placeholder')).toBeNull();
   expect(() => queryByPlaceholderText(/fresh/)).toThrow(
-    'Expected 1 but found 2'
+    'Found multiple elements with placeholder: /fresh/ '
   );
 });
 
@@ -185,7 +185,7 @@ test('getAllByPlaceholderText, queryAllByPlaceholderText', () => {
 
   expect(inputs).toHaveLength(2);
   expect(() => getAllByPlaceholderText('no placeholder')).toThrow(
-    'No instances found'
+    'Unable to find an element with placeholder: no placeholder'
   );
 
   expect(queryAllByPlaceholderText(/fresh/i)).toEqual(inputs);

--- a/src/helpers/a11yAPI.js
+++ b/src/helpers/a11yAPI.js
@@ -1,7 +1,7 @@
 // @flow
 import type { A11yRole, A11yStates, A11yState, A11yValue } from '../types.flow';
 import type { WaitForOptions } from '../waitFor';
-import makeQuery from './makeQuery';
+import makeA11yQuery from './makeA11yQuery';
 
 type GetReturn = ReactTestInstance;
 type GetAllReturn = Array<ReactTestInstance>;
@@ -118,7 +118,7 @@ export function matchObject<T: {}>(prop?: T, matcher: T): boolean {
 
 export const a11yAPI = (instance: ReactTestInstance): A11yAPI =>
   ({
-    ...makeQuery(
+    ...makeA11yQuery(
       'accessibilityLabel',
       {
         getBy: ['getByA11yLabel', 'getByAccessibilityLabel', 'getByLabelText'],
@@ -150,7 +150,7 @@ export const a11yAPI = (instance: ReactTestInstance): A11yAPI =>
       },
       matchStringValue
     )(instance),
-    ...makeQuery(
+    ...makeA11yQuery(
       'accessibilityHint',
       {
         getBy: ['getByA11yHint', 'getByAccessibilityHint', 'getByHintText'],
@@ -178,7 +178,7 @@ export const a11yAPI = (instance: ReactTestInstance): A11yAPI =>
       },
       matchStringValue
     )(instance),
-    ...makeQuery(
+    ...makeA11yQuery(
       'accessibilityRole',
       {
         getBy: ['getByA11yRole', 'getByAccessibilityRole', 'getByRole'],
@@ -202,7 +202,7 @@ export const a11yAPI = (instance: ReactTestInstance): A11yAPI =>
       },
       matchStringValue
     )(instance),
-    ...makeQuery(
+    ...makeA11yQuery(
       'accessibilityStates',
       {
         getBy: ['getByA11yStates', 'getByAccessibilityStates'],
@@ -214,7 +214,7 @@ export const a11yAPI = (instance: ReactTestInstance): A11yAPI =>
       },
       matchArrayValue
     )(instance),
-    ...makeQuery(
+    ...makeA11yQuery(
       'accessibilityState',
       {
         getBy: ['getByA11yState', 'getByAccessibilityState'],
@@ -226,7 +226,7 @@ export const a11yAPI = (instance: ReactTestInstance): A11yAPI =>
       },
       matchObject
     )(instance),
-    ...makeQuery(
+    ...makeA11yQuery(
       'accessibilityValue',
       {
         getBy: ['getByA11yValue', 'getByAccessibilityValue'],

--- a/src/helpers/byDisplayValue.js
+++ b/src/helpers/byDisplayValue.js
@@ -47,10 +47,10 @@ const {
 );
 
 export {
-  getByDisplayValue,
-  getAllByDisplayValue,
-  queryByDisplayValue,
-  findByDisplayValue,
   findAllByDisplayValue,
+  findByDisplayValue,
+  getAllByDisplayValue,
+  getByDisplayValue,
   queryAllByDisplayValue,
+  queryByDisplayValue,
 };

--- a/src/helpers/byDisplayValue.js
+++ b/src/helpers/byDisplayValue.js
@@ -1,0 +1,56 @@
+// @flow
+import { makeQueries } from './makeQueries';
+import type { Queries } from './makeQueries';
+import { filterNodeByType } from './filterNodeByType';
+import { createLibraryNotSupportedError } from './errors';
+
+const getTextInputNodeByDisplayValue = (node, value) => {
+  try {
+    const { TextInput } = require('react-native');
+    const nodeValue =
+      node.props.value !== undefined
+        ? node.props.value
+        : node.props.defaultValue;
+    return (
+      filterNodeByType(node, TextInput) &&
+      (typeof value === 'string' ? value === nodeValue : value.test(nodeValue))
+    );
+  } catch (error) {
+    throw createLibraryNotSupportedError(error);
+  }
+};
+
+const queryAllByDisplayValue = (
+  instance: ReactTestInstance
+): ((displayValue: string | RegExp) => Array<ReactTestInstance>) =>
+  function queryAllByDisplayValueFn(displayValue) {
+    return instance.findAll((node) =>
+      getTextInputNodeByDisplayValue(node, displayValue)
+    );
+  };
+
+const getMultipleError = (displayValue: string | RegExp) =>
+  `Found multiple elements with display value: ${String(displayValue)} `;
+const getMissingError = (displayValue: string | RegExp) =>
+  `Unable to find an element with displayValue: ${String(displayValue)}`;
+
+const {
+  getBy: getByDisplayValue,
+  getAllBy: getAllByDisplayValue,
+  queryBy: queryByDisplayValue,
+  findBy: findByDisplayValue,
+  findAllBy: findAllByDisplayValue,
+}: Queries<string | RegExp> = makeQueries(
+  queryAllByDisplayValue,
+  getMissingError,
+  getMultipleError
+);
+
+export {
+  getByDisplayValue,
+  getAllByDisplayValue,
+  queryByDisplayValue,
+  findByDisplayValue,
+  findAllByDisplayValue,
+  queryAllByDisplayValue,
+};

--- a/src/helpers/byPlaceholderText.js
+++ b/src/helpers/byPlaceholderText.js
@@ -1,0 +1,54 @@
+// @flow
+import { makeQueries } from './makeQueries';
+import type { Queries } from './makeQueries';
+import { filterNodeByType } from './filterNodeByType';
+import { createLibraryNotSupportedError } from './errors';
+
+const getTextInputNodeByPlaceholderText = (node, placeholder) => {
+  try {
+    const { TextInput } = require('react-native');
+    return (
+      filterNodeByType(node, TextInput) &&
+      (typeof placeholder === 'string'
+        ? placeholder === node.props.placeholder
+        : placeholder.test(node.props.placeholder))
+    );
+  } catch (error) {
+    throw createLibraryNotSupportedError(error);
+  }
+};
+
+const queryAllByPlaceholderText = (
+  instance: ReactTestInstance
+): ((placeholder: string | RegExp) => Array<ReactTestInstance>) =>
+  function queryAllByPlaceholderFn(placeholder) {
+    return instance.findAll((node) =>
+      getTextInputNodeByPlaceholderText(node, placeholder)
+    );
+  };
+
+const getMultipleError = (placeholder) =>
+  `Found multiple elements with placeholder: ${String(placeholder)} `;
+const getMissingError = (placeholder) =>
+  `Unable to find an element with placeholder: ${String(placeholder)}`;
+
+const {
+  getBy: getByPlaceholderText,
+  getAllBy: getAllByPlaceholderText,
+  queryBy: queryByPlaceholderText,
+  findBy: findByPlaceholderText,
+  findAllBy: findAllByPlaceholderText,
+}: Queries<string | RegExp> = makeQueries(
+  queryAllByPlaceholderText,
+  getMissingError,
+  getMultipleError
+);
+
+export {
+  getByPlaceholderText,
+  getAllByPlaceholderText,
+  queryByPlaceholderText,
+  findByPlaceholderText,
+  findAllByPlaceholderText,
+  queryAllByPlaceholderText,
+};

--- a/src/helpers/byPlaceholderText.js
+++ b/src/helpers/byPlaceholderText.js
@@ -45,10 +45,10 @@ const {
 );
 
 export {
-  getByPlaceholderText,
-  getAllByPlaceholderText,
-  queryByPlaceholderText,
-  findByPlaceholderText,
   findAllByPlaceholderText,
+  findByPlaceholderText,
+  getAllByPlaceholderText,
+  getByPlaceholderText,
   queryAllByPlaceholderText,
+  queryByPlaceholderText,
 };

--- a/src/helpers/byTestId.js
+++ b/src/helpers/byTestId.js
@@ -37,10 +37,10 @@ const {
 );
 
 export {
-  getByTestId,
-  getAllByTestId,
-  queryByTestId,
-  findByTestId,
   findAllByTestId,
+  findByTestId,
+  getAllByTestId,
+  getByTestId,
   queryAllByTestId,
+  queryByTestId,
 };

--- a/src/helpers/byTestId.js
+++ b/src/helpers/byTestId.js
@@ -11,7 +11,7 @@ const getNodeByTestId = (node, testID) => {
 const queryAllByTestId = (
   instance: ReactTestInstance
 ): ((testId: string | RegExp) => Array<ReactTestInstance>) =>
-  function getAllByTestIdFn(testId) {
+  function queryAllByTestIdFn(testId) {
     const results = instance
       .findAll((node) => getNodeByTestId(node, testId))
       .filter((element) => typeof element.type === 'string');

--- a/src/helpers/byText.js
+++ b/src/helpers/byText.js
@@ -1,0 +1,88 @@
+// @flow
+import * as React from 'react';
+import { makeQueries } from './makeQueries';
+import type { Queries } from './makeQueries';
+import { filterNodeByType } from './filterNodeByType';
+import { createLibraryNotSupportedError } from './errors';
+
+const getChildrenAsText = (children, TextComponent, textContent = []) => {
+  React.Children.forEach(children, (child) => {
+    if (typeof child === 'string') {
+      textContent.push(child);
+      return;
+    }
+
+    if (typeof child === 'number') {
+      textContent.push(child.toString());
+      return;
+    }
+
+    if (child?.props?.children) {
+      // Bail on traversing text children down the tree if current node (child)
+      // has no text. In such situations, react-test-renderer will traverse down
+      // this tree in a separate call and run this query again. As a result, the
+      // query will match the deepest text node that matches requested text.
+      if (filterNodeByType(child, TextComponent) && textContent.length === 0) {
+        return;
+      }
+
+      getChildrenAsText(child.props.children, TextComponent, textContent);
+    }
+  });
+
+  return textContent;
+};
+
+const getNodeByText = (node, text: string | RegExp) => {
+  try {
+    const { Text } = require('react-native');
+    const isTextComponent = filterNodeByType(node, Text);
+    if (isTextComponent) {
+      const textChildren = getChildrenAsText(node.props.children, Text);
+      if (textChildren) {
+        const textToTest = textChildren.join('');
+        return typeof text === 'string'
+          ? text === textToTest
+          : text.test(textToTest);
+      }
+    }
+    return false;
+  } catch (error) {
+    throw createLibraryNotSupportedError(error);
+  }
+};
+
+const queryAllByText = (
+  instance: ReactTestInstance
+): ((text: string | RegExp) => Array<ReactTestInstance>) =>
+  function queryAllByTextFn(text) {
+    const results = instance.findAll((node) => getNodeByText(node, text));
+
+    return results;
+  };
+
+const getMultipleError = (text: string | RegExp) =>
+  `Found multiple elements with text: ${String(text)}`;
+const getMissingError = (text: string | RegExp) =>
+  `Unable to find an element with text: ${String(text)}`;
+
+const {
+  getBy: getByText,
+  getAllBy: getAllByText,
+  queryBy: queryByText,
+  findBy: findByText,
+  findAllBy: findAllByText,
+}: Queries<string | RegExp> = makeQueries(
+  queryAllByText,
+  getMissingError,
+  getMultipleError
+);
+
+export {
+  getByText,
+  getAllByText,
+  queryByText,
+  findByText,
+  findAllByText,
+  queryAllByText,
+};

--- a/src/helpers/byText.js
+++ b/src/helpers/byText.js
@@ -79,10 +79,10 @@ const {
 );
 
 export {
-  getByText,
-  getAllByText,
-  queryByText,
-  findByText,
   findAllByText,
+  findByText,
+  getAllByText,
+  getByText,
   queryAllByText,
+  queryByText,
 };

--- a/src/helpers/filterNodeByType.js
+++ b/src/helpers/filterNodeByType.js
@@ -1,0 +1,1 @@
+export const filterNodeByType = (node, type) => node.type === type;

--- a/src/helpers/findByAPI.js
+++ b/src/helpers/findByAPI.js
@@ -2,14 +2,13 @@
 import waitFor from '../waitFor';
 import type { WaitForOptions } from '../waitFor';
 import {
-  getByText,
-  getAllByText,
   getByPlaceholderText,
   getAllByPlaceholderText,
   getByDisplayValue,
   getAllByDisplayValue,
 } from './getByAPI';
 import { findAllByTestId, findByTestId } from './byTestId';
+import { findAllByText, findByText } from './byText';
 import { throwRenamedFunctionError } from './errors';
 
 export type FindByAPI = {|
@@ -55,26 +54,6 @@ const makeFindQuery = <Text, Result>(
   text: Text,
   waitForOptions: WaitForOptions
 ): Promise<Result> => waitFor(() => getQuery(instance)(text), waitForOptions);
-
-export const findByText = (
-  instance: ReactTestInstance
-): ((
-  text: string | RegExp,
-  waitForOptions?: WaitForOptions
-) => Promise<ReactTestInstance>) => (
-  text: string | RegExp,
-  waitForOptions: WaitForOptions = {}
-) => makeFindQuery(instance, getByText, text, waitForOptions);
-
-export const findAllByText = (
-  instance: ReactTestInstance
-): ((
-  text: string | RegExp,
-  waitForOptions?: WaitForOptions
-) => Promise<Array<ReactTestInstance>>) => (
-  text: string | RegExp,
-  waitForOptions: WaitForOptions = {}
-) => makeFindQuery(instance, getAllByText, text, waitForOptions);
 
 export const findByPlaceholderText = (
   instance: ReactTestInstance

--- a/src/helpers/findByAPI.js
+++ b/src/helpers/findByAPI.js
@@ -1,14 +1,13 @@
 // @flow
 import waitFor from '../waitFor';
 import type { WaitForOptions } from '../waitFor';
-import {
-  getByPlaceholderText,
-  getAllByPlaceholderText,
-  getByDisplayValue,
-  getAllByDisplayValue,
-} from './getByAPI';
+import { getByDisplayValue, getAllByDisplayValue } from './getByAPI';
 import { findAllByTestId, findByTestId } from './byTestId';
 import { findAllByText, findByText } from './byText';
+import {
+  findAllByPlaceholderText,
+  findByPlaceholderText,
+} from './byPlaceholderText';
 import { throwRenamedFunctionError } from './errors';
 
 export type FindByAPI = {|
@@ -54,27 +53,6 @@ const makeFindQuery = <Text, Result>(
   text: Text,
   waitForOptions: WaitForOptions
 ): Promise<Result> => waitFor(() => getQuery(instance)(text), waitForOptions);
-
-export const findByPlaceholderText = (
-  instance: ReactTestInstance
-): ((
-  placeholder: string | RegExp,
-  waitForOptions?: WaitForOptions
-) => Promise<ReactTestInstance>) => (
-  placeholder: string | RegExp,
-  waitForOptions: WaitForOptions = {}
-) => makeFindQuery(instance, getByPlaceholderText, placeholder, waitForOptions);
-
-export const findAllByPlaceholderText = (
-  instance: ReactTestInstance
-): ((
-  placeholder: string | RegExp,
-  waitForOptions?: WaitForOptions
-) => Promise<Array<ReactTestInstance>>) => (
-  placeholder: string | RegExp,
-  waitForOptions: WaitForOptions = {}
-) =>
-  makeFindQuery(instance, getAllByPlaceholderText, placeholder, waitForOptions);
 
 export const findByDisplayValue = (
   instance: ReactTestInstance

--- a/src/helpers/findByAPI.js
+++ b/src/helpers/findByAPI.js
@@ -1,13 +1,12 @@
 // @flow
-import waitFor from '../waitFor';
 import type { WaitForOptions } from '../waitFor';
-import { getByDisplayValue, getAllByDisplayValue } from './getByAPI';
 import { findAllByTestId, findByTestId } from './byTestId';
 import { findAllByText, findByText } from './byText';
 import {
   findAllByPlaceholderText,
   findByPlaceholderText,
 } from './byPlaceholderText';
+import { findAllByDisplayValue, findByDisplayValue } from './byDisplayValue';
 import { throwRenamedFunctionError } from './errors';
 
 export type FindByAPI = {|
@@ -46,33 +45,6 @@ export type FindByAPI = {|
     waitForOptions?: WaitForOptions
   ) => Promise<ReactTestInstance>,
 |};
-
-const makeFindQuery = <Text, Result>(
-  instance: ReactTestInstance,
-  getQuery: (instance: ReactTestInstance) => (text: Text) => Result,
-  text: Text,
-  waitForOptions: WaitForOptions
-): Promise<Result> => waitFor(() => getQuery(instance)(text), waitForOptions);
-
-export const findByDisplayValue = (
-  instance: ReactTestInstance
-): ((
-  value: string | RegExp,
-  waitForOptions?: WaitForOptions
-) => Promise<ReactTestInstance>) => (
-  value: string | RegExp,
-  waitForOptions: WaitForOptions = {}
-) => makeFindQuery(instance, getByDisplayValue, value, waitForOptions);
-
-export const findAllByDisplayValue = (
-  instance: ReactTestInstance
-): ((
-  value: string | RegExp,
-  waitForOptions?: WaitForOptions
-) => Promise<Array<ReactTestInstance>>) => (
-  value: string | RegExp,
-  waitForOptions: WaitForOptions = {}
-) => makeFindQuery(instance, getAllByDisplayValue, value, waitForOptions);
 
 export const findByAPI = (instance: ReactTestInstance): FindByAPI => ({
   findByTestId: findByTestId(instance),

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -1,10 +1,8 @@
 // @flow
 import * as React from 'react';
 import prettyFormat from 'pretty-format';
-import { filterNodeByType } from './filterNodeByType';
 import {
   ErrorWithStack,
-  createLibraryNotSupportedError,
   prepareErrorMessage,
   throwRemovedFunctionError,
   throwRenamedFunctionError,
@@ -15,6 +13,7 @@ import {
   getAllByPlaceholderText,
   getByPlaceholderText,
 } from './byPlaceholderText';
+import { getAllByDisplayValue, getByDisplayValue } from './byDisplayValue';
 
 export type GetByAPI = {|
   getByText: (text: string | RegExp) => ReactTestInstance,
@@ -46,54 +45,6 @@ export type GetByAPI = {|
   getByPlaceholder: () => void,
   getAllByPlaceholder: () => void,
 |};
-
-const getTextInputNodeByDisplayValue = (node, value) => {
-  try {
-    const { TextInput } = require('react-native');
-    const nodeValue =
-      node.props.value !== undefined
-        ? node.props.value
-        : node.props.defaultValue;
-    return (
-      filterNodeByType(node, TextInput) &&
-      (typeof value === 'string' ? value === nodeValue : value.test(nodeValue))
-    );
-  } catch (error) {
-    throw createLibraryNotSupportedError(error);
-  }
-};
-
-export const getByDisplayValue = (
-  instance: ReactTestInstance
-): ((displayValue: string | RegExp) => ReactTestInstance) =>
-  function getByDisplayValueFn(displayValue: string | RegExp) {
-    try {
-      return instance.find((node) =>
-        getTextInputNodeByDisplayValue(node, displayValue)
-      );
-    } catch (error) {
-      throw new ErrorWithStack(
-        prepareErrorMessage(error, 'display value', displayValue),
-        getByDisplayValueFn
-      );
-    }
-  };
-
-export const getAllByDisplayValue = (
-  instance: ReactTestInstance
-): ((value: string | RegExp) => Array<ReactTestInstance>) =>
-  function getAllByDisplayValueFn(value: string | RegExp) {
-    const results = instance.findAll((node) =>
-      getTextInputNodeByDisplayValue(node, value)
-    );
-    if (results.length === 0) {
-      throw new ErrorWithStack(
-        `No instances found with display value: ${String(value)}`,
-        getAllByDisplayValueFn
-      );
-    }
-    return results;
-  };
 
 export const UNSAFE_getByType = (
   instance: ReactTestInstance

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -11,6 +11,10 @@ import {
 } from './errors';
 import { getAllByTestId, getByTestId } from './byTestId';
 import { getAllByText, getByText } from './byText';
+import {
+  getAllByPlaceholderText,
+  getByPlaceholderText,
+} from './byPlaceholderText';
 
 export type GetByAPI = {|
   getByText: (text: string | RegExp) => ReactTestInstance,
@@ -43,20 +47,6 @@ export type GetByAPI = {|
   getAllByPlaceholder: () => void,
 |};
 
-const getTextInputNodeByPlaceholderText = (node, placeholder) => {
-  try {
-    const { TextInput } = require('react-native');
-    return (
-      filterNodeByType(node, TextInput) &&
-      (typeof placeholder === 'string'
-        ? placeholder === node.props.placeholder
-        : placeholder.test(node.props.placeholder))
-    );
-  } catch (error) {
-    throw createLibraryNotSupportedError(error);
-  }
-};
-
 const getTextInputNodeByDisplayValue = (node, value) => {
   try {
     const { TextInput } = require('react-native');
@@ -73,22 +63,6 @@ const getTextInputNodeByDisplayValue = (node, value) => {
   }
 };
 
-export const getByPlaceholderText = (
-  instance: ReactTestInstance
-): ((placeholder: string | RegExp) => ReactTestInstance) =>
-  function getByPlaceholderTextFn(placeholder: string | RegExp) {
-    try {
-      return instance.find((node) =>
-        getTextInputNodeByPlaceholderText(node, placeholder)
-      );
-    } catch (error) {
-      throw new ErrorWithStack(
-        prepareErrorMessage(error, 'placeholder', placeholder),
-        getByPlaceholderTextFn
-      );
-    }
-  };
-
 export const getByDisplayValue = (
   instance: ReactTestInstance
 ): ((displayValue: string | RegExp) => ReactTestInstance) =>
@@ -103,22 +77,6 @@ export const getByDisplayValue = (
         getByDisplayValueFn
       );
     }
-  };
-
-export const getAllByPlaceholderText = (
-  instance: ReactTestInstance
-): ((placeholder: string | RegExp) => Array<ReactTestInstance>) =>
-  function getAllByPlaceholderTextFn(placeholder: string | RegExp) {
-    const results = instance.findAll((node) =>
-      getTextInputNodeByPlaceholderText(node, placeholder)
-    );
-    if (results.length === 0) {
-      throw new ErrorWithStack(
-        `No instances found with placeholder: ${String(placeholder)}`,
-        getAllByPlaceholderTextFn
-      );
-    }
-    return results;
   };
 
 export const getAllByDisplayValue = (

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import prettyFormat from 'pretty-format';
+import { filterNodeByType } from './filterNodeByType';
 import {
   ErrorWithStack,
   createLibraryNotSupportedError,
@@ -40,8 +41,6 @@ export type GetByAPI = {|
   getByPlaceholder: () => void,
   getAllByPlaceholder: () => void,
 |};
-
-const filterNodeByType = (node, type) => node.type === type;
 
 const getNodeByText = (node, text) => {
   try {

--- a/src/helpers/makeA11yQuery.js
+++ b/src/helpers/makeA11yQuery.js
@@ -26,7 +26,7 @@ type QueryNames = {
   findAllBy: Array<string>,
 };
 
-const makeQuery = <P: mixed, M: mixed>(
+const makeA11yQuery = <P: mixed, M: mixed>(
   name: string,
   queryNames: QueryNames,
   matcherFn: (prop: P, value: M) => boolean
@@ -95,4 +95,4 @@ const makeQuery = <P: mixed, M: mixed>(
   };
 };
 
-export default makeQuery;
+export default makeA11yQuery;

--- a/src/helpers/queryByAPI.js
+++ b/src/helpers/queryByAPI.js
@@ -1,8 +1,6 @@
 // @flow
 import * as React from 'react';
 import {
-  getByDisplayValue,
-  getAllByDisplayValue,
   UNSAFE_getByType,
   UNSAFE_getByProps,
   UNSAFE_getAllByType,
@@ -14,6 +12,7 @@ import {
   queryByPlaceholderText,
   queryAllByPlaceholderText,
 } from './byPlaceholderText';
+import { queryByDisplayValue, queryAllByDisplayValue } from './byDisplayValue';
 import {
   createQueryByError,
   throwRemovedFunctionError,
@@ -55,29 +54,6 @@ export type QueryByAPI = {|
   queryByPlaceholder: () => void,
   queryAllByPlaceholder: () => void,
 |};
-
-export const queryByDisplayValue = (
-  instance: ReactTestInstance
-): ((value: string | RegExp) => ReactTestInstance | null) =>
-  function queryByDisplayValueFn(value: string | RegExp) {
-    try {
-      return getByDisplayValue(instance)(value);
-    } catch (error) {
-      return createQueryByError(error, queryByDisplayValueFn);
-    }
-  };
-
-export const queryAllByDisplayValue = (
-  instance: ReactTestInstance
-): ((value: string | RegExp) => Array<ReactTestInstance>) => (
-  value: string | RegExp
-) => {
-  try {
-    return getAllByDisplayValue(instance)(value);
-  } catch (error) {
-    return [];
-  }
-};
 
 export const UNSAFE_queryByType = (
   instance: ReactTestInstance

--- a/src/helpers/queryByAPI.js
+++ b/src/helpers/queryByAPI.js
@@ -1,10 +1,8 @@
 // @flow
 import * as React from 'react';
 import {
-  getByText,
   getByPlaceholderText,
   getByDisplayValue,
-  getAllByText,
   getAllByPlaceholderText,
   getAllByDisplayValue,
   UNSAFE_getByType,
@@ -13,6 +11,7 @@ import {
   UNSAFE_getAllByProps,
 } from './getByAPI';
 import { queryByTestId, queryAllByTestId } from './byTestId';
+import { queryByText, queryAllByText } from './byText';
 import {
   createQueryByError,
   throwRemovedFunctionError,
@@ -55,17 +54,6 @@ export type QueryByAPI = {|
   queryAllByPlaceholder: () => void,
 |};
 
-export const queryByText = (
-  instance: ReactTestInstance
-): ((text: string | RegExp) => ReactTestInstance | null) =>
-  function queryByTextFn(text: string | RegExp) {
-    try {
-      return getByText(instance)(text);
-    } catch (error) {
-      return createQueryByError(error, queryByTextFn);
-    }
-  };
-
 export const queryByPlaceholderText = (
   instance: ReactTestInstance
 ): ((placeholder: string | RegExp) => ReactTestInstance | null) =>
@@ -87,18 +75,6 @@ export const queryByDisplayValue = (
       return createQueryByError(error, queryByDisplayValueFn);
     }
   };
-
-export const queryAllByText = (
-  instance: ReactTestInstance
-): ((text: string | RegExp) => Array<ReactTestInstance>) => (
-  text: string | RegExp
-) => {
-  try {
-    return getAllByText(instance)(text);
-  } catch (error) {
-    return [];
-  }
-};
 
 export const queryAllByPlaceholderText = (
   instance: ReactTestInstance

--- a/src/helpers/queryByAPI.js
+++ b/src/helpers/queryByAPI.js
@@ -1,9 +1,7 @@
 // @flow
 import * as React from 'react';
 import {
-  getByPlaceholderText,
   getByDisplayValue,
-  getAllByPlaceholderText,
   getAllByDisplayValue,
   UNSAFE_getByType,
   UNSAFE_getByProps,
@@ -12,6 +10,10 @@ import {
 } from './getByAPI';
 import { queryByTestId, queryAllByTestId } from './byTestId';
 import { queryByText, queryAllByText } from './byText';
+import {
+  queryByPlaceholderText,
+  queryAllByPlaceholderText,
+} from './byPlaceholderText';
 import {
   createQueryByError,
   throwRemovedFunctionError,
@@ -54,17 +56,6 @@ export type QueryByAPI = {|
   queryAllByPlaceholder: () => void,
 |};
 
-export const queryByPlaceholderText = (
-  instance: ReactTestInstance
-): ((placeholder: string | RegExp) => ReactTestInstance | null) =>
-  function queryByPlaceholderTextFn(placeholder: string | RegExp) {
-    try {
-      return getByPlaceholderText(instance)(placeholder);
-    } catch (error) {
-      return createQueryByError(error, queryByPlaceholderTextFn);
-    }
-  };
-
 export const queryByDisplayValue = (
   instance: ReactTestInstance
 ): ((value: string | RegExp) => ReactTestInstance | null) =>
@@ -75,18 +66,6 @@ export const queryByDisplayValue = (
       return createQueryByError(error, queryByDisplayValueFn);
     }
   };
-
-export const queryAllByPlaceholderText = (
-  instance: ReactTestInstance
-): ((placeholder: string | RegExp) => Array<ReactTestInstance>) => (
-  placeholder: string | RegExp
-) => {
-  try {
-    return getAllByPlaceholderText(instance)(placeholder);
-  } catch (error) {
-    return [];
-  }
-};
 
 export const queryAllByDisplayValue = (
   instance: ReactTestInstance


### PR DESCRIPTION
### Summary

This PR aims to solve [this issue](https://github.com/callstack/react-native-testing-library/issues/325). It is the follow up of this [PR](https://github.com/callstack/react-native-testing-library/pull/608)

Tasks:

- [ ] group queries by their predicate type (byTestId, byText) instead of grouping them by their return 
type (different for get, find, query).
- [ ] maybe group the tests by predicate type instead of query type?



### Requirements
- [ ] The API should not change

### Test plan

No tests should be added since the API does not change, they only need to be moved to be grouped by predicate type
