### PR TITLE
feat: adds onTimeout option to waitFor

### DIFF
--- a/src/__tests__/waitFor.test.js
+++ b/src/__tests__/waitFor.test.js
@@ -115,6 +115,32 @@ test.each([TimerMode.Legacy, TimerMode.Modern])(
   }
 );
 
+test.each([TimerMode.Legacy, TimerMode.Modern])(
+  'waits for assertion until timeout is met with %s fake timers',
+  async (fakeTimerType) => {
+    jest.useFakeTimers(fakeTimerType);
+
+    const mockErrorFn = jest.fn(() => {
+      throw Error('test');
+    });
+
+    const mockHandleFn = jest.fn((e) => e);
+
+    try {
+      await waitFor(() => mockErrorFn(), {
+        timeout: 400,
+        interval: 200,
+        onTimeout: mockHandleFn,
+      });
+    } catch (error) {
+      // suppress
+    }
+
+    expect(mockErrorFn).toHaveBeenCalledTimes(3);
+    expect(mockHandleFn).toHaveBeenCalledTimes(1);
+  }
+);
+
 test.each([TimerMode.Legacy, TimerMode.Legacy])(
   'awaiting something that succeeds before timeout works with %s fake timers',
   async (fakeTimerType) => {

--- a/src/waitFor.js
+++ b/src/waitFor.js
@@ -29,6 +29,7 @@ export type WaitForOptions = {
   timeout?: number,
   interval?: number,
   stackTraceError?: ErrorWithStack,
+  onTimeout?: (error: Error) => Error,
 };
 
 function waitForInternal<T>(
@@ -37,6 +38,7 @@ function waitForInternal<T>(
     timeout = DEFAULT_TIMEOUT,
     interval = DEFAULT_INTERVAL,
     stackTraceError,
+    onTimeout,
   }: WaitForOptions
 ): Promise<T> {
   if (typeof expectation !== 'function') {
@@ -178,6 +180,9 @@ function waitForInternal<T>(
         if (stackTraceError) {
           copyStackTrace(error, stackTraceError);
         }
+      }
+      if (typeof onTimeout === 'function') {
+        onTimeout(error);
       }
       onDone(error, null);
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -388,6 +388,7 @@ type TextMatchOptions = {
 type WaitForOptions = {
   timeout?: number;
   interval?: number;
+  onTimeout?: (error: Error) => Error;
 };
 
 export type WaitForFunction = <T = any>(


### PR DESCRIPTION
### Summary

Adds the option `onTimeout?: (error: Error) => Error` to the `waitFor` function to match the option in [the non-native React Testing Library](https://testing-library.com/docs/dom-testing-library/api-async/).

### Test plan

I added a new test for this as well.


Useful so that you can do stuff like this:

```ts
await waitFor(() => expect(getSlotMachine().props.accessibilityState.disabled).toBeFalsy(), {
    onTimeout: (e) => {
      console.log(getSlotMachine().props.accessibilityState.disabled)
      expect(wrapper).toMatchSnapshot();
      return e;
    }
  });
```