### PR TITLE
Add v9 release docs

### DIFF
--- a/website/docs/MigrationV9.md
+++ b/website/docs/MigrationV9.md
@@ -3,13 +3,13 @@ id: migration-v9
 title: Migration to 9.0
 ---
 
-Version 7.0 brought this package as the standard `react-native` implementation in the `@testing-library`. However it has been implemented independently from its web counterpart, therefore there were some differences in API an behaviour. Version 9.0 solves several of these problems.
+Version 7.0 brought React Native Testing Library into the `@testing-library` family. Since it has been implemented independently from its web counterpart – the React Testing Library – there are some differences in the API and behavior. Version 9.0 solves several of these problems.
 
-# API changes
+## Support for text match options a.k.a string precision API
 
-## Support for text match options a.k.a string precision API (backward compatible change)
+This is a backward compatible change.
 
-When querying text, it is now possible to pass a [`TextMatch`](https://callstack.github.io/react-native-testing-library/docs/api-queries/#textmatch) to most text based queries, which lets you configure how `@testing-library/react-native` should match your text. For instance, passing `exact: false` will allow matching substrings and will ignore case.
+When querying text, it is now possible to pass a [`TextMatch`](https://callstack.github.io/react-native-testing-library/docs/api-queries/#textmatch) to most text based queries, which lets you configure how `@testing-library/react-native` should match your text. For instance, passing `exact: false` will allow matching substrings and will ignore case:
 
 ```jsx
 const { getByText } = render(<Text>Hello World</Text>);
@@ -19,11 +19,35 @@ getByText('Hello'); // Doesn't match
 getByText('hello', { exact: false }); // ignore case-sensitivity and does partial matching
 ```
 
-The `findBy*` queries used to take a `waitForOptions` parameter as a second argument, e.g. `findByText('Hello world', {timeout: 3000})`. It has now been moved to the third argument: `findByText('Hello world', {exact: true}, {timeout: 3000})`. For backward compatibility, `@testing-library/react-native@9.0` can still read `waitForOptions` from the second argument but will print a deprecation warning.
+Please note that the `findBy*` queries used to take a `waitForOptions` parameter as a second argument, which has now been moved to the third argument:
 
-## Stop matching across several nodes (breaking change)
+```diff
+-findByText('Hello world', { timeout: 3000 }); // old findBy* API
++findByText('Hello world', {}, { timeout: 3000 }); // new findBy* API
+```
 
-When text is spread across several nodes, like: `<Text>Hello <Text>world</Text</Text>`, React Native Testing Library used to allow matching the full string using `getByText('Hello world')`. However this behaviour was different than the web one, and wouldn't always be straightforward to reason about. For instance it could match text nodes far from each other on the screen. From v9, this type of match will not work. A work around is to use `within`:
+For backward compatibility RNTL v9 can still read `waitForOptions` from the second argument but will print a deprecation warning.
+
+## Reverted matching text across several nodes
+
+:::caution
+This is a breaking change.
+:::
+
+In v1.14 we've introduced a feature allowing to match text when it's spread across several nodes:
+
+```tsx
+const { getByText } = render(
+  <Text>
+    Hello <Text>world</Text>
+  </Text>
+);
+getByText('Hello world'); // matches
+```
+
+However this behavior was different than the web one, and wouldn't always be straightforward to reason about. For instance it could match text nodes far from each other on the screen. It also prevented us from implementing the string precision API. From v9, this type of match will not work.
+
+A work around is to use `within`:
 
 ```tsx
 import {Text} from 'react-native'
@@ -34,6 +58,10 @@ const {getByText} = render(<Text>Hello <Text>world</Text</Text>)
 within(getByText('Hello', {exact: false})).getByText('world')
 ```
 
-# Future plans
+## Future plans
 
 This release changes a lot of internal logic in the library, paving the way for more improvements to bring us closer to our web counterpart, with a possibly better story for accessibility queries.
+
+We're also [migrating the codebase to TypeScript](https://github.com/callstack/react-native-testing-library/issues/877). Please let us know if you're interested in helping us with this effort.
+
+Stay safe!

--- a/website/docs/MigrationV9.md
+++ b/website/docs/MigrationV9.md
@@ -19,11 +19,11 @@ getByText('Hello'); // Doesn't match
 getByText('hello', { exact: false }); // ignore case-sensitivity and does partial matching
 ```
 
-`findBy*` queries used to take a `waitForOptions` parameter (e.g. `findByText('Hello world', {timeout: 3000})`), that parameter has been moved to the third place: `findByText('Hello world', {exact: true}, {timeout: 3000})`. For backward compatibility, `@testing-library/react-native@9.0` still reads `waitForOptions` from the second parameter but will print a deprecation warning: `findByText('Hello world', {timeout: 3000, exact: false})`.
+The `findBy*` queries used to take a `waitForOptions` parameter as a second argument, e.g. `findByText('Hello world', {timeout: 3000})`. It has now been moved to the third argument: `findByText('Hello world', {exact: true}, {timeout: 3000})`. For backward compatibility, `@testing-library/react-native@9.0` can still read `waitForOptions` from the second argument but will print a deprecation warning.
 
 ## Stop matching across several nodes (breaking change)
 
-When text is spread across several nodes `<Text>Hello <Text>world</Text</Text>`, `@testing-library/react-native` used to allow matching the full string `getByText('Hello world')`. However this behaviour was different than the web one, and wouldn't always be straightforward to reason about (it could match text nodes far from each other on the screen). From v9, this type of match will not work. A work around is to use `within`:
+When text is spread across several nodes, like: `<Text>Hello <Text>world</Text</Text>`, React Native Testing Library used to allow matching the full string using `getByText('Hello world')`. However this behaviour was different than the web one, and wouldn't always be straightforward to reason about. For instance it could match text nodes far from each other on the screen. From v9, this type of match will not work. A work around is to use `within`:
 
 ```tsx
 import {Text} from 'react-native'
@@ -31,10 +31,9 @@ import {render, within} from '@testing-library/react-native'
 
 const {getByText} = render(<Text>Hello <Text>world</Text</Text>)
 
-// exact: false
 within(getByText('Hello', {exact: false})).getByText('world')
 ```
 
 # Future plans
 
-This release changes a lot of internal logic in `@testing-library/react-native`, paving the way for more more improvements to bring us closer from our web counterpart, with for instance a better support for accessibility queries.
+This release changes a lot of internal logic in the library, paving the way for more improvements to bring us closer to our web counterpart, with a possibly better story for accessibility queries.

--- a/website/docs/MigrationV9.md
+++ b/website/docs/MigrationV9.md
@@ -1,0 +1,40 @@
+---
+id: migration-v9
+title: Migration to 9.0
+---
+
+Version 7.0 brought this package as the standard `react-native` implementation in the `@testing-library`. However it has been implemented independently from its web counterpart, therefore there were some differences in API an behaviour. Version 9.0 solves several of these problems.
+
+# API changes
+
+## Support for text match options a.k.a string precision API (backward compatible change)
+
+When querying text, it is now possible to pass a [`TextMatch`](https://callstack.github.io/react-native-testing-library/docs/api-queries/#textmatch) to most text based queries, which lets you configure how `@testing-library/react-native` should match your text. For instance, passing `exact: false` will allow matching substrings and will ignore case.
+
+```jsx
+const { getByText } = render(<Text>Hello World</Text>);
+
+getByText('Hello World'); // Matches
+getByText('Hello'); // Doesn't match
+getByText('hello', { exact: false }); // ignore case-sensitivity and does partial matching
+```
+
+`findBy*` queries used to take a `waitForOptions` parameter (e.g. `findByText('Hello world', {timeout: 3000})`), that parameter has been moved to the third place: `findByText('Hello world', {exact: true}, {timeout: 3000})`. For backward compatibility, `@testing-library/react-native@9.0` still reads `waitForOptions` from the second parameter but will print a deprecation warning: `findByText('Hello world', {timeout: 3000, exact: false})`.
+
+## Stop matching across several nodes (breaking change)
+
+When text is spread across several nodes `<Text>Hello <Text>world</Text</Text>`, `@testing-library/react-native` used to allow matching the full string `getByText('Hello world')`. However this behaviour was different than the web one, and wouldn't always be straightforward to reason about (it could match text nodes far from each other on the screen). From v9, this type of match will not work. A work around is to use `within`:
+
+```tsx
+import {Text} from 'react-native'
+import {render, within} from '@testing-library/react-native'
+
+const {getByText} = render(<Text>Hello <Text>world</Text</Text>)
+
+// exact: false
+within(getByText('Hello', {exact: false})).getByText('world')
+```
+
+# Future plans
+
+This release changes a lot of internal logic in `@testing-library/react-native`, paving the way for more more improvements to bring us closer from our web counterpart, with for instance a better support for accessibility queries.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -2,7 +2,12 @@ module.exports = {
   docs: {
     Introduction: ['getting-started'],
     'API Reference': ['api', 'api-queries'],
-    Guides: ['migration-v7', 'migration-v2', 'how-should-i-query'],
+    Guides: [
+      'migration-v9',
+      'migration-v7',
+      'migration-v2',
+      'how-should-i-query',
+    ],
     Examples: ['react-navigation', 'redux-integration'],
   },
 };


### PR DESCRIPTION
As discussed in https://github.com/callstack/react-native-testing-library/discussions/862#discussioncomment-1705927, here is a proposal for the v9 docs. @thymikee let me know if you had something different in mind.