### PR TITLE
docs: fix textmatch broken link

### DIFF
--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -262,7 +262,7 @@ Queries that take a `TextMatch` also accept an object as the final argument that
 - `exact`: Defaults to `true`; matches full strings, case-sensitive. When false, matches substrings and is not case-sensitive.
   - `exact` has no effect on regex argument.
   - In most cases using a `regex` instead of a string gives you more control over fuzzy matching and should be preferred over `{ exact: false }`.
-- `normalizer`: An optional function which overrides normalization behavior. See [Normalization](#Normalization).
+- `normalizer`: An optional function which overrides normalization behavior. See [Normalization](#normalization).
 
 `exact` option defaults to `true` but if you want to search for a text slice or make text matching case-insensitive you can override it. That being said we advise you to use regex in more complex scenarios.
 

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -55,7 +55,7 @@ type ReactTestInstance = {
 
 ### Options
 
-Query first argument can be a **string** or a **regex**. Some queries accept optional argument which change string matching behaviour. See [TextMatch](#TextMatch) for more info.
+Query first argument can be a **string** or a **regex**. Some queries accept optional argument which change string matching behaviour. See [TextMatch](#textmatch) for more info.
 
 ### `ByText`
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

When pressing the `#TextMatch` link in the [docs](https://callstack.github.io/react-native-testing-library/docs/api-queries/#options) under queries > options we aren't redirected anywhere due to capital letters included in the relative path of the header.

The same issue exists with the `#Normalization` link in the [docs](https://callstack.github.io/react-native-testing-library/docs/api-queries/#precision) under precision.

Due to this the `TextMatch` and `Normalization` are not that visible and might cause confusion 🙈

This pr fixes both links.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

You can check the links provided below to test.

|Broken|Fixed|
|---|---|
|https://callstack.github.io/react-native-testing-library/docs/api-queries/#Normalization|https://callstack.github.io/react-native-testing-library/docs/api-queries/#normalization|
|https://callstack.github.io/react-native-testing-library/docs/api-queries/#TextMatch|https://callstack.github.io/react-native-testing-library/docs/api-queries/#textmatch|
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
