### PR TITLE
Update react navigation  docs to support RN-0.64

### DIFF
--- a/website/docs/ReactNavigation.md
+++ b/website/docs/ReactNavigation.md
@@ -139,7 +139,7 @@ module.exports = {
   preset: 'react-native',
   setupFiles: ['./node_modules/react-native-gesture-handler/jestSetup.js'],
   transformIgnorePatterns: [
-    'node_modules/(?!(jest-)?react-native|@react-native-community|@react-navigation)',
+    'node_modules/(?!(jest-)?@?react-native|@react-native-community|@react-navigation)',
   ],
 };
 ```


### PR DESCRIPTION
### Summary

Update docs in the react-navigation example section that broke the test after upgraded to react-native v0.64

