### PR TITLE
doc: update minimum react-native version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npm install --save-dev @testing-library/react-native
 
 This library has a peerDependencies listing for `react-test-renderer` and, of course, `react`. Make sure to install them too!
 
-> In order to properly use helpers for async tests (`findBy` queries and `waitFor`) you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
+> In order to properly use helpers for async tests (`findBy` queries and `waitFor`) you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.61 (which comes with React >=16.9.0).
 
 ### Additional Jest matchers
 

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -363,7 +363,7 @@ test('waiting for an Banana to be ready', async () => {
 ```
 
 :::info
-In order to properly use `waitFor` you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
+In order to properly use `waitFor` you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.61 (which comes with React >=16.9.0).
 :::
 
 ## `waitForElementToBeRemoved`
@@ -399,7 +399,7 @@ This method expects that the element is initally present in the render tree and 
 You can use any of `getBy`, `getAllBy`, `queryBy` and `queryAllBy` queries for `expectation` parameter.
 
 :::info
-In order to properly use `waitForElementToBeRemoved` you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
+In order to properly use `waitForElementToBeRemoved` you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.61 (which comes with React >=16.9.0).
 :::
 
 ## `within`, `getQueriesForElement`

--- a/website/docs/GettingStarted.md
+++ b/website/docs/GettingStarted.md
@@ -36,7 +36,7 @@ npm install --save-dev @testing-library/react-native
 This library has a peerDependencies listing for `react-test-renderer` and, of course, `react`. Make sure to install them too!
 
 :::info
-In order to properly use helpers for async tests (`findBy` queries and `waitFor`) you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
+In order to properly use helpers for async tests (`findBy` queries and `waitFor`) you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.61 (which comes with React >=16.9.0).
 :::
 
 ### Additional Jest matchers

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -33,7 +33,7 @@ title: Queries
 `findAllBy` queries return a promise which resolves to an array when any matching elements are found. The promise is rejected if no elements match after a default timeout of 4500ms.
 
 :::info
-In order to properly use `findBy` and `findAllBy` queries you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.60 (which comes with React >=16.9.0).
+In order to properly use `findBy` and `findAllBy` queries you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.61 (which comes with React >=16.9.0).
 :::
 
 :::info


### PR DESCRIPTION
This PR resolves the issue https://github.com/callstack/react-native-testing-library/issues/668. Simply update minimum react-native version info to 0.61

![Screen Shot 2021-10-15 at 18 31 09](https://user-images.githubusercontent.com/40958989/137514072-f4ff501b-169e-4d8e-947e-42ab0b6bf210.png)



