### PR TITLE
chore: upgrade pretty-format to v28 to match Jest deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@testing-library/react-native",
-  "version": "10.1.1",
+  "version": "11.0.0-rc.0",
   "description": "Simple and complete React Native testing utilities that encourage good testing practices.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "pretty-format": "^27.0.0"
+    "pretty-format": "^28.1.3"
   },
   "peerDependencies": {
     "react": ">=16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8203,7 +8203,7 @@ pretty-format@^26.5.2, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-pretty-format@^27.0.0, pretty-format@^27.3.1:
+pretty-format@^27.3.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
   integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

We require Jest 28 now, so it makes sense to pull the pretty-format version that comes along with it.

### Test plan

CI
