### PR TITLE
docs: create document describing act function and related errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ The [public API](https://callstack.github.io/react-native-testing-library/docs/a
 - [Migration to 7.0](https://callstack.github.io/react-native-testing-library/docs/migration-v7)
 - [Migration to 2.0](https://callstack.github.io/react-native-testing-library/docs/migration-v2)
 
+## Troubleshooting
+
+- [Understanding `act` function](https://callstack.github.io/react-native-testing-library/docs/undestanding-act)
+
 ## Related External Resources
 
 - [Real world extensive examples repo](https://github.com/vanGalilea/react-native-testing)

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -372,6 +372,10 @@ test('waiting for an Banana to be ready', async () => {
 In order to properly use `waitFor` you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.61 (which comes with React >=16.9.0).
 :::
 
+:::note
+If you receive warnings related to `act()` function consult our [Undestanding Act](./UnderstandingAct.md) function document.
+:::
+
 ## `waitForElementToBeRemoved`
 
 - [`Example code`](https://github.com/callstack/react-native-testing-library/blob/main/src/__tests__/waitForElementToBeRemoved.test.tsx)
@@ -406,6 +410,10 @@ You can use any of `getBy`, `getAllBy`, `queryBy` and `queryAllBy` queries for `
 
 :::info
 In order to properly use `waitForElementToBeRemoved` you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.61 (which comes with React >=16.9.0).
+:::
+
+:::note
+If you receive warnings related to `act()` function consult our [Undestanding Act](./UnderstandingAct.md) function document.
 :::
 
 ## `within`, `getQueriesForElement`
@@ -465,6 +473,8 @@ expect(submitButtons).toHaveLength(3); // expect 3 elements
 ## `act`
 
 Useful function to help testing components that use hooks API. By default any `render`, `update`, `fireEvent`, and `waitFor` calls are wrapped by this function, so there is no need to wrap it manually. This method is re-exported from [`react-test-renderer`](https://github.com/facebook/react/blob/main/packages/react-test-renderer/src/ReactTestRenderer.js#L567]).
+
+Consult our [Undestanding Act](./UnderstandingAct.md) function document for more understanding of its intricacies.
 
 ## `renderHook`
 

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -474,7 +474,7 @@ expect(submitButtons).toHaveLength(3); // expect 3 elements
 
 Useful function to help testing components that use hooks API. By default any `render`, `update`, `fireEvent`, and `waitFor` calls are wrapped by this function, so there is no need to wrap it manually. This method is re-exported from [`react-test-renderer`](https://github.com/facebook/react/blob/main/packages/react-test-renderer/src/ReactTestRenderer.js#L567]).
 
-Consult our [Undestanding Act](./UnderstandingAct.md) function document for more understanding of its intricacies.
+Consult our [Undestanding Act function](./UnderstandingAct.md) document for more understanding of its intricacies.
 
 ## `renderHook`
 

--- a/website/docs/UnderstandingAct.md
+++ b/website/docs/UnderstandingAct.md
@@ -3,11 +3,11 @@ id: understanding-act
 title: Understanding Act function
 ---
 
-When writing RNTL tests one of the things that confuses developers the most are cryptic `act()` function errors logged into console. In this article I will try to build an understanding of the purpose and behaviour of `act()` so you can build your tests with more confidence.
+When writing RNTL tests one of the things that confuses developers the most are cryptic [`act()`](https://reactjs.org/docs/testing-recipes.html#act) function errors logged into console. In this article I will try to build an understanding of the purpose and behaviour of `act()` so you can build your tests with more confidence.
 
 ## The act warnings
 
-Let’s start with typical `act()` warnings logged to console. There are two kinds of these issues, let’s call the first one sync `act()` warnings:
+Let’s start with typical `act()` warnings logged to console. There are two kinds of these issues, let’s call the first one a sync `act()` warning:
 
 ```
 Warning: An update to Component inside a test was not wrapped in act(...).
@@ -20,7 +20,7 @@ act(() => {
 /* assert on the output */
 ```
 
-The second one relates to async usage of `act` so let’s call it async `act` error:
+The second one relates to async usage of `act` so let’s call it an "async `act`" error:
 
 ```
 Warning: You called act(async () => ...) without await. This could lead to unexpected
@@ -84,21 +84,21 @@ The name `act` comes from [Arrange-Act-Assert](http://wiki.c2.com/?ArrangeActAss
 
 So far we learned that `act` function allows tests to wait for all pending React interactions to be applied before we make our assertions. When using `act` we get guarantee that any state updates will be executed as well as any enqueued effects will be executed.
 
-Therefore, we should use `act` whenever the is some action that causes element tree to render, particularly:
+Therefore, we should use `act` whenever there is some action that causes element tree to render, particularly:
 
 - initial render call - `ReactTestRenderer.create` call
 - re-rendering of component -`renderer.update` call
 - triggering any event handlers that cause component tree render
 
-Thankfully, for these basic cases RNTL has got you covered as our `render`, `update` and `fireEvent` calls already wrap their calls in sync `act` so that you do not have to do it explicitly.
+Thankfully, for these basic cases RNTL has got you covered as our `render`, `update` and `fireEvent` methods already wrap their calls in sync `act` so that you do not have to do it explicitly.
 
-Note that `act`calls can be safely nested and internally form a stack of calls. However, overlapping `act` calls, which can be achieved using async version of `act`, [are not supported](https://github.com/facebook/react/blob/main/packages/react/src/ReactAct.js#L161).
+Note that `act` calls can be safely nested and internally form a stack of calls. However, overlapping `act` calls, which can be achieved using async version of `act`, [are not supported](https://github.com/facebook/react/blob/main/packages/react/src/ReactAct.js#L161).
 
 ### Implementation
 
 As of React version of 18.1.0, the `act` implementation is defined in the [ReactAct.js source file](https://github.com/facebook/react/blob/main/packages/react/src/ReactAct.js) inside React repository. This implementation has been fairly stable since React 17.0.
 
-RNTL exports `act` for convenience of the users as defined in the [act.ts source file](https://github.com/callstack/react-native-testing-library/blob/main/src/act.ts). That file refers to [ReactTestRenderer.js source](https://github.com/facebook/react/blob/ce13860281f833de8a3296b7a3dad9caced102e9/packages/react-test-renderer/src/ReactTestRenderer.js#L52) file from React Test Renderer package, which finally leads to React `act` implementation mentioned above.
+RNTL exports `act` for convenience of the users as defined in the [act.ts source file](https://github.com/callstack/react-native-testing-library/blob/main/src/act.ts). That file refers to [ReactTestRenderer.js source](https://github.com/facebook/react/blob/ce13860281f833de8a3296b7a3dad9caced102e9/packages/react-test-renderer/src/ReactTestRenderer.js#L52) file from React Test Renderer package, which finally leads to React act implementation in ReactAct.js (already mentioned above).
 
 ## Asynchronous act
 
@@ -108,7 +108,7 @@ So far we have seen synchronous version of `act` which runs its callback immedia
 
 Asynchronous version of `act` also is executed immediately, but the callback is not yet completed because of some asynchronous operations inside.
 
-Lets look at a simple example with component using `setTimeout`call to simulate asynchronous behaviour:
+Lets look at a simple example with component using `setTimeout` call to simulate asynchronous behaviour:
 
 ```jsx
 function TestAsyncComponent() {
@@ -147,7 +147,7 @@ Note that this is not yet the infamous async act warning. It only asks us to wra
 
 ### Solution with fake timers
 
-First solution is to use jest fake timers inside out tests:
+First solution is to use Jest's fake timers inside out tests:
 
 ```jsx
 test('render with fake timers', () => {
@@ -171,7 +171,7 @@ If we wanted to stick with real timers then things get a bit more complex. Let�
 test('render with real timers - sleep', async () => {
   const view = render(<TestAsyncComponent />);
   await act(async () => {
-    await sleep(50 + 10); // Wait a bit longer then setTimeout in component
+    await sleep(50 + 10); // Wait a bit longer than setTimeout in `TestAsyncComponent`
   });
 
   expect(view.getByText('Count 1')).toBeTruthy();
@@ -191,7 +191,7 @@ test('render with real timers - waitFor', async () => {
 });
 ```
 
-This also works correctly, because `waitFor` calls executes async `act()` call internally.
+This also works correctly, because `waitFor` call executes async `act()` call internally.
 
 The above code can be simplified using `findBy` query:
 
@@ -224,3 +224,4 @@ The exact reasons why you might see async `act()`warnings vary, but finally it m
 ## References
 
 - [React `act` implementation source](https://github.com/facebook/react/blob/main/packages/react/src/ReactAct.js)
+- [React testing recipes: `act()`](https://reactjs.org/docs/testing-recipes.html#act)

--- a/website/docs/UnderstandingAct.md
+++ b/website/docs/UnderstandingAct.md
@@ -220,3 +220,7 @@ testing behaviour, interleaving multiple act calls and mixing their scopes. You 
 React decides to show this error whenever it detects that async `act()`call [has not been awaited](https://github.com/facebook/react/blob/ce13860281f833de8a3296b7a3dad9caced102e9/packages/react/src/ReactAct.js#L93).
 
 The exact reasons why you might see async `act()`warnings vary, but finally it means that `act()` has been called with callback that returns `Promise`-like object, but it has not been waited on.
+
+## References
+
+- [React `act` implementation source](https://github.com/facebook/react/blob/main/packages/react/src/ReactAct.js)

--- a/website/docs/UnderstandingAct.md
+++ b/website/docs/UnderstandingAct.md
@@ -1,0 +1,222 @@
+---
+id: understanding-act
+title: Understanding Act function
+---
+
+# Understanding Act function
+
+When writing RNTL tests one of the things that confuses developers the most are cryptic `act()` function errors logged into console. In this article I will try to build an understanding of the purpose and behaviour of `act()` so you can build your tests with more confidence.
+
+# The act warnings
+
+Let’s start with typical `act()` warnings logged to console. There are two kinds of these issues, let’s call the first one sync `act()` warnings:
+
+```
+Warning: An update to Component inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+```
+
+The second one relates to async usage of `act` so let’s call it async `act` error:
+
+```
+Warning: You called act(async () => ...) without await. This could lead to unexpected testing behaviour, interleaving multiple act calls and mixing their scopes. You should - await act(async () => ...);
+```
+
+# Sync act
+
+## Responsibility
+
+This function is intended only for using in automated tests and works only in development mode. Attempting to use it in production build will throw an error.
+
+The responsibility for `act` function is to make React renders and updates work in tests in a similar way they work in real application by grouping and executing related units of interaction (e.g. renders, effects, etc) together.
+
+To showcase that behaviour let make a small experiment. First we define a function component that uses `useEffect` hook in a trivial way.
+
+```jsx
+function TestComponent() {
+  const [count, setCount] = React.useState(0);
+  React.useEffect(() => {
+    setCount((c) => c + 1);
+  }, []);
+
+  return <Text>Count {count}</Text>;
+}
+```
+
+In the following tests we will directly use `ReactTestRenderer` instead of RNTL `render` function to render our component for tests. In order to expose familiar queries like `getByText` we will use `within` function from RNTL.
+
+```jsx
+test('render without act', () => {
+  const renderer = TestRenderer.create(<TestComponent />);
+
+  // Bind RNTL queries for root element.
+  const view = within(renderer.root);
+  expect(view.getByText('Count 0')).toBeTruthy();
+});
+```
+
+When testing without `act` call wrapping rendering call, we see that the assertion runs just after the rendering but before `useEffect`hooks effects are applied. Which is not what we expected in our tests.
+
+```jsx
+test('render with act', () => {
+  let renderer: ReactTestRenderer;
+  act(() => {
+    renderer = TestRenderer.create(<TestComponent />);
+  });
+
+  // Bind RNTL queries for root element.
+  const view = within(renderer!.root);
+  expect(view.getByText('Count 1')).toBeTruthy();
+});
+```
+
+When wrapping rendering call with `act` we see that the changes caused by `useEffect` hook have been applied as we would expect.
+
+## When to use act
+
+The name `act` comes from [Arrange-Act-Assert](http://wiki.c2.com/?ArrangeActAssert) unit testing pattern. Which means it’s related to part of the test when we execute some actions on the component tree.
+
+So far we learned that `act` function allows tests to wait for all pending React interactions to be applied before we make our assertions. When using `act` we get guarantee that any state updates will be executed as well as any enqueued effects will be executed.
+
+Therefore, we should use `act` whenever the is some action that causes element tree to render, particularly:
+
+- initial render call - `ReactTestRenderer.create` call
+- re-rendering of component -`renderer.update` call
+- triggering any event handlers that cause component tree render
+
+Thankfully, for these basic cases RNTL has got you covered as our `render`, `update` and `fireEvent` calls already wrap their calls in sync `act` so that you do not have to do it explicitly.
+
+Note that `act`calls can be safely nested and internally form a stack of calls. However, overlapping `act` calls, which can be achieved using async version of `act`, [are not supported](https://github.com/facebook/react/blob/main/packages/react/src/ReactAct.js#L161).
+
+## Implementation
+
+As of React version of 18.1.0, the `act` implementation is defined in the [ReactAct.js source file](https://github.com/facebook/react/blob/main/packages/react/src/ReactAct.js) inside React repository. This implementation has been fairly stable since React 17.0.
+
+RNTL exports `act` for convenience of the users as defined in the [act.ts source file](https://github.com/callstack/react-native-testing-library/blob/main/src/act.ts). That file refers to [ReactTestRenderer.js source](https://github.com/facebook/react/blob/ce13860281f833de8a3296b7a3dad9caced102e9/packages/react-test-renderer/src/ReactTestRenderer.js#L52) file from React Test Renderer package, which finally leads to React `act` implementation mentioned above.
+
+# Async act
+
+So far we have seen synchronous version of `act` which runs its callback immediately. This can deal with things like synchronous effects or mocks using already resolved promises. However, not all component code is synchronous. Frequently our components or mocks contain some asynchronous behaviours like `setTimeout` calls or network calls. Starting from React 16.9, `act` can also be called in asynchronous mode. In such case `act` implementation checks that the passed callback returns [object resembling promise](https://github.com/facebook/react/blob/ce13860281f833de8a3296b7a3dad9caced102e9/packages/react/src/ReactAct.js#L60).
+
+## Basics
+
+Asynchronous version of `act` also is executed immediately, but the callback is not yet completed because of some asynchronous operations inside.
+
+Lets look at a simple example with component using `setTimeout`call to simulate asynchronous behaviour:
+
+```jsx
+function TestAsyncComponent() {
+  const [count, setCount] = React.useState(0);
+  React.useEffect(() => {
+    setTimeout(() => {
+      setCount((c) => c + 1);
+    }, 50);
+  }, []);
+
+  return <Text>Count {count}</Text>;
+}
+```
+
+```jsx
+test('render async natively', () => {
+  const view = render(<TestAsyncComponent />);
+  expect(view.getByText('Count 0')).toBeTruthy();
+});
+```
+
+If we test our component in a native way without handling its asynchronous behaviour we will end up with sync act warning:
+
+```
+Warning: An update to TestAsyncComponent inside a test was not wrapped in act(...).
+
+When testing, code that causes React state updates should be wrapped into act(...):
+
+act(() => {
+  /* fire events that update state */
+});
+/* assert on the output */
+```
+
+Note that this is not yet the infamous async act warning. It only asks us to wrap our event code with `act` calls. However, this time our immediate state change does not originate from externally triggered events but rather forms an internal part of the component. So how can we apply `act` in such scenario?
+
+### Async act and fake timers
+
+First solution is to use jest fake timers inside out tests.
+
+```jsx
+test('render with fake timers', () => {
+  jest.useFakeTimers();
+  const view = render(<TestAsyncComponent />);
+
+  act(() => {
+    jest.runAllTimers();
+  });
+  expect(view.getByText('Count 1')).toBeTruthy();
+});
+```
+
+That way we can wrap `jest.runAllTimers()` call which triggers the `setTimeout` updates inside an `act` call, hence resolving the act warning. Note that this whole code is synchronous thanks to usage of Jest fake timers.
+
+### Async act and real timers
+
+If we wanted to stick with real timers then things get a bit more complex.
+
+Let’s start by applying a crude solution of opening async `act()` call for the expected duration of components updates:
+
+```jsx
+test('render with real timers - sleep', async () => {
+  const view = render(<TestAsyncComponent />);
+  await act(async () => {
+    await sleep(50 + 10); // Wait a bit longer then setTimeout in component
+  });
+
+  expect(view.getByText('Count 1')).toBeTruthy();
+});
+```
+
+This works correctly as we use an explicit async `act()` call that resolves the console error. However, it relies on our knowledge of exact implementation details which is a bad practice.
+
+Let’s try more elegant solution using `waitFor` that will wait for our desired state:
+
+```jsx
+test('render with real timers - waitFor', async () => {
+  const view = render(<TestAsyncComponent />);
+
+  await waitFor(() => view.getByText('Count 1'));
+  expect(view.getByText('Count 1')).toBeTruthy();
+});
+```
+
+This also works correctly, because `waitFor` calls executes async `act()` call internally.
+
+The above code can be simplified using `findBy` query:
+
+```jsx
+test('render with real timers - findBy', async () => {
+  const view = render(<TestAsyncComponent />);
+
+  expect(await view.findByText('Count 1')).toBeTruthy();
+});
+```
+
+This also works since `findByText` internally calls `waitFor` which uses async `act()`.
+
+Note that all of the above examples are async tests using & awaiting async `act()` function call.
+
+### Async act warnings
+
+If we modify any of the above async tests and remove `await` keyword, then we will trigger the notorious async `act()`warning:
+
+```jsx
+Warning: You called act(async () => ...) without await. This could lead to unexpected testing behaviour, interleaving multiple act calls and mixing their scopes. You should - await act(async () => ...);
+```
+
+React decides to show this error whenever it detects that async `act()`call [has not been awaited](https://github.com/facebook/react/blob/ce13860281f833de8a3296b7a3dad9caced102e9/packages/react/src/ReactAct.js#L93).
+
+The exact reasons why you might see async `act()`warnings vary, but finally it means that `act()` has been called with callback that returns `Promise`-like object, but it has not been waited on.

--- a/website/docs/UnderstandingAct.md
+++ b/website/docs/UnderstandingAct.md
@@ -7,7 +7,7 @@ When writing RNTL tests one of the things that confuses developers the most are 
 
 ## The act warnings
 
-Let’s start with typical `act()` warnings logged to console. There are two kinds of these issues, let’s call the first one a sync `act()` warning:
+Let’s start with typical `act()` warnings logged to console. There are two kinds of these issues, let’s call the first one the "sync `act()`" warning:
 
 ```
 Warning: An update to Component inside a test was not wrapped in act(...).
@@ -20,7 +20,7 @@ act(() => {
 /* assert on the output */
 ```
 
-The second one relates to async usage of `act` so let’s call it an "async `act`" error:
+The second one relates to async usage of `act` so let’s call it the "async `act`" error:
 
 ```
 Warning: You called act(async () => ...) without await. This could lead to unexpected
@@ -171,7 +171,7 @@ If we wanted to stick with real timers then things get a bit more complex. Let�
 test('render with real timers - sleep', async () => {
   const view = render(<TestAsyncComponent />);
   await act(async () => {
-    await sleep(50 + 10); // Wait a bit longer than setTimeout in `TestAsyncComponent`
+    await sleep(100); // Wait a bit longer than setTimeout in `TestAsyncComponent`
   });
 
   expect(view.getByText('Count 1')).toBeTruthy();
@@ -219,7 +219,7 @@ testing behaviour, interleaving multiple act calls and mixing their scopes. You 
 
 React decides to show this error whenever it detects that async `act()`call [has not been awaited](https://github.com/facebook/react/blob/ce13860281f833de8a3296b7a3dad9caced102e9/packages/react/src/ReactAct.js#L93).
 
-The exact reasons why you might see async `act()`warnings vary, but finally it means that `act()` has been called with callback that returns `Promise`-like object, but it has not been waited on.
+The exact reasons why you might see async `act()` warnings vary, but finally it means that `act()` has been called with callback that returns `Promise`-like object, but it has not been waited on.
 
 ## References
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -8,6 +8,7 @@ module.exports = {
       'migration-v2',
       'how-should-i-query',
       'eslint-plugin-testing-library',
+      'understanding-act',
     ],
     Examples: ['react-navigation', 'redux-integration'],
   },


### PR DESCRIPTION
### Summary

Our users frequently report cryptic errors related to `act()` function usage, like #379 or #859. In order to address this I've created Understanding Act function document to describe it's why and how to use it. Consider it to be initial version of the document describing the `act` basics, with intention to add more specific information for async act warnings later on.

Please share your thoughts and suggestions to improve this document.

### Test plan
Docs only
I've run docosaurus and manually verified links and layout.
