### PR TITLE
docs: fix cleanup API doc

### DIFF
--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -138,33 +138,6 @@ Unmounts React trees that were mounted with `render`.
 Please note that this is done automatically if the testing framework you're using supports the `afterEach` global (like mocha, Jest, and Jasmine). If not, you will need to do manual cleanups after each test.
 :::
 
-For example, if you're using the `jest` testing framework, then you would need to use the `afterEach` hook like so:
-
-```jsx
-import { cleanup, render } from '@testing-library/react-native/pure';
-import { View } from 'react-native';
-
-afterEach(cleanup);
-
-it('renders a view', () => {
-  render(<View />);
-  // ...
-});
-```
-
-The `afterEach(cleanup)` call also works in `describe` blocks:
-
-```jsx
-describe('when logged in', () => {
-  afterEach(cleanup);
-
-  it('renders the user', () => {
-    render(<SiteHeader />);
-    // ...
-  });
-});
-```
-
 Failing to call `cleanup` when you've called `render` could result in a memory leak and tests which are not "idempotent" (which can lead to difficult to debug errors in your tests).
 
 The alternative to `cleanup` is balancing every `render` with an `unmount` method call.


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

`cleanup` is done automatically if using jest, right?
Unfortunately, I couldn't find out an alternative example.  
[ava](https://github.com/avajs/ava) , introduced in [react-testing-library doc](https://testing-library.com/docs/react-testing-library/api#cleanup) supports React Native? 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
