### PR TITLE
docs: v11 migration changelog link

### DIFF
--- a/website/docs/MigrationV11.md
+++ b/website/docs/MigrationV11.md
@@ -60,5 +60,5 @@ From version 11, RNTL continues to disable `press` event for these targets but a
 * chore: reenable skipped byText tests by @mdjastrzebski in https://github.com/callstack/react-native-testing-library/pull/1017
 
 # Full Changelog
-https://github.com/callstack/react-native-testing-library/compare/v10.1.1...v11.0.0-rc.0
+https://github.com/callstack/react-native-testing-library/compare/v10.1.1...v11.0.0
 


### PR DESCRIPTION
### Summary

Small fix to v11 migration guide changelog link (link to v11.0.0 tag instead of v11.0.0-rc tag).

### Test plan

All checks pass.