### PR TITLE
fix: add React.Fragment support for matching text

### DIFF
--- a/src/__tests__/queryByApi.test.js
+++ b/src/__tests__/queryByApi.test.js
@@ -114,3 +114,17 @@ test('queryByText nested deep <CustomText> in <Text>', () => {
     ).queryByText('Hello World!')
   ).toBeTruthy();
 });
+
+test('queryByText nested <React.Fragment> in <Text>', () => {
+  const CustomText = () => {
+    return <React.Fragment>Hello World</React.Fragment>;
+  };
+
+  expect(
+    render(
+      <Text>
+        <CustomText />
+      </Text>
+    ).queryByText('Hello World')
+  ).toBeTruthy();
+});

--- a/src/__tests__/queryByApi.test.js
+++ b/src/__tests__/queryByApi.test.js
@@ -1,6 +1,6 @@
 // @flow
 import * as React from 'react';
-import { Text, Image } from 'react-native';
+import { Text, Image, View } from 'react-native';
 import { render } from '..';
 
 test('queryByText nested <Image> in <Text> at start', () => {
@@ -127,4 +127,18 @@ test('queryByText nested <React.Fragment> in <Text>', () => {
       </Text>
     ).queryByText('Hello World')
   ).toBeTruthy();
+});
+
+test('queryByText nested <React.Fragment> in <View>', () => {
+  const CustomText = () => {
+    return <React.Fragment>Hello World</React.Fragment>;
+  };
+
+  expect(
+    render(
+      <View>
+        <CustomText />
+      </View>
+    ).queryByText('Hello World')
+  ).toBeFalsy();
 });

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -41,7 +41,7 @@ export type GetByAPI = {|
   getAllByPlaceholder: () => void,
 |};
 
-const filterNodeByType = (node, type) => node.type === type;
+const filterNodeByType = (node, type) => node?.type === type;
 
 const getNodeByText = (node, text) => {
   try {
@@ -57,13 +57,16 @@ const getNodeByText = (node, text) => {
       }
     }
 
-    // Fragments
-    if (typeof node.children?.[0] === 'string') {
-      const textToTest = node.children.join('');
-      return typeof text === 'string'
-        ? text === textToTest
-        : text.test(textToTest);
+    const isParentTextComponent = filterNodeByType(node.parent?.parent, Text);
+    if (isParentTextComponent && !isTextComponent) {
+      if (typeof node.children?.[0] === 'string') {
+        const textToTest = node.children.join('');
+        return typeof text === 'string'
+          ? text === textToTest
+          : text.test(textToTest);
+      }
     }
+
     return false;
   } catch (error) {
     throw createLibraryNotSupportedError(error);

--- a/src/helpers/getByAPI.js
+++ b/src/helpers/getByAPI.js
@@ -56,6 +56,14 @@ const getNodeByText = (node, text) => {
           : text.test(textToTest);
       }
     }
+
+    // Fragments
+    if (typeof node.children?.[0] === 'string') {
+      const textToTest = node.children.join('');
+      return typeof text === 'string'
+        ? text === textToTest
+        : text.test(textToTest);
+    }
     return false;
   } catch (error) {
     throw createLibraryNotSupportedError(error);


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

When using getByText() on a custom component using nested Fragments, it should return the text content within the fragments.

```jsx
const CustomText = () => {
  return <React.Fragment>Hello World</React.Fragment>;
};

<Text>
  <CustomText />
</Text>
```
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

I've added an additional test and all other tests are passing. Let me know if there's any concerns or other things we can add to protect against regression.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
