### PR TITLE
feat: support pointerEvents

### DIFF
--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -234,7 +234,7 @@ test('should not fire on non-editable TextInput with nested Text', () => {
   expect(onChangeTextMock).not.toHaveBeenCalled();
 });
 
-test.only('should not fire on non-targetable View', () => {
+test('should not fire on none pointerEvents View', () => {
   const handlePress = jest.fn();
 
   const screen = render(
@@ -242,6 +242,38 @@ test.only('should not fire on non-targetable View', () => {
       <Pressable onPress={handlePress}>
         <Text>Trigger</Text>
       </Pressable>
+    </View>
+  );
+
+  fireEvent.press(screen.getByText('Trigger'));
+  expect(handlePress).not.toHaveBeenCalled();
+});
+
+test('should not fire on box-only pointerEvents View', () => {
+  const handlePress = jest.fn();
+
+  const screen = render(
+    <View pointerEvents="box-only">
+      <Pressable onPress={handlePress}>
+        <Text>Trigger</Text>
+      </Pressable>
+    </View>
+  );
+
+  fireEvent.press(screen.getByText('Trigger'));
+  expect(handlePress).not.toHaveBeenCalled();
+});
+
+test('should not fire on none pointerEvents View with nested elements', () => {
+  const handlePress = jest.fn();
+
+  const screen = render(
+    <View pointerEvents="box-only">
+      <View>
+        <Pressable onPress={handlePress}>
+          <Text>Trigger</Text>
+        </Pressable>
+      </View>
     </View>
   );
 

--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -294,7 +294,7 @@ test('should fire on auto pointerEvents View', () => {
   expect(handlePress).toHaveBeenCalled();
 });
 
-test('should not fire on none pointerEvents View with nested elements', () => {
+test('should not fire on box-only pointerEvents View with nested elements', () => {
   const handlePress = jest.fn();
 
   const screen = render(

--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -279,6 +279,21 @@ test('should fire on box-none pointerEvents View', () => {
   expect(handlePress).toHaveBeenCalled();
 });
 
+test('should fire on auto pointerEvents View', () => {
+  const handlePress = jest.fn();
+
+  const screen = render(
+    <View pointerEvents="auto">
+      <Pressable onPress={handlePress}>
+        <Text>Trigger</Text>
+      </Pressable>
+    </View>
+  );
+
+  fireEvent.press(screen.getByText('Trigger'));
+  expect(handlePress).toHaveBeenCalled();
+});
+
 test('should not fire on none pointerEvents View with nested elements', () => {
   const handlePress = jest.fn();
 

--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -264,6 +264,21 @@ test('should not fire on box-only pointerEvents View', () => {
   expect(handlePress).not.toHaveBeenCalled();
 });
 
+test('should fire on box-none pointerEvents View', () => {
+  const handlePress = jest.fn();
+
+  const screen = render(
+    <View pointerEvents="box-none">
+      <Pressable onPress={handlePress}>
+        <Text>Trigger</Text>
+      </Pressable>
+    </View>
+  );
+
+  fireEvent.press(screen.getByText('Trigger'));
+  expect(handlePress).toHaveBeenCalled();
+});
+
 test('should not fire on none pointerEvents View with nested elements', () => {
   const handlePress = jest.fn();
 

--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -234,6 +234,21 @@ test('should not fire on non-editable TextInput with nested Text', () => {
   expect(onChangeTextMock).not.toHaveBeenCalled();
 });
 
+test.only('should not fire on non-targetable View', () => {
+  const handlePress = jest.fn();
+
+  const screen = render(
+    <View pointerEvents="none">
+      <Pressable onPress={handlePress}>
+        <Text>Trigger</Text>
+      </Pressable>
+    </View>
+  );
+
+  fireEvent.press(screen.getByText('Trigger'));
+  expect(handlePress).not.toHaveBeenCalled();
+});
+
 test('should pass event up on disabled TouchableOpacity', () => {
   const handleInnerPress = jest.fn();
   const handleOuterPress = jest.fn();

--- a/src/fireEvent.js
+++ b/src/fireEvent.js
@@ -17,11 +17,25 @@ const isTouchResponder = (element?: ReactTestInstance) => {
   return !!element?.props.onStartShouldSetResponder || isTextInput(element);
 };
 
+const isPointerEventEnabled = (element?: ReactTestInstance) => {
+  if (
+    element?.props.pointerEvents === 'none' ||
+    element?.props.pointerEvents === 'box-only'
+  ) {
+    return false;
+  }
+
+  if (!element?.parent) return true;
+
+  return isPointerEventEnabled(element.parent);
+};
+
 const isEventEnabled = (
   element?: ReactTestInstance,
   touchResponder?: ReactTestInstance
 ) => {
   if (isTextInput(element)) return element?.props.editable !== false;
+  if (!isPointerEventEnabled(element)) return false;
 
   const touchStart = touchResponder?.props.onStartShouldSetResponder?.();
   const touchMove = touchResponder?.props.onMoveShouldSetResponder?.();

--- a/src/fireEvent.js
+++ b/src/fireEvent.js
@@ -17,17 +17,21 @@ const isTouchResponder = (element?: ReactTestInstance) => {
   return !!element?.props.onStartShouldSetResponder || isTextInput(element);
 };
 
-const isPointerEventEnabled = (element?: ReactTestInstance) => {
-  if (
-    element?.props.pointerEvents === 'none' ||
-    element?.props.pointerEvents === 'box-only'
-  ) {
+const isPointerEventEnabled = (
+  element?: ReactTestInstance,
+  isParent?: boolean
+) => {
+  const parentCondition = isParent
+    ? element?.props.pointerEvents === 'box-only'
+    : element?.props.pointerEvents === 'box-none';
+
+  if (element?.props.pointerEvents === 'none' || parentCondition) {
     return false;
   }
 
   if (!element?.parent) return true;
 
-  return isPointerEventEnabled(element.parent);
+  return isPointerEventEnabled(element.parent, true);
 };
 
 const isEventEnabled = (


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR allows handling test cases that use `pointerEvents` which was mentioned in #650. I'm not sure if we should also additionally handle the `box-none` value. 

Fixes #650

### Test plan

I've added 3 tests that check pointerEvents `none` and `box-only` and also pointerEvents `none` with nested views.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
