### PR TITLE
test: add failing tests for #776

### DIFF
--- a/src/__tests__/byText.test.js
+++ b/src/__tests__/byText.test.js
@@ -105,6 +105,37 @@ test('findByText queries work asynchronously', async () => {
   await expect(findAllByText('Some Text')).resolves.toHaveLength(1);
 }, 20000);
 
+test.skip('getByText works properly with custom text component', () => {
+  function BoldText({ children }) {
+    return <Text>{children}</Text>;
+  }
+
+  expect(
+    render(
+      <Text>
+        <BoldText>Hello</BoldText>
+      </Text>
+    ).getByText('Hello')
+  ).toBeTruthy();
+});
+
+test.skip('getByText works properly with custom text container', () => {
+  function MyText({ children }) {
+    return <Text>{children}</Text>;
+  }
+  function BoldText({ children }) {
+    return <Text>{children}</Text>;
+  }
+
+  expect(
+    render(
+      <MyText>
+        <BoldText>Hello</BoldText>
+      </MyText>
+    ).getByText('Hello')
+  ).toBeTruthy();
+});
+
 test('queryByText nested <Image> in <Text> at start', () => {
   expect(
     render(


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This shows two failing test cases for #776 

Note that #554 fixes both of them, so if #554 is merged, they can be enabled.

### Test plan

They test themselves 🙂 
 
Skipped because they fail on current `master`:

<img width="604" alt="Screenshot 2021-07-06 at 17 11 32" src="https://user-images.githubusercontent.com/697707/124614719-3700a700-de7d-11eb-8240-7a1425c81be5.png">
