### PR TITLE
feat: accessibility findAll

### DIFF
--- a/src/__tests__/byDisplayValue.test.js
+++ b/src/__tests__/byDisplayValue.test.js
@@ -111,7 +111,7 @@ test('all queries should respect accessibility', async () => {
   );
   const Comp = () => (
     <View>
-      <OtherComp accessibilityElementsHidden />
+      <OtherComp importantForAccessibility="no-hide-descendants" />
       <TextInput value="test_02" />
       <View>
         <TextInput value="test_02" />

--- a/src/__tests__/byDisplayValue.test.js
+++ b/src/__tests__/byDisplayValue.test.js
@@ -102,12 +102,23 @@ test('findBy queries work asynchronously', async () => {
 }, 20000);
 
 test('all queries should respect accessibility', async () => {
-  const Comp = () => (
-    <View>
-      <View accessibilityElementsHidden>
+  const Input = () => (
+    <View >
+      <View>
         <TextInput value="test_01" />
       </View>
+    </View>
+  );
+  const Comp = () => (
+    <View>
+      <Input accessibilityElementsHidden />
       <TextInput value="test_02" />
+      <View>
+        <TextInput value="test_02" />
+      </View>
+      <View>
+        <TextInput accessibilityElementsHidden value="test_01" />
+      </View>
     </View>
   );
 
@@ -120,14 +131,30 @@ test('all queries should respect accessibility', async () => {
     queryByDisplayValue,
   } = render(<Comp />, { respectAccessibility: true });
 
-  await expect(findAllByDisplayValue('test_01')).rejects.toBeTruthy();
-  await expect(findByDisplayValue('test_01')).rejects.toBeTruthy();
+  await expect(getAllByDisplayValue("test_02")).toHaveLength(2);
   await expect(() => getAllByDisplayValue('test_01')).toThrow(
     'Unable to find an element with displayValue: test_01'
   );
-  await expect(queryAllByDisplayValue('test_01')).toHaveLength(0);
+  await expect(() => getByDisplayValue("test_02")).toThrow(
+    "Found multiple elements with display value: test_02 "
+  );
   await expect(() => getByDisplayValue('test_01')).toThrow(
     'Unable to find an element with displayValue: test_01'
   );
+  await expect(queryAllByDisplayValue('test_01')).toHaveLength(0);
+  await expect(queryAllByDisplayValue("test_02")).toHaveLength(2);
   await expect(queryByDisplayValue('test_01')).toBeNull();
+  await expect(() => queryByDisplayValue("test_02")).toThrow(
+    "Found multiple elements with display value: test_02 "
+  );
+  await expect(findAllByDisplayValue('test_01')).rejects.toEqual(
+    new Error("Unable to find an element with displayValue: test_01")
+  );
+  await expect(findAllByDisplayValue('test_02')).resolves.toHaveLength(2);
+  await expect(findByDisplayValue('test_01')).rejects.toEqual(
+    new Error("Unable to find an element with displayValue: test_01")
+  );
+  await expect(findByDisplayValue('test_02')).rejects.toEqual(
+    new Error("Found multiple elements with display value: test_02 ")
+  );
 });

--- a/src/__tests__/byDisplayValue.test.js
+++ b/src/__tests__/byDisplayValue.test.js
@@ -107,13 +107,16 @@ test('all queries should respect accessibility', async () => {
       <View>
         <TextInput value="test_01" />
       </View>
+      <View accessibilityViewIsModal>
+        <TextInput value="test_02" />
+      </View>
     </View>
   );
   const Comp = () => (
     <View>
       <OtherComp importantForAccessibility="no-hide-descendants" />
       <OtherComp style={{display: "none"}} />
-      <TextInput value="test_02" />
+      <OtherComp />
       <View>
         <TextInput value="test_02" />
       </View>

--- a/src/__tests__/byDisplayValue.test.js
+++ b/src/__tests__/byDisplayValue.test.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react';
 import { View, TextInput } from 'react-native';
-import { isExportDeclaration } from 'typescript';
 
 import { render } from '..';
 
@@ -118,17 +117,17 @@ test('all queries should respect accessibility', async () => {
     getAllByDisplayValue,
     queryAllByDisplayValue,
     getByDisplayValue,
-    queryByDisplayValue
+    queryByDisplayValue,
   } = render(<Comp />, { respectAccessibility: true });
 
-  await expect(findAllByDisplayValue("test_01")).rejects.toBeTruthy();
-  await expect(findByDisplayValue("test_01")).rejects.toBeTruthy();
-  await expect(() => getAllByDisplayValue("test_01")).toThrow(
-    "Unable to find an element with displayValue: test_01"
+  await expect(findAllByDisplayValue('test_01')).rejects.toBeTruthy();
+  await expect(findByDisplayValue('test_01')).rejects.toBeTruthy();
+  await expect(() => getAllByDisplayValue('test_01')).toThrow(
+    'Unable to find an element with displayValue: test_01'
   );
-  await expect(queryAllByDisplayValue("test_01")).toHaveLength(0);
-  await expect(() => getByDisplayValue("test_01")).toThrow(
-    "Unable to find an element with displayValue: test_01"
+  await expect(queryAllByDisplayValue('test_01')).toHaveLength(0);
+  await expect(() => getByDisplayValue('test_01')).toThrow(
+    'Unable to find an element with displayValue: test_01'
   );
-  await expect(queryByDisplayValue("test_01")).toBeNull();
+  await expect(queryByDisplayValue('test_01')).toBeNull();
 });

--- a/src/__tests__/byDisplayValue.test.js
+++ b/src/__tests__/byDisplayValue.test.js
@@ -102,7 +102,7 @@ test('findBy queries work asynchronously', async () => {
 }, 20000);
 
 test('all queries should respect accessibility', async () => {
-  const Input = () => (
+  const OtherComp = () => (
     <View >
       <View>
         <TextInput value="test_01" />
@@ -111,7 +111,7 @@ test('all queries should respect accessibility', async () => {
   );
   const Comp = () => (
     <View>
-      <Input accessibilityElementsHidden />
+      <OtherComp accessibilityElementsHidden />
       <TextInput value="test_02" />
       <View>
         <TextInput value="test_02" />

--- a/src/__tests__/byDisplayValue.test.js
+++ b/src/__tests__/byDisplayValue.test.js
@@ -112,6 +112,7 @@ test('all queries should respect accessibility', async () => {
   const Comp = () => (
     <View>
       <OtherComp importantForAccessibility="no-hide-descendants" />
+      <OtherComp style={{display: "none"}} />
       <TextInput value="test_02" />
       <View>
         <TextInput value="test_02" />

--- a/src/__tests__/byDisplayValue.test.js
+++ b/src/__tests__/byDisplayValue.test.js
@@ -119,7 +119,7 @@ test('all queries should respect accessibility', async () => {
     queryAllByDisplayValue,
     getByDisplayValue,
     queryByDisplayValue
-  } = render(<Comp />, { respectAccessibilityProps: true });
+  } = render(<Comp />, { respectAccessibility: true });
 
   await expect(findAllByDisplayValue("test_01")).rejects.toBeTruthy();
   await expect(findByDisplayValue("test_01")).rejects.toBeTruthy();

--- a/src/__tests__/byDisplayValue.test.js
+++ b/src/__tests__/byDisplayValue.test.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import { View, TextInput } from 'react-native';
+import { isExportDeclaration } from 'typescript';
 
 import { render } from '..';
 
@@ -100,3 +101,34 @@ test('findBy queries work asynchronously', async () => {
   await expect(findByDisplayValue('Display Value')).resolves.toBeTruthy();
   await expect(findAllByDisplayValue('Display Value')).resolves.toHaveLength(1);
 }, 20000);
+
+test('all queries should respect accessibility', async () => {
+  const Comp = () => (
+    <View>
+      <View accessibilityElementsHidden>
+        <TextInput value="test_01" />
+      </View>
+      <TextInput value="test_02" />
+    </View>
+  );
+
+  const {
+    findAllByDisplayValue,
+    findByDisplayValue,
+    getAllByDisplayValue,
+    queryAllByDisplayValue,
+    getByDisplayValue,
+    queryByDisplayValue
+  } = render(<Comp />, { respectAccessibilityProps: true });
+
+  await expect(findAllByDisplayValue("test_01")).rejects.toBeTruthy();
+  await expect(findByDisplayValue("test_01")).rejects.toBeTruthy();
+  await expect(() => getAllByDisplayValue("test_01")).toThrow(
+    "Unable to find an element with displayValue: test_01"
+  );
+  await expect(queryAllByDisplayValue("test_01")).toHaveLength(0);
+  await expect(() => getByDisplayValue("test_01")).toThrow(
+    "Unable to find an element with displayValue: test_01"
+  );
+  await expect(queryByDisplayValue("test_01")).toBeNull();
+});

--- a/src/__tests__/byDisplayValue.test.js
+++ b/src/__tests__/byDisplayValue.test.js
@@ -103,7 +103,7 @@ test('findBy queries work asynchronously', async () => {
 
 test('all queries should respect accessibility', async () => {
   const OtherComp = () => (
-    <View >
+    <View>
       <View>
         <TextInput value="test_01" />
       </View>
@@ -115,7 +115,7 @@ test('all queries should respect accessibility', async () => {
   const Comp = () => (
     <View>
       <OtherComp importantForAccessibility="no-hide-descendants" />
-      <OtherComp style={{display: "none"}} />
+      <OtherComp style={{ display: 'none' }} />
       <OtherComp />
       <View>
         <TextInput value="test_02" />
@@ -135,30 +135,30 @@ test('all queries should respect accessibility', async () => {
     queryByDisplayValue,
   } = render(<Comp />, { respectAccessibility: true });
 
-  await expect(getAllByDisplayValue("test_02")).toHaveLength(2);
+  await expect(getAllByDisplayValue('test_02')).toHaveLength(2);
   await expect(() => getAllByDisplayValue('test_01')).toThrow(
     'Unable to find an element with displayValue: test_01'
   );
-  await expect(() => getByDisplayValue("test_02")).toThrow(
-    "Found multiple elements with display value: test_02 "
+  await expect(() => getByDisplayValue('test_02')).toThrow(
+    'Found multiple elements with display value: test_02 '
   );
   await expect(() => getByDisplayValue('test_01')).toThrow(
     'Unable to find an element with displayValue: test_01'
   );
   await expect(queryAllByDisplayValue('test_01')).toHaveLength(0);
-  await expect(queryAllByDisplayValue("test_02")).toHaveLength(2);
+  await expect(queryAllByDisplayValue('test_02')).toHaveLength(2);
   await expect(queryByDisplayValue('test_01')).toBeNull();
-  await expect(() => queryByDisplayValue("test_02")).toThrow(
-    "Found multiple elements with display value: test_02 "
+  await expect(() => queryByDisplayValue('test_02')).toThrow(
+    'Found multiple elements with display value: test_02 '
   );
   await expect(findAllByDisplayValue('test_01')).rejects.toEqual(
-    new Error("Unable to find an element with displayValue: test_01")
+    new Error('Unable to find an element with displayValue: test_01')
   );
   await expect(findAllByDisplayValue('test_02')).resolves.toHaveLength(2);
   await expect(findByDisplayValue('test_01')).rejects.toEqual(
-    new Error("Unable to find an element with displayValue: test_01")
+    new Error('Unable to find an element with displayValue: test_01')
   );
   await expect(findByDisplayValue('test_02')).rejects.toEqual(
-    new Error("Found multiple elements with display value: test_02 ")
+    new Error('Found multiple elements with display value: test_02 ')
   );
 });

--- a/src/__tests__/byPlaceholderText.test.js
+++ b/src/__tests__/byPlaceholderText.test.js
@@ -67,13 +67,16 @@ test('queries should respect accessibility', async () => {
       <View>
         <TextInput placeholder="test_01" />
       </View>
+      <View accessibilityViewIsModal>
+        <TextInput placeholder="test_02" />
+      </View>
     </View>
   );
   const Comp = () => (
     <View>
       <OtherComp importantForAccessibility="no-hide-descendants" />
       <OtherComp style={{display: "none"}} />
-      <TextInput placeholder="test_02" />
+      <OtherComp />
       <View>
         <TextInput placeholder="test_02" />
       </View>

--- a/src/__tests__/byPlaceholderText.test.js
+++ b/src/__tests__/byPlaceholderText.test.js
@@ -77,7 +77,7 @@ test("queries should respect accessibility", async () => {
     queryAllByPlaceholderText,
     queryByPlaceholderText
   } = render(<Comp />, {
-    respectAccessibilityProps: true,
+    respectAccessibility: true,
   });
 
   await expect(findAllByPlaceholderText("hidden")).rejects.toBeTruthy();

--- a/src/__tests__/byPlaceholderText.test.js
+++ b/src/__tests__/byPlaceholderText.test.js
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { View, TextInput } from 'react-native';
 import { render } from '..';
-import { queryAllByDisplayValue } from '../helpers/byDisplayValue';
 
 const PLACEHOLDER_FRESHNESS = 'Add custom freshness';
 const PLACEHOLDER_CHEF = 'Who inspected freshness?';
@@ -63,7 +62,7 @@ test('getAllByPlaceholderText, queryAllByPlaceholderText', () => {
 
 test('queries should respect accessibility', async () => {
   const OtherComp = () => (
-    <View >
+    <View>
       <View>
         <TextInput placeholder="test_01" />
       </View>
@@ -75,7 +74,7 @@ test('queries should respect accessibility', async () => {
   const Comp = () => (
     <View>
       <OtherComp importantForAccessibility="no-hide-descendants" />
-      <OtherComp style={{display: "none"}} />
+      <OtherComp style={{ display: 'none' }} />
       <OtherComp />
       <View>
         <TextInput placeholder="test_02" />
@@ -100,18 +99,18 @@ test('queries should respect accessibility', async () => {
   await expect(() => getAllByPlaceholderText('test_01')).toThrow(
     'Unable to find an element with placeholder: test_01'
   );
-  await expect(getAllByPlaceholderText("test_02")).toHaveLength(2);
+  await expect(getAllByPlaceholderText('test_02')).toHaveLength(2);
   await expect(() => getByPlaceholderText('test_01')).toThrow(
     'Unable to find an element with placeholder: test_01'
   );
-  await expect(() => getByPlaceholderText("test_02")).toThrow(
-    "Found multiple elements with placeholder: test_02 "
-  )
+  await expect(() => getByPlaceholderText('test_02')).toThrow(
+    'Found multiple elements with placeholder: test_02 '
+  );
   await expect(queryAllByPlaceholderText('test_01')).toHaveLength(0);
   await expect(queryAllByPlaceholderText('test_02')).toHaveLength(2);
   await expect(queryByPlaceholderText('test_01')).toBeNull();
   await expect(() => queryByPlaceholderText('test_02')).toThrow(
-    "Found multiple elements with placeholder: test_02 "
+    'Found multiple elements with placeholder: test_02 '
   );
   await expect(findAllByPlaceholderText('test_01')).rejects.toEqual(
     new Error('Unable to find an element with placeholder: test_01')
@@ -121,6 +120,6 @@ test('queries should respect accessibility', async () => {
     new Error('Unable to find an element with placeholder: test_01')
   );
   await expect(findByPlaceholderText('test_02')).rejects.toEqual(
-    new Error("Found multiple elements with placeholder: test_02 ")
+    new Error('Found multiple elements with placeholder: test_02 ')
   );
 });

--- a/src/__tests__/byPlaceholderText.test.js
+++ b/src/__tests__/byPlaceholderText.test.js
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { View, TextInput } from 'react-native';
 import { render } from '..';
+import { queryAllByDisplayValue } from '../helpers/byDisplayValue';
 
 const PLACEHOLDER_FRESHNESS = 'Add custom freshness';
 const PLACEHOLDER_CHEF = 'Who inspected freshness?';
@@ -61,10 +62,22 @@ test('getAllByPlaceholderText, queryAllByPlaceholderText', () => {
 });
 
 test('queries should respect accessibility', async () => {
+  const Input = () => (
+    <View >
+      <View>
+        <TextInput placeholder="test_01" />
+      </View>
+    </View>
+  );
   const Comp = () => (
     <View>
-      <View accessibilityElementsHidden>
-        <TextInput placeholder="hidden" value={INPUT_FRESHNESS} />
+      <Input accessibilityElementsHidden />
+      <TextInput placeholder="test_02" />
+      <View>
+        <TextInput placeholder="test_02" />
+      </View>
+      <View>
+        <TextInput accessibilityElementsHidden placeholder="test_01" />
       </View>
     </View>
   );
@@ -80,14 +93,30 @@ test('queries should respect accessibility', async () => {
     respectAccessibility: true,
   });
 
-  await expect(findAllByPlaceholderText('hidden')).rejects.toBeTruthy();
-  await expect(findByPlaceholderText('hidden')).rejects.toBeTruthy();
-  await expect(() => getAllByPlaceholderText('hidden')).toThrow(
-    'Unable to find an element with placeholder: hidden'
+  await expect(() => getAllByPlaceholderText('test_01')).toThrow(
+    'Unable to find an element with placeholder: test_01'
   );
-  await expect(() => getByPlaceholderText('hidden')).toThrow(
-    'Unable to find an element with placeholder: hidden'
+  await expect(getAllByPlaceholderText("test_02")).toHaveLength(2);
+  await expect(() => getByPlaceholderText('test_01')).toThrow(
+    'Unable to find an element with placeholder: test_01'
   );
-  await expect(queryAllByPlaceholderText('hidden')).toHaveLength(0);
-  await expect(queryByPlaceholderText('hidden')).toBeNull();
+  await expect(() => getByPlaceholderText("test_02")).toThrow(
+    "Found multiple elements with placeholder: test_02 "
+  )
+  await expect(queryAllByPlaceholderText('test_01')).toHaveLength(0);
+  await expect(queryAllByPlaceholderText('test_02')).toHaveLength(2);
+  await expect(queryByPlaceholderText('test_01')).toBeNull();
+  await expect(() => queryByPlaceholderText('test_02')).toThrow(
+    "Found multiple elements with placeholder: test_02 "
+  );
+  await expect(findAllByPlaceholderText('test_01')).rejects.toEqual(
+    new Error('Unable to find an element with placeholder: test_01')
+  );
+  await expect(findAllByPlaceholderText('test_02')).resolves.toHaveLength(2);
+  await expect(findByPlaceholderText('test_01')).rejects.toEqual(
+    new Error('Unable to find an element with placeholder: test_01')
+  );
+  await expect(findByPlaceholderText('test_02')).rejects.toEqual(
+    new Error("Found multiple elements with placeholder: test_02 ")
+  );
 });

--- a/src/__tests__/byPlaceholderText.test.js
+++ b/src/__tests__/byPlaceholderText.test.js
@@ -60,7 +60,7 @@ test('getAllByPlaceholderText, queryAllByPlaceholderText', () => {
   expect(queryAllByPlaceholderText('no placeholder')).toHaveLength(0);
 });
 
-test("queries should respect accessibility", async () => {
+test('queries should respect accessibility', async () => {
   const Comp = () => (
     <View>
       <View accessibilityElementsHidden>
@@ -69,25 +69,25 @@ test("queries should respect accessibility", async () => {
     </View>
   );
 
-  const { 
+  const {
     findAllByPlaceholderText,
     findByPlaceholderText,
     getAllByPlaceholderText,
     getByPlaceholderText,
     queryAllByPlaceholderText,
-    queryByPlaceholderText
+    queryByPlaceholderText,
   } = render(<Comp />, {
     respectAccessibility: true,
   });
 
-  await expect(findAllByPlaceholderText("hidden")).rejects.toBeTruthy();
-  await expect(findByPlaceholderText("hidden")).rejects.toBeTruthy();
-  await expect(() => getAllByPlaceholderText("hidden")).toThrow(
-    "Unable to find an element with placeholder: hidden"
+  await expect(findAllByPlaceholderText('hidden')).rejects.toBeTruthy();
+  await expect(findByPlaceholderText('hidden')).rejects.toBeTruthy();
+  await expect(() => getAllByPlaceholderText('hidden')).toThrow(
+    'Unable to find an element with placeholder: hidden'
   );
-  await expect(() => getByPlaceholderText("hidden")).toThrow(
-    "Unable to find an element with placeholder: hidden"
+  await expect(() => getByPlaceholderText('hidden')).toThrow(
+    'Unable to find an element with placeholder: hidden'
   );
-  await expect(queryAllByPlaceholderText("hidden")).toHaveLength(0);
-  await expect(queryByPlaceholderText("hidden")).toBeNull();
+  await expect(queryAllByPlaceholderText('hidden')).toHaveLength(0);
+  await expect(queryByPlaceholderText('hidden')).toBeNull();
 });

--- a/src/__tests__/byPlaceholderText.test.js
+++ b/src/__tests__/byPlaceholderText.test.js
@@ -72,6 +72,7 @@ test('queries should respect accessibility', async () => {
   const Comp = () => (
     <View>
       <OtherComp importantForAccessibility="no-hide-descendants" />
+      <OtherComp style={{display: "none"}} />
       <TextInput placeholder="test_02" />
       <View>
         <TextInput placeholder="test_02" />

--- a/src/__tests__/byPlaceholderText.test.js
+++ b/src/__tests__/byPlaceholderText.test.js
@@ -62,7 +62,7 @@ test('getAllByPlaceholderText, queryAllByPlaceholderText', () => {
 });
 
 test('queries should respect accessibility', async () => {
-  const Input = () => (
+  const OtherComp = () => (
     <View >
       <View>
         <TextInput placeholder="test_01" />
@@ -71,7 +71,7 @@ test('queries should respect accessibility', async () => {
   );
   const Comp = () => (
     <View>
-      <Input accessibilityElementsHidden />
+      <OtherComp importantForAccessibility="no-hide-descendants" />
       <TextInput placeholder="test_02" />
       <View>
         <TextInput placeholder="test_02" />

--- a/src/__tests__/byPlaceholderText.test.js
+++ b/src/__tests__/byPlaceholderText.test.js
@@ -59,3 +59,35 @@ test('getAllByPlaceholderText, queryAllByPlaceholderText', () => {
   expect(queryAllByPlaceholderText(/fresh/i)).toEqual(inputs);
   expect(queryAllByPlaceholderText('no placeholder')).toHaveLength(0);
 });
+
+test("queries should respect accessibility", async () => {
+  const Comp = () => (
+    <View>
+      <View accessibilityElementsHidden>
+        <TextInput placeholder="hidden" value={INPUT_FRESHNESS} />
+      </View>
+    </View>
+  );
+
+  const { 
+    findAllByPlaceholderText,
+    findByPlaceholderText,
+    getAllByPlaceholderText,
+    getByPlaceholderText,
+    queryAllByPlaceholderText,
+    queryByPlaceholderText
+  } = render(<Comp />, {
+    respectAccessibilityProps: true,
+  });
+
+  await expect(findAllByPlaceholderText("hidden")).rejects.toBeTruthy();
+  await expect(findByPlaceholderText("hidden")).rejects.toBeTruthy();
+  await expect(() => getAllByPlaceholderText("hidden")).toThrow(
+    "Unable to find an element with placeholder: hidden"
+  );
+  await expect(() => getByPlaceholderText("hidden")).toThrow(
+    "Unable to find an element with placeholder: hidden"
+  );
+  await expect(queryAllByPlaceholderText("hidden")).toHaveLength(0);
+  await expect(queryByPlaceholderText("hidden")).toBeNull();
+});

--- a/src/__tests__/byTestId.test.js
+++ b/src/__tests__/byTestId.test.js
@@ -140,13 +140,16 @@ test('queries should respect accessibility', async () => {
       <View>
         <TextInput testID="test_01" />
       </View>
+      <View accessibilityViewIsModal>
+        <TextInput testID="test_02" />
+      </View>
     </View>
   );
   const Comp = () => (
     <View>
       <OtherComp importantForAccessibility="no-hide-descendants" />
       <OtherComp style={{display: "none"}} />
-      <TextInput testID="test_02" />
+      <OtherComp />
       <View>
         <TextInput testID="test_02" />
       </View>

--- a/src/__tests__/byTestId.test.js
+++ b/src/__tests__/byTestId.test.js
@@ -152,7 +152,7 @@ test("queries should respect accessibility", async () => {
     queryAllByTestId,
     queryByTestId
   } = render(<Comp />, {
-    respectAccessibilityProps: true,
+    respectAccessibility: true,
   });
 
   await expect(findAllByTestId("test")).rejects.toBeTruthy();

--- a/src/__tests__/byTestId.test.js
+++ b/src/__tests__/byTestId.test.js
@@ -133,3 +133,36 @@ test('findByTestId and findAllByTestId work asynchronously', async () => {
   await expect(findByTestId('aTestId')).resolves.toBeTruthy();
   await expect(findAllByTestId('aTestId')).resolves.toHaveLength(1);
 }, 20000);
+
+test("queries should respect accessibility", async () => {
+  const Comp = () => (
+    <View>
+      <View accessibilityElementsHidden>
+        <Text testID="test">hello world</Text>
+      </View>
+      <Text>hello space</Text>
+    </View>
+  );
+
+  const { 
+    findAllByTestId,
+    findByTestId,
+    getAllByTestId,
+    getByTestId,
+    queryAllByTestId,
+    queryByTestId
+  } = render(<Comp />, {
+    respectAccessibilityProps: true,
+  });
+
+  await expect(findAllByTestId("test")).rejects.toBeTruthy();
+  await expect(findByTestId("test")).rejects.toBeTruthy();
+  await expect(() => getAllByTestId("test")).toThrow(
+    "Unable to find an element with testID: test"
+  );
+  await expect(() => getByTestId("test")).toThrow(
+    "Unable to find an element with testID: test"
+  );
+  await expect(queryAllByTestId("test")).toHaveLength(0);
+  await expect(queryByTestId("test")).toBeNull();
+});

--- a/src/__tests__/byTestId.test.js
+++ b/src/__tests__/byTestId.test.js
@@ -134,7 +134,7 @@ test('findByTestId and findAllByTestId work asynchronously', async () => {
   await expect(findAllByTestId('aTestId')).resolves.toHaveLength(1);
 }, 20000);
 
-test("queries should respect accessibility", async () => {
+test('queries should respect accessibility', async () => {
   const Comp = () => (
     <View>
       <View accessibilityElementsHidden>
@@ -144,25 +144,25 @@ test("queries should respect accessibility", async () => {
     </View>
   );
 
-  const { 
+  const {
     findAllByTestId,
     findByTestId,
     getAllByTestId,
     getByTestId,
     queryAllByTestId,
-    queryByTestId
+    queryByTestId,
   } = render(<Comp />, {
     respectAccessibility: true,
   });
 
-  await expect(findAllByTestId("test")).rejects.toBeTruthy();
-  await expect(findByTestId("test")).rejects.toBeTruthy();
-  await expect(() => getAllByTestId("test")).toThrow(
-    "Unable to find an element with testID: test"
+  await expect(findAllByTestId('test')).rejects.toBeTruthy();
+  await expect(findByTestId('test')).rejects.toBeTruthy();
+  await expect(() => getAllByTestId('test')).toThrow(
+    'Unable to find an element with testID: test'
   );
-  await expect(() => getByTestId("test")).toThrow(
-    "Unable to find an element with testID: test"
+  await expect(() => getByTestId('test')).toThrow(
+    'Unable to find an element with testID: test'
   );
-  await expect(queryAllByTestId("test")).toHaveLength(0);
-  await expect(queryByTestId("test")).toBeNull();
+  await expect(queryAllByTestId('test')).toHaveLength(0);
+  await expect(queryByTestId('test')).toBeNull();
 });

--- a/src/__tests__/byTestId.test.js
+++ b/src/__tests__/byTestId.test.js
@@ -136,7 +136,7 @@ test('findByTestId and findAllByTestId work asynchronously', async () => {
 
 test('queries should respect accessibility', async () => {
   const OtherComp = () => (
-    <View >
+    <View>
       <View>
         <TextInput testID="test_01" />
       </View>
@@ -148,7 +148,7 @@ test('queries should respect accessibility', async () => {
   const Comp = () => (
     <View>
       <OtherComp importantForAccessibility="no-hide-descendants" />
-      <OtherComp style={{display: "none"}} />
+      <OtherComp style={{ display: 'none' }} />
       <OtherComp />
       <View>
         <TextInput testID="test_02" />
@@ -178,13 +178,13 @@ test('queries should respect accessibility', async () => {
     'Unable to find an element with testID: test_01'
   );
   await expect(() => getByTestId('test_02')).toThrow(
-    "Found multiple elements with testID: test_02"
-  )
+    'Found multiple elements with testID: test_02'
+  );
   await expect(queryAllByTestId('test_01')).toHaveLength(0);
   await expect(queryAllByTestId('test_02')).toHaveLength(2);
   await expect(queryByTestId('test_01')).toBeNull();
   await expect(() => queryByTestId('test_02')).toThrow(
-    "Found multiple elements with testID: test_02"
+    'Found multiple elements with testID: test_02'
   );
   await expect(findAllByTestId('test_01')).rejects.toEqual(
     new Error('Unable to find an element with testID: test_01')
@@ -194,6 +194,6 @@ test('queries should respect accessibility', async () => {
     new Error('Unable to find an element with testID: test_01')
   );
   await expect(findByTestId('test_02')).rejects.toEqual(
-    new Error("Found multiple elements with testID: test_02")
+    new Error('Found multiple elements with testID: test_02')
   );
 });

--- a/src/__tests__/byTestId.test.js
+++ b/src/__tests__/byTestId.test.js
@@ -135,12 +135,23 @@ test('findByTestId and findAllByTestId work asynchronously', async () => {
 }, 20000);
 
 test('queries should respect accessibility', async () => {
+  const Input = () => (
+    <View >
+      <View>
+        <TextInput testID="test_01" />
+      </View>
+    </View>
+  );
   const Comp = () => (
     <View>
-      <View accessibilityElementsHidden>
-        <Text testID="test">hello world</Text>
+      <Input accessibilityElementsHidden />
+      <TextInput testID="test_02" />
+      <View>
+        <TextInput testID="test_02" />
       </View>
-      <Text>hello space</Text>
+      <View>
+        <TextInput accessibilityElementsHidden testID="test_01" />
+      </View>
     </View>
   );
 
@@ -155,14 +166,30 @@ test('queries should respect accessibility', async () => {
     respectAccessibility: true,
   });
 
-  await expect(findAllByTestId('test')).rejects.toBeTruthy();
-  await expect(findByTestId('test')).rejects.toBeTruthy();
-  await expect(() => getAllByTestId('test')).toThrow(
+  await expect(() => getAllByTestId('test_01')).toThrow(
     'Unable to find an element with testID: test'
   );
-  await expect(() => getByTestId('test')).toThrow(
-    'Unable to find an element with testID: test'
+  await expect(getAllByTestId('test_02')).toHaveLength(2);
+  await expect(() => getByTestId('test_01')).toThrow(
+    'Unable to find an element with testID: test_01'
   );
-  await expect(queryAllByTestId('test')).toHaveLength(0);
-  await expect(queryByTestId('test')).toBeNull();
+  await expect(() => getByTestId('test_02')).toThrow(
+    "Found multiple elements with testID: test_02"
+  )
+  await expect(queryAllByTestId('test_01')).toHaveLength(0);
+  await expect(queryAllByTestId('test_02')).toHaveLength(2);
+  await expect(queryByTestId('test_01')).toBeNull();
+  await expect(() => queryByTestId('test_02')).toThrow(
+    "Found multiple elements with testID: test_02"
+  );
+  await expect(findAllByTestId('test_01')).rejects.toEqual(
+    new Error('Unable to find an element with testID: test_01')
+  );
+  await expect(findAllByTestId('test_02')).resolves.toHaveLength(2);
+  await expect(findByTestId('test_01')).rejects.toEqual(
+    new Error('Unable to find an element with testID: test_01')
+  );
+  await expect(findByTestId('test_02')).rejects.toEqual(
+    new Error("Found multiple elements with testID: test_02")
+  );
 });

--- a/src/__tests__/byTestId.test.js
+++ b/src/__tests__/byTestId.test.js
@@ -135,7 +135,7 @@ test('findByTestId and findAllByTestId work asynchronously', async () => {
 }, 20000);
 
 test('queries should respect accessibility', async () => {
-  const Input = () => (
+  const OtherComp = () => (
     <View >
       <View>
         <TextInput testID="test_01" />
@@ -144,7 +144,7 @@ test('queries should respect accessibility', async () => {
   );
   const Comp = () => (
     <View>
-      <Input accessibilityElementsHidden />
+      <OtherComp importantForAccessibility="no-hide-descendants" />
       <TextInput testID="test_02" />
       <View>
         <TextInput testID="test_02" />

--- a/src/__tests__/byTestId.test.js
+++ b/src/__tests__/byTestId.test.js
@@ -145,6 +145,7 @@ test('queries should respect accessibility', async () => {
   const Comp = () => (
     <View>
       <OtherComp importantForAccessibility="no-hide-descendants" />
+      <OtherComp style={{display: "none"}} />
       <TextInput testID="test_02" />
       <View>
         <TextInput testID="test_02" />

--- a/src/__tests__/byText.test.js
+++ b/src/__tests__/byText.test.js
@@ -103,7 +103,7 @@ test('queries should respect accessibility', async () => {
     queryAllByText,
     queryByText
   } = render(<Comp />, {
-    respectAccessibilityProps: true,
+    respectAccessibility: true,
   });
 
   await expect(findAllByText("hello world")).rejects.toBeTruthy();
@@ -128,7 +128,7 @@ test('queryAllByText returns an empty array if respectAccessibilityProps is true
     </View>
   );
   const { queryAllByText } = render(<Comp />, {
-    respectAccessibilityProps: true,
+    respectAccessibility: true,
   });
 
   expect(queryAllByText(/hello world/i)).toHaveLength(0);
@@ -144,7 +144,7 @@ test('getAllByText throws if respectAccessibilityProps is true', () => {
     </View>
   );
   const { getAllByText } = render(<Comp />, {
-    respectAccessibilityProps: true,
+    respectAccessibility: true,
   });
 
   expect(() => getAllByText(/hello world/i)).toThrow(

--- a/src/__tests__/byText.test.js
+++ b/src/__tests__/byText.test.js
@@ -91,15 +91,17 @@ test('queries should respect accessibility', async () => {
       <View>
         <Text>test_01</Text>
       </View>
+      <View accessibilityViewIsModal>
+        <Text>test_02</Text>
+      </View>
     </View>
   );
   const Comp = () => (
     <View>
       <OtherComp importantForAccessibility="no-hide-descendants" />
+      <OtherComp style={{display: "none"}} />
+      <OtherComp />
       <Text>test_02</Text>
-      <View>
-        <Text>test_02</Text>
-      </View>
       <View accessibilityElementsHidden>
         <Text>test_01</Text>
       </View>

--- a/src/__tests__/byText.test.js
+++ b/src/__tests__/byText.test.js
@@ -95,27 +95,27 @@ test('queries should respect accessibility', async () => {
     </View>
   );
 
-  const { 
+  const {
     findAllByText,
     findByText,
     getAllByText,
     getByText,
     queryAllByText,
-    queryByText
+    queryByText,
   } = render(<Comp />, {
     respectAccessibility: true,
   });
 
-  await expect(findAllByText("hello world")).rejects.toBeTruthy();
-  await expect(findByText("hello world")).rejects.toBeTruthy();
-  await expect(() => getAllByText("hello world")).toThrow(
-    "Unable to find an element with text: hello world"
+  await expect(findAllByText('hello world')).rejects.toBeTruthy();
+  await expect(findByText('hello world')).rejects.toBeTruthy();
+  await expect(() => getAllByText('hello world')).toThrow(
+    'Unable to find an element with text: hello world'
   );
-  await expect(() => getByText("hello world")).toThrow(
-    "Unable to find an element with text: hello world"
+  await expect(() => getByText('hello world')).toThrow(
+    'Unable to find an element with text: hello world'
   );
-  await expect(queryAllByText("hello world")).toHaveLength(0);
-  await expect(queryByText("hello world")).toBeNull();
+  await expect(queryAllByText('hello world')).toHaveLength(0);
+  await expect(queryByText('hello world')).toBeNull();
 });
 
 test('queryAllByText returns an empty array if respectAccessibilityProps is true', () => {

--- a/src/__tests__/byText.test.js
+++ b/src/__tests__/byText.test.js
@@ -85,6 +85,73 @@ test('getAllByText, queryAllByText', () => {
   expect(queryAllByText('InExistent')).toHaveLength(0);
 });
 
+test('queries should respect accessibility', async () => {
+  const Comp = () => (
+    <View>
+      <View accessibilityElementsHidden>
+        <Text>hello world</Text>
+      </View>
+      <Text>hello space</Text>
+    </View>
+  );
+
+  const { 
+    findAllByText,
+    findByText,
+    getAllByText,
+    getByText,
+    queryAllByText,
+    queryByText
+  } = render(<Comp />, {
+    respectAccessibilityProps: true,
+  });
+
+  await expect(findAllByText("hello world")).rejects.toBeTruthy();
+  await expect(findByText("hello world")).rejects.toBeTruthy();
+  await expect(() => getAllByText("hello world")).toThrow(
+    "Unable to find an element with text: hello world"
+  );
+  await expect(() => getByText("hello world")).toThrow(
+    "Unable to find an element with text: hello world"
+  );
+  await expect(queryAllByText("hello world")).toHaveLength(0);
+  await expect(queryByText("hello world")).toBeNull();
+});
+
+test('queryAllByText returns an empty array if respectAccessibilityProps is true', () => {
+  const Comp = () => (
+    <View>
+      <View accessibilityElementsHidden>
+        <Text>hello world</Text>
+      </View>
+      <Text>hello space</Text>
+    </View>
+  );
+  const { queryAllByText } = render(<Comp />, {
+    respectAccessibilityProps: true,
+  });
+
+  expect(queryAllByText(/hello world/i)).toHaveLength(0);
+});
+
+test('getAllByText throws if respectAccessibilityProps is true', () => {
+  const Comp = () => (
+    <View>
+      <View accessibilityElementsHidden>
+        <Text>hello world</Text>
+      </View>
+      <Text>hello space</Text>
+    </View>
+  );
+  const { getAllByText } = render(<Comp />, {
+    respectAccessibilityProps: true,
+  });
+
+  expect(() => getAllByText(/hello world/i)).toThrow(
+    'Unable to find an element with text: /hello world/i'
+  );
+});
+
 test('findByText queries work asynchronously', async () => {
   const options = { timeout: 10 }; // Short timeout so that this test runs quickly
   const { rerender, findByText, findAllByText } = render(<View />);

--- a/src/__tests__/byText.test.js
+++ b/src/__tests__/byText.test.js
@@ -86,7 +86,7 @@ test('getAllByText, queryAllByText', () => {
 });
 
 test('queries should respect accessibility', async () => {
-  const Input = () => (
+  const OtherComp = () => (
     <View >
       <View>
         <Text>test_01</Text>
@@ -95,7 +95,7 @@ test('queries should respect accessibility', async () => {
   );
   const Comp = () => (
     <View>
-      <Input accessibilityElementsHidden />
+      <OtherComp importantForAccessibility="no-hide-descendants" />
       <Text>test_02</Text>
       <View>
         <Text>test_02</Text>

--- a/src/__tests__/byText.test.js
+++ b/src/__tests__/byText.test.js
@@ -86,12 +86,23 @@ test('getAllByText, queryAllByText', () => {
 });
 
 test('queries should respect accessibility', async () => {
+  const Input = () => (
+    <View >
+      <View>
+        <Text>test_01</Text>
+      </View>
+    </View>
+  );
   const Comp = () => (
     <View>
-      <View accessibilityElementsHidden>
-        <Text>hello world</Text>
+      <Input accessibilityElementsHidden />
+      <Text>test_02</Text>
+      <View>
+        <Text>test_02</Text>
       </View>
-      <Text>hello space</Text>
+      <View accessibilityElementsHidden>
+        <Text>test_01</Text>
+      </View>
     </View>
   );
 
@@ -106,49 +117,31 @@ test('queries should respect accessibility', async () => {
     respectAccessibility: true,
   });
 
-  await expect(findAllByText('hello world')).rejects.toBeTruthy();
-  await expect(findByText('hello world')).rejects.toBeTruthy();
-  await expect(() => getAllByText('hello world')).toThrow(
-    'Unable to find an element with text: hello world'
+  await expect(() => getAllByText('test_01')).toThrow(
+    'Unable to find an element with text: test_01'
   );
-  await expect(() => getByText('hello world')).toThrow(
-    'Unable to find an element with text: hello world'
+  await expect(getAllByText('test_02')).toHaveLength(2);
+  await expect(() => getByText('test_01')).toThrow(
+    'Unable to find an element with text: test_01'
   );
-  await expect(queryAllByText('hello world')).toHaveLength(0);
-  await expect(queryByText('hello world')).toBeNull();
-});
-
-test('queryAllByText returns an empty array if respectAccessibilityProps is true', () => {
-  const Comp = () => (
-    <View>
-      <View accessibilityElementsHidden>
-        <Text>hello world</Text>
-      </View>
-      <Text>hello space</Text>
-    </View>
+  await expect(() => getByText('test_02')).toThrow(
+    "Found multiple elements with text: test_02"
+  )
+  await expect(queryAllByText('test_01')).toHaveLength(0);
+  await expect(queryAllByText('test_02')).toHaveLength(2);
+  await expect(queryByText('test_01')).toBeNull();
+  await expect(() => queryByText('test_02')).toThrow(
+    "Found multiple elements with text: test_02"
+  )
+  await expect(findAllByText('test_01')).rejects.toEqual(
+    new Error('Unable to find an element with text: test_01')
   );
-  const { queryAllByText } = render(<Comp />, {
-    respectAccessibility: true,
-  });
-
-  expect(queryAllByText(/hello world/i)).toHaveLength(0);
-});
-
-test('getAllByText throws if respectAccessibilityProps is true', () => {
-  const Comp = () => (
-    <View>
-      <View accessibilityElementsHidden>
-        <Text>hello world</Text>
-      </View>
-      <Text>hello space</Text>
-    </View>
+  await expect(findAllByText('test_02')).resolves.toHaveLength(2);
+  await expect(findByText('test_01')).rejects.toEqual(
+    new Error('Unable to find an element with text: test_01')
   );
-  const { getAllByText } = render(<Comp />, {
-    respectAccessibility: true,
-  });
-
-  expect(() => getAllByText(/hello world/i)).toThrow(
-    'Unable to find an element with text: /hello world/i'
+  await expect(findByText('test_02')).rejects.toEqual(
+    new Error("Found multiple elements with text: test_02")
   );
 });
 

--- a/src/__tests__/byText.test.js
+++ b/src/__tests__/byText.test.js
@@ -87,7 +87,7 @@ test('getAllByText, queryAllByText', () => {
 
 test('queries should respect accessibility', async () => {
   const OtherComp = () => (
-    <View >
+    <View>
       <View>
         <Text>test_01</Text>
       </View>
@@ -99,7 +99,7 @@ test('queries should respect accessibility', async () => {
   const Comp = () => (
     <View>
       <OtherComp importantForAccessibility="no-hide-descendants" />
-      <OtherComp style={{display: "none"}} />
+      <OtherComp style={{ display: 'none' }} />
       <OtherComp />
       <Text>test_02</Text>
       <View accessibilityElementsHidden>
@@ -127,14 +127,14 @@ test('queries should respect accessibility', async () => {
     'Unable to find an element with text: test_01'
   );
   await expect(() => getByText('test_02')).toThrow(
-    "Found multiple elements with text: test_02"
-  )
+    'Found multiple elements with text: test_02'
+  );
   await expect(queryAllByText('test_01')).toHaveLength(0);
   await expect(queryAllByText('test_02')).toHaveLength(2);
   await expect(queryByText('test_01')).toBeNull();
   await expect(() => queryByText('test_02')).toThrow(
-    "Found multiple elements with text: test_02"
-  )
+    'Found multiple elements with text: test_02'
+  );
   await expect(findAllByText('test_01')).rejects.toEqual(
     new Error('Unable to find an element with text: test_01')
   );
@@ -143,7 +143,7 @@ test('queries should respect accessibility', async () => {
     new Error('Unable to find an element with text: test_01')
   );
   await expect(findByText('test_02')).rejects.toEqual(
-    new Error("Found multiple elements with text: test_02")
+    new Error('Found multiple elements with text: test_02')
   );
 });
 

--- a/src/render.js
+++ b/src/render.js
@@ -116,21 +116,29 @@ function appendFindAllTrap(renderer: ReactTestRenderer) {
     get(target, prop) {
       const isFindAllProp = prop === 'findAll';
 
-      return isFindAllProp ? newFindAll(target) : Reflect.get(...arguments);
+      return isFindAllProp ? newFindAll(target) : target[prop];
     },
   });
 }
 
 function newFindAll(instance: ReactTestInstance) {
-  return (originalPredicate: (instance: ReactTestInstance) => boolean) => {
-    const elements = instance.findAll(originalPredicate);
+  return (predicate: (instance: ReactTestInstance) => boolean): ReactTestInstance[] => {
+    const elements = instance.findAll(predicate);
 
     return elements.filter(isReactTestElementVisibleToAccessibility);
   }
 }
 
-function isReactTestElementVisibleToAccessibility(instance: ReactTestInstance) {
-  const isElementVisible = !instance.props.accessibilityElementsHidden;
-  const isParentVisible = !instance.parent || isReactTestElementVisibleToAccessibility(instance.parent);
+function isReactTestElementVisibleToAccessibility(instance: ReactTestInstance): boolean {
+  const isElementVisible = 
+    !instance.props.accessibilityElementsHidden;
+    //&& instance.props.importantForAccessibility !== "no-hide-descendants";
+
+  if (!instance.parent) {
+    return isElementVisible;
+  }
+
+  const isParentVisible = isReactTestElementVisibleToAccessibility(instance.parent);
+
   return isParentVisible && isElementVisible;
 }

--- a/src/render.js
+++ b/src/render.js
@@ -151,7 +151,7 @@ function accessibilityHiddenIOS(instance: ReactTestInstance): boolean {
       .parent
       .children
       .some(c => (
-        typeof c !== "string" && 
+        c.props && 
         c.props.accessibilityViewIsModal && 
         !Object.is(c, instance)
       ));

--- a/src/render.js
+++ b/src/render.js
@@ -130,9 +130,10 @@ function newFindAll(instance: ReactTestInstance) {
 }
 
 function isReactTestElementVisibleToAccessibility(instance: ReactTestInstance): boolean {
-  const isElementVisible = 
-    !instance.props.accessibilityElementsHidden
-    && instance.props.importantForAccessibility !== "no-hide-descendants";
+  const isElementVisible =
+    !accessibilityHiddenIOS(instance) &&
+    !accessibilityHiddenAndroid(instance) &&
+    !hiddenByStyles(instance);
 
   if (!instance.parent) {
     return isElementVisible;
@@ -141,4 +142,27 @@ function isReactTestElementVisibleToAccessibility(instance: ReactTestInstance): 
   const isParentVisible = isReactTestElementVisibleToAccessibility(instance.parent);
 
   return isParentVisible && isElementVisible;
+}
+
+function accessibilityHiddenIOS(instance: ReactTestInstance): boolean {
+  const siblingHasAccessibilityViewIsModal =
+    instance.parent &&
+    instance
+      .parent
+      .children
+      .some(c => (
+        typeof c !== "string" && 
+        c.props.accessibilityViewIsModal && 
+        !Object.is(c, instance)
+      ));
+
+  return instance.props.accessibilityElementsHidden || siblingHasAccessibilityViewIsModal;
+}
+
+function accessibilityHiddenAndroid(instance: ReactTestInstance) {
+  return instance.props.importantForAccessibility === 'no-hide-descendants';
+}
+
+function hiddenByStyles(instance: ReactTestInstance) {
+  return instance.props.style && instance.props.style.display === "none";
 }

--- a/src/render.js
+++ b/src/render.js
@@ -13,7 +13,7 @@ import debugDeep from './helpers/debugDeep';
 type Options = {
   wrapper?: React.ComponentType<any>,
   createNodeMock?: (element: React.Element<any>) => any,
-  respectAccessibilityProps?: boolean,
+  respectAccessibility?: boolean,
 };
 type TestRendererOptions = {
   createNodeMock: (element: React.Element<any>) => any,
@@ -25,7 +25,7 @@ type TestRendererOptions = {
  */
 export default function render<T>(
   component: React.Element<T>,
-  { wrapper: Wrapper, createNodeMock, respectAccessibilityProps }: Options = {}
+  { wrapper: Wrapper, createNodeMock, respectAccessibility }: Options = {}
 ): {
   ...FindByAPI,
   ...QueryByAPI,
@@ -47,7 +47,7 @@ export default function render<T>(
     // respectAccessibilityProps
   );
   const update = updateWithAct(renderer, wrap);
-  const instance = respectAccessibilityProps
+  const instance = respectAccessibility
     ? appendFindAllTrap(renderer)
     : renderer.root;
   const unmount = () => {

--- a/src/render.js
+++ b/src/render.js
@@ -131,8 +131,8 @@ function newFindAll(instance: ReactTestInstance) {
 
 function isReactTestElementVisibleToAccessibility(instance: ReactTestInstance): boolean {
   const isElementVisible = 
-    !instance.props.accessibilityElementsHidden;
-    //&& instance.props.importantForAccessibility !== "no-hide-descendants";
+    !instance.props.accessibilityElementsHidden
+    && instance.props.importantForAccessibility !== "no-hide-descendants";
 
   if (!instance.parent) {
     return isElementVisible;

--- a/src/render.js
+++ b/src/render.js
@@ -43,11 +43,13 @@ export default function render<T>(
 
   const renderer = renderWithAct(
     wrap(component),
-    createNodeMock ? { createNodeMock } : undefined,
+    createNodeMock ? { createNodeMock } : undefined
     // respectAccessibilityProps
   );
   const update = updateWithAct(renderer, wrap);
-  const instance = respectAccessibilityProps ? appendFindAllTrap(renderer) : renderer.root;
+  const instance = respectAccessibilityProps
+    ? appendFindAllTrap(renderer)
+    : renderer.root;
   const unmount = () => {
     act(() => {
       renderer.unmount();
@@ -72,7 +74,7 @@ export default function render<T>(
 
 function renderWithAct(
   component: React.Element<any>,
-  options?: TestRendererOptions,
+  options?: TestRendererOptions
 ): ReactTestRenderer {
   let renderer: ReactTestRenderer;
 
@@ -113,9 +115,8 @@ function debug(
 function appendFindAllTrap(renderer: ReactTestRenderer) {
   return new Proxy(renderer.root, {
     get(target, prop) {
-      const isFindAllProp = prop === "findAll";
+      const isFindAllProp = prop === 'findAll';
       const newFindAll = (fn, node = target) => {
-
         if (node.props.accessibilityElementsHidden) {
           return [];
         }
@@ -129,9 +130,9 @@ function appendFindAllTrap(renderer: ReactTestRenderer) {
 
           return result.concat(newFindAll(fn, child));
         }, initial);
-      }
+      };
 
       return isFindAllProp ? newFindAll : Reflect.get(...arguments);
-    }
+    },
   });
 }

--- a/src/render.js
+++ b/src/render.js
@@ -122,14 +122,18 @@ function appendFindAllTrap(renderer: ReactTestRenderer) {
 }
 
 function newFindAll(instance: ReactTestInstance) {
-  return (predicate: (instance: ReactTestInstance) => boolean): ReactTestInstance[] => {
+  return (
+    predicate: (instance: ReactTestInstance) => boolean
+  ): ReactTestInstance[] => {
     const elements = instance.findAll(predicate);
 
     return elements.filter(isReactTestElementVisibleToAccessibility);
-  }
+  };
 }
 
-function isReactTestElementVisibleToAccessibility(instance: ReactTestInstance): boolean {
+function isReactTestElementVisibleToAccessibility(
+  instance: ReactTestInstance
+): boolean {
   const isElementVisible =
     !accessibilityHiddenIOS(instance) &&
     !accessibilityHiddenAndroid(instance) &&
@@ -139,7 +143,9 @@ function isReactTestElementVisibleToAccessibility(instance: ReactTestInstance): 
     return isElementVisible;
   }
 
-  const isParentVisible = isReactTestElementVisibleToAccessibility(instance.parent);
+  const isParentVisible = isReactTestElementVisibleToAccessibility(
+    instance.parent
+  );
 
   return isParentVisible && isElementVisible;
 }
@@ -147,16 +153,15 @@ function isReactTestElementVisibleToAccessibility(instance: ReactTestInstance): 
 function accessibilityHiddenIOS(instance: ReactTestInstance): boolean {
   const siblingHasAccessibilityViewIsModal =
     instance.parent &&
-    instance
-      .parent
-      .children
-      .some(c => (
-        c.props && 
-        c.props.accessibilityViewIsModal && 
-        !Object.is(c, instance)
-      ));
+    instance.parent.children.some(
+      (c) =>
+        c.props && c.props.accessibilityViewIsModal && !Object.is(c, instance)
+    );
 
-  return instance.props.accessibilityElementsHidden || siblingHasAccessibilityViewIsModal;
+  return (
+    instance.props.accessibilityElementsHidden ||
+    siblingHasAccessibilityViewIsModal
+  );
 }
 
 function accessibilityHiddenAndroid(instance: ReactTestInstance) {
@@ -164,5 +169,5 @@ function accessibilityHiddenAndroid(instance: ReactTestInstance) {
 }
 
 function hiddenByStyles(instance: ReactTestInstance) {
-  return instance.props.style && instance.props.style.display === "none";
+  return instance.props.style && instance.props.style.display === 'none';
 }

--- a/src/render.js
+++ b/src/render.js
@@ -44,7 +44,6 @@ export default function render<T>(
   const renderer = renderWithAct(
     wrap(component),
     createNodeMock ? { createNodeMock } : undefined
-    // respectAccessibilityProps
   );
   const update = updateWithAct(renderer, wrap);
   const instance = respectAccessibility

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -296,6 +296,7 @@ export interface Thenable {
 export interface RenderOptions {
   wrapper?: React.ComponentType<any>;
   createNodeMock?: (element: React.ReactElement<any>) => any;
+  respectAccessibility?: boolean;
 }
 
 type Debug = {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
This PR adds a new option to the render function called respectAccessibility.  When this property is true a new implementation of ReactTestInstance.findAll() is 
used.  This new findAll() is defined in render.js inside the function `appendFindAllTrap`.  This new findAll ignores sub trees that have a root node with a prop
`accessibilityElementsHidden: true`.  This solution is an attempt to mimic the first approach found in [@MattAgn 's list](https://github.com/callstack/react-native-testing-library/issues/659#issuecomment-830781869).

### Test plan
Tests added in `src/__tests__/byTestId.test.js`, `src/__tests__/byPlaceholderText.test.js`, and `src/__tests__/byDisplayValue.test.js`
- run `yarn test`
  - tests should pass

### Scope
- [x] Implement `findAll` trap
- [x] Add tests
- [ ] Add flow & typescript type definitions
- [ ] Update documentation