### PR TITLE
Forward extra data to press event

### DIFF
--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -91,13 +91,19 @@ describe('fireEvent', () => {
 test('fireEvent.press', () => {
   const onPressMock = jest.fn();
   const text = 'Fireevent press';
+  const eventData = {
+    nativeEvent: {
+      pageX: 20,
+      pageY: 30,
+    },
+  };
   const { getByText } = render(
     <OnPressComponent onPress={onPressMock} text={text} />
   );
 
-  fireEvent.press(getByText(text));
+  fireEvent.press(getByText(text), eventData);
 
-  expect(onPressMock).toHaveBeenCalled();
+  expect(onPressMock).toHaveBeenCalledWith(eventData);
 });
 
 test('fireEvent.scroll', () => {

--- a/src/fireEvent.js
+++ b/src/fireEvent.js
@@ -105,8 +105,8 @@ const invokeEvent = (
 const toEventHandlerName = (eventName: string) =>
   `on${eventName.charAt(0).toUpperCase()}${eventName.slice(1)}`;
 
-const pressHandler = (element: ReactTestInstance): void =>
-  invokeEvent(element, 'press', pressHandler);
+const pressHandler = (element: ReactTestInstance, ...data: Array<any>): void =>
+  invokeEvent(element, 'press', pressHandler, ...data);
 const changeTextHandler = (
   element: ReactTestInstance,
   ...data: Array<any>

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -321,7 +321,7 @@ export type FireEventFunction = (
 ) => any;
 
 export type FireEventAPI = FireEventFunction & {
-  press: (element: ReactTestInstance) => any;
+  press: (element: ReactTestInstance, ...data: Array<any>) => any;
   changeText: (element: ReactTestInstance, ...data: Array<any>) => any;
   scroll: (element: ReactTestInstance, ...data: Array<any>) => any;
 };

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -225,7 +225,7 @@ fireEvent[eventName](element: ReactTestInstance, ...data: Array<any>): void
 
 Convenience methods for common events like: `press`, `changeText`, `scroll`.
 
-### `fireEvent.press: (element: ReactTestInstance) => void`
+### `fireEvent.press: (element: ReactTestInstance, ...data: Array<any>) => void`
 
 Invokes `press` event handler on the element or parent element in the tree.
 
@@ -234,6 +234,12 @@ import { View, Text, TouchableOpacity } from 'react-native';
 import { render, fireEvent } from '@testing-library/react-native';
 
 const onPressMock = jest.fn();
+const eventData = {
+  nativeEvent: {
+    pageX: 20,
+    pageY: 30,
+  },
+};
 
 const { getByText } = render(
   <View>
@@ -243,8 +249,8 @@ const { getByText } = render(
   </View>
 );
 
-fireEvent.press(getByText('Press me'));
-expect(onPressMock).toHaveBeenCalled();
+fireEvent.press(getByText('Press me'), eventData);
+expect(onPressMock).toHaveBeenCalledWith(eventData);
 ```
 
 ### `fireEvent.changeText: (element: ReactTestInstance, ...data: Array<any>) => void`


### PR DESCRIPTION
### Summary

Currently the `onPress` callbacks are called with `undefined`. While I think there should probably be a default value being passed, let's at least align the API with `scroll` and `changeText`

### Test plan

The added tests show exactly what changes, if you pass extra parameters to `fireEvent.press`, they'll be forwarded to the `onPress` callback.
