### PR TITLE
fix: textinput's onChange to be called with fireEvent

### DIFF
--- a/src/__tests__/fireEvent.test.js
+++ b/src/__tests__/fireEvent.test.js
@@ -127,25 +127,84 @@ test('fireEvent.scroll', () => {
   expect(onScrollMock).toHaveBeenCalledWith(eventData);
 });
 
-test('fireEvent.changeText', () => {
-  const onChangeTextMock = jest.fn();
-  const CHANGE_TEXT = 'content';
+describe('fireEvent.changeText', () => {
+  test('fires the onChangeText and onChange listeners on TextInput', () => {
+    const onChangeTextMock = jest.fn();
+    const onChangeMock = jest.fn();
 
-  const { getByPlaceholderText } = render(
-    <View>
-      <TextInput
-        placeholder="Customer placeholder"
-        onChangeText={onChangeTextMock}
-      />
-    </View>
-  );
+    const CHANGE_TEXT = 'content';
 
-  fireEvent.changeText(
-    getByPlaceholderText('Customer placeholder'),
-    CHANGE_TEXT
-  );
+    const { getByPlaceholderText } = render(
+      <View>
+        <TextInput
+          placeholder="Customer placeholder"
+          onChangeText={onChangeTextMock}
+          onChange={onChangeMock}
+        />
+      </View>
+    );
 
-  expect(onChangeTextMock).toHaveBeenCalledWith(CHANGE_TEXT);
+    fireEvent.changeText(
+      getByPlaceholderText('Customer placeholder'),
+      CHANGE_TEXT
+    );
+
+    expect(onChangeTextMock).toHaveBeenCalledWith(CHANGE_TEXT);
+    expect(onChangeMock).toHaveBeenCalledWith({
+      nativeEvent: {
+        target: expect.any(React.Component),
+        text: CHANGE_TEXT,
+        eventCount: undefined,
+      },
+    });
+  });
+
+  test('should not fire on non-editable TextInput', () => {
+    const placeholder = 'Test placeholder';
+    const onChangeTextMock = jest.fn();
+    const onChangeMock = jest.fn();
+
+    const NEW_TEXT = 'New text';
+
+    const { getByPlaceholderText } = render(
+      <View>
+        <TextInput
+          editable={false}
+          placeholder={placeholder}
+          onChangeText={onChangeTextMock}
+          onChange={onChangeMock}
+        />
+      </View>
+    );
+
+    fireEvent.changeText(getByPlaceholderText(placeholder), NEW_TEXT);
+    expect(onChangeTextMock).not.toHaveBeenCalled();
+    expect(onChangeMock).not.toHaveBeenCalled();
+  });
+
+  test('should not fire on non-editable TextInput with nested Text', () => {
+    const placeholder = 'Test placeholder';
+    const onChangeTextMock = jest.fn();
+    const onChangeMock = jest.fn();
+    const NEW_TEXT = 'New text';
+
+    const { getByPlaceholderText } = render(
+      <View>
+        <TextInput
+          editable={false}
+          placeholder={placeholder}
+          onChangeText={onChangeTextMock}
+          onChange={onChangeMock}
+        >
+          <Text>Test text</Text>
+        </TextInput>
+      </View>
+    );
+
+    fireEvent.changeText(getByPlaceholderText(placeholder), NEW_TEXT);
+    expect(onChangeTextMock).not.toHaveBeenCalled();
+    expect(onChangeMock).not.toHaveBeenCalled();
+  });
 });
 
 test('custom component with custom event name', () => {
@@ -198,46 +257,6 @@ test('should not fire on disabled Pressable', () => {
 
   fireEvent.press(screen.getByText('Trigger'));
   expect(handlePress).not.toHaveBeenCalled();
-});
-
-test('should not fire on non-editable TextInput', () => {
-  const placeholder = 'Test placeholder';
-  const onChangeTextMock = jest.fn();
-  const NEW_TEXT = 'New text';
-
-  const { getByPlaceholderText } = render(
-    <View>
-      <TextInput
-        editable={false}
-        placeholder={placeholder}
-        onChangeText={onChangeTextMock}
-      />
-    </View>
-  );
-
-  fireEvent.changeText(getByPlaceholderText(placeholder), NEW_TEXT);
-  expect(onChangeTextMock).not.toHaveBeenCalled();
-});
-
-test('should not fire on non-editable TextInput with nested Text', () => {
-  const placeholder = 'Test placeholder';
-  const onChangeTextMock = jest.fn();
-  const NEW_TEXT = 'New text';
-
-  const { getByPlaceholderText } = render(
-    <View>
-      <TextInput
-        editable={false}
-        placeholder={placeholder}
-        onChangeText={onChangeTextMock}
-      >
-        <Text>Test text</Text>
-      </TextInput>
-    </View>
-  );
-
-  fireEvent.changeText(getByPlaceholderText(placeholder), NEW_TEXT);
-  expect(onChangeTextMock).not.toHaveBeenCalled();
 });
 
 test('should not fire on none pointerEvents View', () => {

--- a/src/fireEvent.js
+++ b/src/fireEvent.js
@@ -107,10 +107,18 @@ const toEventHandlerName = (eventName: string) =>
 
 const pressHandler = (element: ReactTestInstance, ...data: Array<any>): void =>
   invokeEvent(element, 'press', pressHandler, ...data);
-const changeTextHandler = (
-  element: ReactTestInstance,
-  ...data: Array<any>
-): void => invokeEvent(element, 'changeText', changeTextHandler, ...data);
+
+const changeTextHandler = (element: ReactTestInstance, text: string): void => {
+  invokeEvent(element, 'changeText', changeTextHandler, text);
+  invokeEvent(element, 'change', changeTextHandler, {
+    nativeEvent: {
+      target: element?.instance,
+      text,
+      eventCount: undefined,
+    },
+  });
+};
+
 const scrollHandler = (element: ReactTestInstance, ...data: Array<any>): void =>
   invokeEvent(element, 'scroll', scrollHandler, ...data);
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -322,7 +322,7 @@ export type FireEventFunction = (
 
 export type FireEventAPI = FireEventFunction & {
   press: (element: ReactTestInstance, ...data: Array<any>) => any;
-  changeText: (element: ReactTestInstance, ...data: Array<any>) => any;
+  changeText: (element: ReactTestInstance, text: string) => any;
   scroll: (element: ReactTestInstance, ...data: Array<any>) => any;
 };
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This is a suggestion, I'm ready to change the PR as necessary or leave it if it does not fit :)

the motivation is following: `fireEvent.changeText()` simulates the action of user entering text into text input.

In a react native app, when user does that, both `onChangeText` and `onChange` event handlers are called. In RNTL, only `onChangeText` is called. I'd argue the behavior should be the same, which is what this PR does.

It'd require changes to docs, to explain that this is the case; I'm happy to do it. Also, this changes the function signature slightly but I do not believe this should be a breaking change for users.


### Test plan


I expanded the existing test suite, and grouped the existing `fireEvent.changeText` tests into one describe block

Thanks! :)