### PR TITLE
fix: queryByText and getByText match newlines and tabs properly

### DIFF
--- a/src/matches.ts
+++ b/src/matches.ts
@@ -13,9 +13,10 @@ export function matches(
 
   const normalizedText = normalizer(text);
   if (typeof matcher === 'string') {
+    const normalizedMatcher = normalizer(matcher);
     return exact
-      ? normalizedText === matcher
-      : normalizedText.toLowerCase().includes(matcher.toLowerCase());
+      ? normalizedText === normalizedMatcher
+      : normalizedText.toLowerCase().includes(normalizedMatcher.toLowerCase());
   } else {
     return matcher.test(normalizedText);
   }

--- a/src/queries/__tests__/text.test.tsx
+++ b/src/queries/__tests__/text.test.tsx
@@ -473,3 +473,17 @@ test('getByText and queryByText work properly with multiple nested fragments', (
   expect(getByText('Hello')).toBeTruthy();
   expect(queryByText('Hello')).not.toBeNull();
 });
+
+test('getByText and queryByText work with newlines', () => {
+  const textWithNewLines = 'Line 1\nLine 2';
+  const { getByText, queryByText } = render(<Text>{textWithNewLines}</Text>);
+  expect(getByText(textWithNewLines)).toBeTruthy();
+  expect(queryByText(textWithNewLines)).toBeTruthy();
+});
+
+test('getByText and queryByText work with tabs', () => {
+  const textWithTabs = 'Line 1\tLine 2';
+  const { getByText, queryByText } = render(<Text>{textWithTabs}</Text>);
+  expect(getByText(textWithTabs)).toBeTruthy();
+  expect(queryByText(textWithTabs)).toBeTruthy();
+});


### PR DESCRIPTION
### Summary

This fixes #983.

New lines, that are rendered in RN as separate Lines, are wrongly normalised during testing.

```tsx
const { queryByText } = render(<Text>{"Line 1\nLine 2"}</Text>)
expect(queryByText("Line 1\nLine 2")).toBeDefined()
``` 

### Test plan

I have added 2 new tests to verify the fix is working.
