### PR TITLE
Fix issue of getByDisplayValue not checking TextInputs defaultValue

### DIFF
--- a/src/__tests__/__snapshots__/render.test.js.snap
+++ b/src/__tests__/__snapshots__/render.test.js.snap
@@ -20,11 +20,18 @@ exports[`debug 1`] = `
   />
   <TextInput
     allowFontScaling={true}
+    defaultValue=\\"What did you inspect?\\"
     placeholder=\\"Who inspected freshness?\\"
     rejectResponderTermination={true}
     testID=\\"bananaChef\\"
     underlineColorAndroid=\\"transparent\\"
     value=\\"I inspected freshie\\"
+  />
+  <TextInput
+    allowFontScaling={true}
+    defaultValue=\\"What banana?\\"
+    rejectResponderTermination={true}
+    underlineColorAndroid=\\"transparent\\"
   />
   <View
     accessible={true}
@@ -82,11 +89,18 @@ exports[`debug changing component: bananaFresh button message should now be "fre
   />
   <TextInput
     allowFontScaling={true}
+    defaultValue=\\"What did you inspect?\\"
     placeholder=\\"Who inspected freshness?\\"
     rejectResponderTermination={true}
     testID=\\"bananaChef\\"
     underlineColorAndroid=\\"transparent\\"
     value=\\"I inspected freshie\\"
+  />
+  <TextInput
+    allowFontScaling={true}
+    defaultValue=\\"What banana?\\"
+    rejectResponderTermination={true}
+    underlineColorAndroid=\\"transparent\\"
   />
   <View
     accessible={true}
@@ -144,11 +158,18 @@ exports[`debug: shallow 1`] = `
   />
   <TextInput
     allowFontScaling={true}
+    defaultValue=\\"What did you inspect?\\"
     placeholder=\\"Who inspected freshness?\\"
     rejectResponderTermination={true}
     testID=\\"bananaChef\\"
     underlineColorAndroid=\\"transparent\\"
     value=\\"I inspected freshie\\"
+  />
+  <TextInput
+    allowFontScaling={true}
+    defaultValue=\\"What banana?\\"
+    rejectResponderTermination={true}
+    underlineColorAndroid=\\"transparent\\"
   />
   <MyButton
     onPress={[Function anonymous]}
@@ -194,11 +215,18 @@ exports[`debug: shallow with message 1`] = `
   />
   <TextInput
     allowFontScaling={true}
+    defaultValue=\\"What did you inspect?\\"
     placeholder=\\"Who inspected freshness?\\"
     rejectResponderTermination={true}
     testID=\\"bananaChef\\"
     underlineColorAndroid=\\"transparent\\"
     value=\\"I inspected freshie\\"
+  />
+  <TextInput
+    allowFontScaling={true}
+    defaultValue=\\"What banana?\\"
+    rejectResponderTermination={true}
+    underlineColorAndroid=\\"transparent\\"
   />
   <MyButton
     onPress={[Function anonymous]}
@@ -244,11 +272,18 @@ exports[`debug: with message 1`] = `
   />
   <TextInput
     allowFontScaling={true}
+    defaultValue=\\"What did you inspect?\\"
     placeholder=\\"Who inspected freshness?\\"
     rejectResponderTermination={true}
     testID=\\"bananaChef\\"
     underlineColorAndroid=\\"transparent\\"
     value=\\"I inspected freshie\\"
+  />
+  <TextInput
+    allowFontScaling={true}
+    defaultValue=\\"What banana?\\"
+    rejectResponderTermination={true}
+    underlineColorAndroid=\\"transparent\\"
   />
   <View
     accessible={true}

--- a/src/__tests__/__snapshots__/render.test.js.snap
+++ b/src/__tests__/__snapshots__/render.test.js.snap
@@ -33,6 +33,13 @@ exports[`debug 1`] = `
     rejectResponderTermination={true}
     underlineColorAndroid=\\"transparent\\"
   />
+  <TextInput
+    allowFontScaling={true}
+    defaultValue=\\"hello\\"
+    rejectResponderTermination={true}
+    underlineColorAndroid=\\"transparent\\"
+    value=\\"\\"
+  />
   <View
     accessible={true}
     focusable={true}
@@ -101,6 +108,13 @@ exports[`debug changing component: bananaFresh button message should now be "fre
     defaultValue=\\"What banana?\\"
     rejectResponderTermination={true}
     underlineColorAndroid=\\"transparent\\"
+  />
+  <TextInput
+    allowFontScaling={true}
+    defaultValue=\\"hello\\"
+    rejectResponderTermination={true}
+    underlineColorAndroid=\\"transparent\\"
+    value=\\"\\"
   />
   <View
     accessible={true}
@@ -171,6 +185,13 @@ exports[`debug: shallow 1`] = `
     rejectResponderTermination={true}
     underlineColorAndroid=\\"transparent\\"
   />
+  <TextInput
+    allowFontScaling={true}
+    defaultValue=\\"hello\\"
+    rejectResponderTermination={true}
+    underlineColorAndroid=\\"transparent\\"
+    value=\\"\\"
+  />
   <MyButton
     onPress={[Function anonymous]}
     type=\\"primary\\"
@@ -228,6 +249,13 @@ exports[`debug: shallow with message 1`] = `
     rejectResponderTermination={true}
     underlineColorAndroid=\\"transparent\\"
   />
+  <TextInput
+    allowFontScaling={true}
+    defaultValue=\\"hello\\"
+    rejectResponderTermination={true}
+    underlineColorAndroid=\\"transparent\\"
+    value=\\"\\"
+  />
   <MyButton
     onPress={[Function anonymous]}
     type=\\"primary\\"
@@ -284,6 +312,13 @@ exports[`debug: with message 1`] = `
     defaultValue=\\"What banana?\\"
     rejectResponderTermination={true}
     underlineColorAndroid=\\"transparent\\"
+  />
+  <TextInput
+    allowFontScaling={true}
+    defaultValue=\\"hello\\"
+    rejectResponderTermination={true}
+    underlineColorAndroid=\\"transparent\\"
+    value=\\"\\"
   />
   <View
     accessible={true}

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -72,6 +72,7 @@ class Banana extends React.Component<any, any> {
           defaultValue={DEFAULT_INPUT_CHEF}
         />
         <TextInput defaultValue={DEFAULT_INPUT_CUSTOMER} />
+        <TextInput defaultValue={'hello'} value="" />
         <MyButton onPress={this.changeFresh} type="primary">
           Change freshness!
         </MyButton>
@@ -209,6 +210,9 @@ test('getByDisplayValue, queryByDisplayValue get element by default value only w
   const { getByDisplayValue, queryByDisplayValue } = render(<Banana />);
   expect(() => getByDisplayValue(DEFAULT_INPUT_CHEF)).toThrow();
   expect(queryByDisplayValue(DEFAULT_INPUT_CHEF)).toBeNull();
+
+  expect(() => getByDisplayValue('hello')).toThrow();
+  expect(queryByDisplayValue('hello')).toBeNull();
 
   expect(getByDisplayValue(DEFAULT_INPUT_CUSTOMER)).toBeTruthy();
   expect(queryByDisplayValue(DEFAULT_INPUT_CUSTOMER)).toBeTruthy();

--- a/src/__tests__/render.test.js
+++ b/src/__tests__/render.test.js
@@ -16,6 +16,8 @@ const PLACEHOLDER_FRESHNESS = 'Add custom freshness';
 const PLACEHOLDER_CHEF = 'Who inspected freshness?';
 const INPUT_FRESHNESS = 'Custom Freshie';
 const INPUT_CHEF = 'I inspected freshie';
+const DEFAULT_INPUT_CHEF = 'What did you inspect?';
+const DEFAULT_INPUT_CUSTOMER = 'What banana?';
 
 class MyButton extends React.Component<any> {
   render() {
@@ -67,7 +69,9 @@ class Banana extends React.Component<any, any> {
           testID="bananaChef"
           placeholder={PLACEHOLDER_CHEF}
           value={INPUT_CHEF}
+          defaultValue={DEFAULT_INPUT_CHEF}
         />
+        <TextInput defaultValue={DEFAULT_INPUT_CUSTOMER} />
         <MyButton onPress={this.changeFresh} type="primary">
           Change freshness!
         </MyButton>
@@ -199,6 +203,15 @@ test('getByDisplayValue, queryByDisplayValue', () => {
   expect(queryByDisplayValue(/custom/i)).toBe(input);
   expect(queryByDisplayValue('no value')).toBeNull();
   expect(() => queryByDisplayValue(/fresh/i)).toThrow('Expected 1 but found 2');
+});
+
+test('getByDisplayValue, queryByDisplayValue get element by default value only when value is undefined', () => {
+  const { getByDisplayValue, queryByDisplayValue } = render(<Banana />);
+  expect(() => getByDisplayValue(DEFAULT_INPUT_CHEF)).toThrow();
+  expect(queryByDisplayValue(DEFAULT_INPUT_CHEF)).toBeNull();
+
+  expect(getByDisplayValue(DEFAULT_INPUT_CUSTOMER)).toBeTruthy();
+  expect(queryByDisplayValue(DEFAULT_INPUT_CUSTOMER)).toBeTruthy();
 });
 
 test('getAllByDisplayValue, queryAllByDisplayValue', () => {

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -107,11 +107,10 @@ const getTextInputNodeByPlaceholderText = (node, placeholder) => {
 const getTextInputNodeByDisplayValue = (node, value) => {
   try {
     const { TextInput } = require('react-native');
+    const nodeValue = node.props.value || node.props.defaultValue;
     return (
       filterNodeByType(node, TextInput) &&
-      (typeof value === 'string'
-        ? value === node.props.value
-        : value.test(node.props.value))
+      (typeof value === 'string' ? value === nodeValue : value.test(nodeValue))
     );
   } catch (error) {
     throw createLibraryNotSupportedError(error);

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -107,7 +107,10 @@ const getTextInputNodeByPlaceholderText = (node, placeholder) => {
 const getTextInputNodeByDisplayValue = (node, value) => {
   try {
     const { TextInput } = require('react-native');
-    const nodeValue = node.props.value || node.props.defaultValue;
+    const nodeValue =
+      node.props.value !== undefined
+        ? node.props.value
+        : node.props.defaultValue;
     return (
       filterNodeByType(node, TextInput) &&
       (typeof value === 'string' ? value === nodeValue : value.test(nodeValue))


### PR DESCRIPTION
### Summary

This PR aims to solve [this issue](https://github.com/callstack/react-native-testing-library/issues/649). Basically the issue to fix is that the byDisplayValue helpers don't check the defaultValue prop of TextInputs.

### Requirements

- [ ] If a TextInput only has a defaultValue and no value, getByDisplayValue should find it
- [ ] If a TextInput has a defaultValue AND a value, getByDisplayValue should only find it by its value and not its defaultValue (since if a value is provided, the default value won't be displayed)

### Test plan

- [ ] Check that getByDisplayValue and queryByDisplayValue get the TextInput by defaultValue if no value is provided
- [ ] Check that getByDisplayValue and queryByDisplayValue don't get the TextInput by defaultValue if a value is provided