### PR TITLE
Debug implicit any error

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -299,7 +299,7 @@ export interface RenderOptions {
 }
 
 type Debug = {
-  (message?: string): any;
+  (message?: string): void;
   shallow: (message?: string) => void;
 };
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -299,7 +299,7 @@ export interface RenderOptions {
 }
 
 type Debug = {
-  (message?: string);
+  (message?: string): any;
   shallow: (message?: string) => void;
 };
 


### PR DESCRIPTION
### Summary

In a project that didn’t allow implicit `any`s, this error would be thrown for `Debug`.

```
Call signature, which lacks return-type annotation, implicitly has an 'any' return type.
```

### Test plan

Use the `yarn run typescript-check`.

I’ve tested this change against a live project and it corrects the error, though perhaps there is a better type?
