### PR TITLE
Update GettingStarted.md

### DIFF
--- a/website/docs/GettingStarted.md
+++ b/website/docs/GettingStarted.md
@@ -27,11 +27,25 @@ Open a Terminal in your project's folder and run:
 yarn add --dev @testing-library/react-native
 ```
 
+You'll also need jest to run the tests
+
+```sh
+yarn add --dev jest
+```
+
+
 #### Using `npm`
 
 ```sh
 npm install --save-dev @testing-library/react-native
 ```
+
+You'll also need jest to run the tests
+
+```sh
+npm install --save-dev jest
+```
+
 
 This library has a peerDependencies listing for `react-test-renderer` and, of course, `react`. Make sure to install them too!
 
@@ -100,3 +114,12 @@ test('form submits two answers', () => {
 ```
 
 You can find the source of `QuestionsBoard` component and this example [here](https://github.com/callstack/react-native-testing-library/blob/master/src/__tests__/questionsBoard.test.js).
+
+## Run your test
+
+Place the above test for example into a `/test` directory in the root of your project as `QuestionsBoard.test.js`.
+
+Run it with:
+```sh
+yarn jest
+```


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Updated Getting Started guide to include mentions of Jest, as Jest is required to run the tests but this was not obvious from Getting Started. This otherwise excellent guide is missing a crucial setup step.

### Test plan

See the current guide at [Getting Started](https://callstack.github.io/react-native-testing-library/docs/getting-started/) - it doesn't actually tell you how to get started to run a test. This otherwise excellent guide is missing a crucial setup step, and assumes prior knowledge on how to run tests.

Full setup should be documented like below IMO:

-------

#### Using `yarn`
```sh
yarn add --dev @testing-library/react-native
```

You'll also need jest to run the tests

```sh
yarn add --dev jest
```


#### Using `npm`

```sh
npm install --save-dev @testing-library/react-native
```

You'll also need jest to run the tests

```sh
npm install --save-dev jest
```
--------
And could we add a command at the end on how to actually run the tests for the un-ininitated like:
---------
..... find the source of `QuestionsBoard` component and this example [here](https://github.com/callstack/react-native-testing-library/blob/master/src/__tests__/questionsBoard.test.js).

## Run your test

Place the above test for example into a `/test` directory in the root of your project as `QuestionsBoard.test.js`.

Run it with:
```sh
yarn jest
```
