### PR TITLE
feat: allow getByText and queryByText to find text nested in fragments

### DIFF
--- a/src/__tests__/byText.test.js
+++ b/src/__tests__/byText.test.js
@@ -436,3 +436,36 @@ describe('Supports normalization', () => {
     expect(getByText('A text', { normalizer: normalizerFn })).toBeTruthy();
   });
 });
+
+test('getByText and queryByText work properly with text nested in React.Fragment', () => {
+  const { getByText, queryByText } = render(
+    <Text>
+      <>Hello</>
+    </Text>
+  );
+  expect(getByText('Hello')).toBeTruthy();
+  expect(queryByText('Hello')).not.toBeNull();
+});
+
+test('getByText and queryByText work properly with text partially nested in React.Fragment', () => {
+  const { getByText, queryByText } = render(
+    <Text>
+      He<>llo</>
+    </Text>
+  );
+  expect(getByText('Hello')).toBeTruthy();
+  expect(queryByText('Hello')).not.toBeNull();
+});
+
+test('getByText and queryByText work properly with multiple nested fragments', () => {
+  const { getByText, queryByText } = render(
+    <Text>
+      He
+      <>
+        l<>l</>o
+      </>
+    </Text>
+  );
+  expect(getByText('Hello')).toBeTruthy();
+  expect(queryByText('Hello')).not.toBeNull();
+});

--- a/src/helpers/byText.js
+++ b/src/helpers/byText.js
@@ -30,11 +30,15 @@ const getChildrenAsText = (children, TextComponent) => {
       // has no text. In such situations, react-test-renderer will traverse down
       // this tree in a separate call and run this query again. As a result, the
       // query will match the deepest text node that matches requested text.
-      if (filterNodeByType(child, TextComponent) && textContent.length === 0) {
+      if (filterNodeByType(child, TextComponent)) {
         return;
       }
 
-      getChildrenAsText(child.props.children, TextComponent);
+      if (filterNodeByType(child, React.Fragment)) {
+        textContent.push(
+          ...getChildrenAsText(child.props.children, TextComponent)
+        );
+      }
     }
   });
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This fixes the issue #866 

There are already two open prs for this issue, #663 and #883 but they seem to be stale. 

As suggested in this comment https://github.com/callstack/react-native-testing-library/pull/883#issuecomment-1008809986, this implementation modifies getChildrenAsText function and tests for Fragment type.


<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

I added several test cases with fragments. It should work as if fragments were not there as far as getByText and queryByText are concerned

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
