### PR TITLE
feat(breaking): do not throw because event handler was not found

### DIFF
--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -62,6 +62,16 @@ describe('fireEvent', () => {
     expect(onPressMock).toHaveBeenCalled();
   });
 
+  test('should not fire if the press handler is not passed to children', () => {
+    const onPressMock = jest.fn();
+    const { getByText } = render(
+      // TODO: this functionality is buggy, i.e. it will fail if we wrap this component with a View.
+      <WithoutEventComponent onPress={onPressMock} />
+    );
+    fireEvent(getByText('Without event'), 'press');
+    expect(onPressMock).not.toHaveBeenCalled();
+  });
+
   test('should invoke event with custom name', () => {
     const handlerMock = jest.fn();
     const EVENT_DATA = 'event data';

--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -62,16 +62,6 @@ describe('fireEvent', () => {
     expect(onPressMock).toHaveBeenCalled();
   });
 
-  test('should throw an Error when event handler was not found', () => {
-    const { getByText } = render(
-      <WithoutEventComponent onPress={() => 'this is not passed to children'} />
-    );
-
-    expect(() => fireEvent(getByText('Without event'), 'press')).toThrow(
-      'No handler function found for event: "press"'
-    );
-  });
-
   test('should invoke event with custom name', () => {
     const handlerMock = jest.fn();
     const EVENT_DATA = 'event data';

--- a/src/fireEvent.js
+++ b/src/fireEvent.js
@@ -52,8 +52,7 @@ const findEventHandler = (
   element: ReactTestInstance,
   eventName: string,
   callsite?: any,
-  nearestTouchResponder?: ReactTestInstance,
-  hasDescendandHandler?: boolean
+  nearestTouchResponder?: ReactTestInstance
 ) => {
   const touchResponder = isTouchResponder(element)
     ? element
@@ -62,19 +61,11 @@ const findEventHandler = (
   const handler = getEventHandler(element, eventName);
   if (handler && isEventEnabled(element, touchResponder)) return handler;
 
-  // Do not bubble event to the root element
-  const hasHandler = handler != null || hasDescendandHandler;
   if (element.parent === null || element.parent.parent === null) {
     return null;
   }
 
-  return findEventHandler(
-    element.parent,
-    eventName,
-    callsite,
-    touchResponder,
-    hasHandler
-  );
+  return findEventHandler(element.parent, eventName, callsite, touchResponder);
 };
 
 const getEventHandler = (element: ReactTestInstance, eventName: string) => {

--- a/src/fireEvent.js
+++ b/src/fireEvent.js
@@ -1,6 +1,5 @@
 // @flow
 import act from './act';
-import { ErrorWithStack } from './helpers/errors';
 
 const isHostElement = (element?: ReactTestInstance) => {
   return typeof element?.type === 'string';
@@ -66,14 +65,7 @@ const findEventHandler = (
   // Do not bubble event to the root element
   const hasHandler = handler != null || hasDescendandHandler;
   if (element.parent === null || element.parent.parent === null) {
-    if (hasHandler) {
-      return null;
-    } else {
-      throw new ErrorWithStack(
-        `No handler function found for event: "${eventName}"`,
-        callsite || invokeEvent
-      );
-    }
+    return null;
   }
 
   return findEventHandler(


### PR DESCRIPTION
### Summary

Idea from: https://github.com/callstack/react-native-testing-library/pull/674#discussion_r584551609

Quote from @thymikee:
```
We actually don't the invokeEvent to be throwable. It supposed to be there as a debugging aid, but the original Testing Library don't have this behavior and here it actually complicates things a little more.

How about removing this behavior altogether in a separate PR and adjusting this one to keep the invokeEvent without the try/catch?
```