### PR TITLE
fix: add React.Fragment support for matching text

### DIFF
--- a/src/__tests__/byText.test.js
+++ b/src/__tests__/byText.test.js
@@ -176,6 +176,20 @@ test.skip('getByText works properly with custom text container', () => {
   ).toBeTruthy();
 });
 
+test('getByText works properly with React.Fragment nested in <Text>', () => {
+  function FragmentText({ children }) {
+    return <React.Fragment>{children}</React.Fragment>;
+  }
+
+  const { getByText, queryByText } = render(
+    <Text>
+      <FragmentText>Hello</FragmentText>
+    </Text>
+  );
+  expect(getByText('Hello')).toBeTruthy();
+  expect(queryByText('Hello')).not.toBeNull();
+});
+
 test('queryByText nested <Image> in <Text> at start', () => {
   expect(
     render(

--- a/src/helpers/byText.js
+++ b/src/helpers/byText.js
@@ -57,6 +57,18 @@ const getNodeByText = (
         return matches(text, textToTest, normalizer, exact);
       }
     }
+    if (node?.parent?.parent) {
+      const isParentTextComponent = filterNodeByType(node.parent?.parent, Text);
+      if (isParentTextComponent && !isTextComponent) {
+        if (typeof node.children?.[0] === 'string') {
+          const textToTest = node.children.join('');
+          return typeof text === 'string'
+            ? text === textToTest
+            : text.test(textToTest);
+        }
+      }
+    }
+
     return false;
   } catch (error) {
     throw createLibraryNotSupportedError(error);


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
#### This PR builds upon #663

I have used the code provided by @lachiet with an added conditional.

Searching for text by using `getByText()` should now detect the text inside of a `<React.Fragment>` nested in a `<Text>` component.
```javascript
<Text>
  <React.Fragment>Hello world</React.Fragment>
</Text>
```


### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
I have included a test to test the new change and all other tests have passed.
