### PR TITLE
Fixed broken link of mock setup file

### DIFF
--- a/website/docs/ReactNavigation.md
+++ b/website/docs/ReactNavigation.md
@@ -266,7 +266,7 @@ Install required dev dependencies:
 $ yarn add -D jest @testing-library/react-native
 ```
 
-Create a [`mock file`](https://github.com/callstack/react-native-testing-library/blob/master/examples/reactnavigation/jest-mocks.js) necessary for your tests:
+Create a [`mock file`](https://github.com/callstack/react-native-testing-library/blob/master/examples/reactnavigation/jest-setup.js) necessary for your tests:
 
 ```jsx
 import 'react-native-gesture-handler/jestSetup';
@@ -290,7 +290,7 @@ Create your `jest.config.js` file (or place the following properties in your `pa
 ```js
 module.exports = {
   preset: 'react-native',
-  setupFiles: ['./jest-mocks.js'],
+  setupFiles: ['./jest-setup.js'],
   transformIgnorePatterns: [
     'node_modules/(?!(jest-)?react-native|@react-native-community|@react-navigation)',
   ],


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

In documentation jest-setup.js file from the example, was mentioned as jest-mocks.js. 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Create a [mock file](https://github.com/callstack/react-native-testing-library/blob/master/examples/reactnavigation/jest-setup.js) necessary for your tests: (Now, on click redirects to correct file)

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

