### PR TITLE
feat: predicate query

### DIFF
--- a/src/queries/__tests__/predicate.test.tsx
+++ b/src/queries/__tests__/predicate.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { View, Text, TextInput, Button } from 'react-native';
+import { ReactTestInstance } from 'react-test-renderer';
+import { render } from '../..';
+
+test('getByPredicate returns only native elements', () => {
+  const testIdPredicate = (testID: string) => (node: ReactTestInstance) => {
+    return node.props.testID === testID;
+  };
+
+  const { getByPredicate, getAllByPredicate } = render(
+    <View>
+      <Text testID="text">Text</Text>
+      <TextInput testID="textInput" />
+      <View testID="view" />
+      <Button testID="button" title="Button" onPress={jest.fn()} />
+    </View>
+  );
+
+  expect(getByPredicate(testIdPredicate('text'))).toBeTruthy();
+  expect(getByPredicate(testIdPredicate('textInput'))).toBeTruthy();
+  expect(getByPredicate(testIdPredicate('view'))).toBeTruthy();
+  expect(getByPredicate(testIdPredicate('button'))).toBeTruthy();
+
+  expect(getAllByPredicate(testIdPredicate('text'))).toHaveLength(1);
+  expect(getAllByPredicate(testIdPredicate('textInput'))).toHaveLength(1);
+  expect(getAllByPredicate(testIdPredicate('view'))).toHaveLength(1);
+  expect(getAllByPredicate(testIdPredicate('button'))).toHaveLength(1);
+
+  expect(() => getByPredicate(testIdPredicate('myComponent'))).toThrowError(
+    /^Unable to find an element matching predicate: /i
+  );
+  expect(() => getAllByPredicate(testIdPredicate('myComponent'))).toThrowError(
+    /^Unable to find an element matching predicate: /i
+  );
+});

--- a/src/queries/predicate.ts
+++ b/src/queries/predicate.ts
@@ -1,4 +1,6 @@
 import type { ReactTestInstance } from 'react-test-renderer';
+import { isHostElement } from '../helpers/component-tree';
+import { findAll } from '../helpers/findAll';
 import { makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
@@ -8,24 +10,25 @@ import type {
   QueryAllByQuery,
   QueryByQuery,
 } from './makeQueries';
+import { CommonQueryOptions } from './options';
 
 type PredicateFn = (instance: ReactTestInstance) => boolean;
-// Not used so far
-type PredicateQueryOptions = void;
+type ByPredicateQueryOptions = CommonQueryOptions;
 
-const queryAllByPredicate = (
-  instance: ReactTestInstance
-): ((
-  predicate: PredicateFn,
-  options?: PredicateQueryOptions
-) => Array<ReactTestInstance>) =>
-  function queryAllByTestIdFn(predicate) {
-    const results = instance.findAll(
-      (node) => typeof node.type === 'string' && predicate(node)
+function queryAllByPredicate(instance: ReactTestInstance) {
+  return function queryAllByPredicateFn(
+    predicate: PredicateFn,
+    options?: ByPredicateQueryOptions
+  ): Array<ReactTestInstance> {
+    const results = findAll(
+      instance,
+      (node) => isHostElement(node) && predicate(node),
+      options
     );
 
     return results;
   };
+}
 
 const getMultipleError = (predicate: PredicateFn) =>
   `Found multiple elements matching predicate: ${predicate}`;
@@ -40,12 +43,12 @@ const { getBy, getAllBy, queryBy, queryAllBy, findBy, findAllBy } = makeQueries(
 );
 
 export type ByTestIdQueries = {
-  getByPredicate: GetByQuery<PredicateFn, PredicateQueryOptions>;
-  getAllByPredicate: GetAllByQuery<PredicateFn, PredicateQueryOptions>;
-  queryByPredicate: QueryByQuery<PredicateFn, PredicateQueryOptions>;
-  queryAllByPredicate: QueryAllByQuery<PredicateFn, PredicateQueryOptions>;
-  findByPredicate: FindByQuery<PredicateFn, PredicateQueryOptions>;
-  findAllByPredicate: FindAllByQuery<PredicateFn, PredicateQueryOptions>;
+  getByPredicate: GetByQuery<PredicateFn, ByPredicateQueryOptions>;
+  getAllByPredicate: GetAllByQuery<PredicateFn, ByPredicateQueryOptions>;
+  queryByPredicate: QueryByQuery<PredicateFn, ByPredicateQueryOptions>;
+  queryAllByPredicate: QueryAllByQuery<PredicateFn, ByPredicateQueryOptions>;
+  findByPredicate: FindByQuery<PredicateFn, ByPredicateQueryOptions>;
+  findAllByPredicate: FindAllByQuery<PredicateFn, ByPredicateQueryOptions>;
 };
 
 export const bindByPredicateQueries = (

--- a/src/queries/predicate.ts
+++ b/src/queries/predicate.ts
@@ -1,0 +1,60 @@
+import type { ReactTestInstance } from 'react-test-renderer';
+import { makeQueries } from './makeQueries';
+import type {
+  FindAllByQuery,
+  FindByQuery,
+  GetAllByQuery,
+  GetByQuery,
+  QueryAllByQuery,
+  QueryByQuery,
+} from './makeQueries';
+
+type PredicateFn = (instance: ReactTestInstance) => boolean;
+// Not used so far
+type PredicateQueryOptions = void;
+
+const queryAllByPredicate = (
+  instance: ReactTestInstance
+): ((
+  predicate: PredicateFn,
+  options?: PredicateQueryOptions
+) => Array<ReactTestInstance>) =>
+  function queryAllByTestIdFn(predicate) {
+    const results = instance.findAll(
+      (node) => typeof node.type === 'string' && predicate(node)
+    );
+
+    return results;
+  };
+
+const getMultipleError = (predicate: PredicateFn) =>
+  `Found multiple elements matching predicate: ${predicate}`;
+
+const getMissingError = (predicate: PredicateFn) =>
+  `Unable to find an element matching predicate: ${predicate}`;
+
+const { getBy, getAllBy, queryBy, queryAllBy, findBy, findAllBy } = makeQueries(
+  queryAllByPredicate,
+  getMissingError,
+  getMultipleError
+);
+
+export type ByTestIdQueries = {
+  getByPredicate: GetByQuery<PredicateFn, PredicateQueryOptions>;
+  getAllByPredicate: GetAllByQuery<PredicateFn, PredicateQueryOptions>;
+  queryByPredicate: QueryByQuery<PredicateFn, PredicateQueryOptions>;
+  queryAllByPredicate: QueryAllByQuery<PredicateFn, PredicateQueryOptions>;
+  findByPredicate: FindByQuery<PredicateFn, PredicateQueryOptions>;
+  findAllByPredicate: FindAllByQuery<PredicateFn, PredicateQueryOptions>;
+};
+
+export const bindByPredicateQueries = (
+  instance: ReactTestInstance
+): ByTestIdQueries => ({
+  getByPredicate: getBy(instance),
+  getAllByPredicate: getAllBy(instance),
+  queryByPredicate: queryBy(instance),
+  queryAllByPredicate: queryAllBy(instance),
+  findByPredicate: findBy(instance),
+  findAllByPredicate: findAllBy(instance),
+});

--- a/src/screen.ts
+++ b/src/screen.ts
@@ -107,6 +107,12 @@ const defaultScreen: RenderResult = {
   queryAllByText: notImplemented,
   findByText: notImplemented,
   findAllByText: notImplemented,
+  getByPredicate: notImplemented,
+  getAllByPredicate: notImplemented,
+  queryByPredicate: notImplemented,
+  queryAllByPredicate: notImplemented,
+  findByPredicate: notImplemented,
+  findAllByPredicate: notImplemented,
 };
 
 export let screen: RenderResult = defaultScreen;

--- a/src/within.ts
+++ b/src/within.ts
@@ -10,6 +10,7 @@ import { bindByA11yStateQueries } from './queries/a11yState';
 import { bindByA11yValueQueries } from './queries/a11yValue';
 import { bindUnsafeByTypeQueries } from './queries/unsafeType';
 import { bindUnsafeByPropsQueries } from './queries/unsafeProps';
+import { bindByPredicateQueries } from './queries/predicate';
 
 export function within(instance: ReactTestInstance) {
   return {
@@ -22,6 +23,7 @@ export function within(instance: ReactTestInstance) {
     ...bindByRoleQueries(instance),
     ...bindByA11yStateQueries(instance),
     ...bindByA11yValueQueries(instance),
+    ...bindByPredicateQueries(instance),
     ...bindUnsafeByTypeQueries(instance),
     ...bindUnsafeByPropsQueries(instance),
   };

--- a/typings/index.flow.js
+++ b/typings/index.flow.js
@@ -389,32 +389,33 @@ interface A11yAPI {
   ) => FindAllReturn;
 }
 
+type PredicateFn = (node: ReactTestInstance) => boolean;
 type ByPredicateOptions = CommonQueryOptions;
 
 interface ByPredicateQueries {
   getByPredicate: (
-    placeholder: TextMatch,
+    predicate: PredicateFn,
     options?: ByPredicateOptions
   ) => ReactTestInstance;
   getAllByPredicate: (
-    placeholder: TextMatch,
+    predicate: PredicateFn,
     options?: ByPredicateOptions
   ) => Array<ReactTestInstance>;
   queryByPredicate: (
-    placeholder: TextMatch,
+    predicate: PredicateFn,
     options?: ByPredicateOptions
   ) => ReactTestInstance | null;
   queryAllByPredicate: (
-    placeholder: TextMatch,
+    predicate: PredicateFn,
     options?: ByPredicateOptions
   ) => Array<ReactTestInstance> | [];
   findByPredicate: (
-    placeholder: TextMatch,
+    predicate: PredicateFn,
     queryOptions?: ByPredicateOptions,
     waitForOptions?: WaitForOptions
   ) => FindReturn;
   findAllByPredicate: (
-    placeholder: TextMatch,
+    predicate: PredicateFn,
     queryOptions?: ByPredicateOptions,
     waitForOptions?: WaitForOptions
   ) => FindAllReturn;

--- a/typings/index.flow.js
+++ b/typings/index.flow.js
@@ -389,6 +389,37 @@ interface A11yAPI {
   ) => FindAllReturn;
 }
 
+type ByPredicateOptions = CommonQueryOptions;
+
+interface ByPredicateQueries {
+  getByPredicate: (
+    placeholder: TextMatch,
+    options?: ByPredicateOptions
+  ) => ReactTestInstance;
+  getAllByPredicate: (
+    placeholder: TextMatch,
+    options?: ByPredicateOptions
+  ) => Array<ReactTestInstance>;
+  queryByPredicate: (
+    placeholder: TextMatch,
+    options?: ByPredicateOptions
+  ) => ReactTestInstance | null;
+  queryAllByPredicate: (
+    placeholder: TextMatch,
+    options?: ByPredicateOptions
+  ) => Array<ReactTestInstance> | [];
+  findByPredicate: (
+    placeholder: TextMatch,
+    queryOptions?: ByPredicateOptions,
+    waitForOptions?: WaitForOptions
+  ) => FindReturn;
+  findAllByPredicate: (
+    placeholder: TextMatch,
+    queryOptions?: ByPredicateOptions,
+    waitForOptions?: WaitForOptions
+  ) => FindAllReturn;
+}
+
 interface Thenable {
   then: (resolve: () => any, reject?: () => any) => any;
 }
@@ -412,6 +443,7 @@ type Queries = ByTextQueries &
   ByTestIdQueries &
   ByDisplayValueQueries &
   ByPlaceholderTextQueries &
+  ByPredicateQueries &
   UnsafeByTypeQueries &
   UnsafeByPropsQueries &
   A11yAPI;

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -26,6 +26,7 @@ title: Queries
     - [Default state for: `disabled`, `selected`, and `busy` keys](#default-state-for-disabled-selected-and-busy-keys)
     - [Default state for: `checked` and `expanded` keys](#default-state-for-checked-and-expanded-keys)
   - [`ByA11Value`, `ByAccessibilityValue`](#bya11value-byaccessibilityvalue)
+  - [`ByPredicate`](#bypredicate)
 - [Common options](#common-options)
   - [`includeHiddenElements` option](#includehiddenelements-option)
 - [TextMatch](#textmatch)
@@ -390,6 +391,23 @@ render(<View accessibilityValue={{ min: 0, max: 100, now: 25, text: '25%' }} />)
 const element = screen.getByA11yValue({ now: 25 });
 const element2 = screen.getByA11yValue({ text: /25/ });
 ```
+
+### `ByPredicate`
+
+> getByPredicate, getAllByPredicate, queryByPredicate, queryAllByPredicate, findByPredicate, findAllByPredicate
+
+```ts
+getByPredicate(
+  predicate: (element: ReactTestInstance) => boolean,
+  options?: {
+    includeHiddenElements?: boolean;
+  }
+): ReactTestInstance;
+```
+
+Returns a host element matching a custom `predicate` function.
+
+This query type is an escape hatch and should be used with care. In most cases you using the standard queries like `getByRole` or `getByText` will lead to test more-resembling user perspective. Use this query with care in rare cases where more flexibility is needed.
 
 ## Common options
 


### PR DESCRIPTION
Implementation of custom queries based on option 3 from #971. This is different from custom query impl. in RTL, but because of the reasons explained in #971 I believe that their implementation has significant flaws, and we can provide a better API for such feature.

### Summary
* family of queries: `*ByPredicate(predicate: (instance: ReactTestInstance) => boolean)` 

### Test plan
* tests for matching proper elements
* tests for negative cases incl. error messages

Looking forward for your comments.
