### PR TITLE
Export options types and `renderHook` result type

### DIFF
--- a/src/pure.ts
+++ b/src/pure.ts
@@ -1,15 +1,15 @@
 import act from './act';
 import cleanup from './cleanup';
 import fireEvent from './fireEvent';
-import render, { RenderResult } from './render';
+import render, { RenderResult, RenderOptions } from './render';
 import waitFor from './waitFor';
 import waitForElementToBeRemoved from './waitForElementToBeRemoved';
 import { within, getQueriesForElement } from './within';
 import { getDefaultNormalizer } from './matches';
-import { renderHook } from './renderHook';
+import { renderHook, RenderHookOptions, RenderHookResult } from './renderHook';
 import { screen } from './screen';
 
-export type { RenderResult };
+export type { RenderOptions, RenderResult };
 export type RenderAPI = RenderResult;
 
 export { act };
@@ -20,5 +20,5 @@ export { waitFor };
 export { waitForElementToBeRemoved };
 export { within, getQueriesForElement };
 export { getDefaultNormalizer };
-export { renderHook };
+export { renderHook, RenderHookOptions, RenderHookResult };
 export { screen };

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -8,7 +8,7 @@ import debugDeep from './helpers/debugDeep';
 import { getQueriesForElement } from './within';
 import { setRenderResult } from './screen';
 
-type Options = {
+export type RenderOptions = {
   wrapper?: React.ComponentType<any>;
   createNodeMock?: (element: React.ReactElement) => any;
 };
@@ -24,7 +24,7 @@ export type RenderResult = ReturnType<typeof render>;
  */
 export default function render<T>(
   component: React.ReactElement<T>,
-  { wrapper: Wrapper, createNodeMock }: Options = {}
+  { wrapper: Wrapper, createNodeMock }: RenderOptions = {}
 ) {
   const wrap = (innerElement: React.ReactElement) =>
     Wrapper ? <Wrapper>{innerElement}</Wrapper> : innerElement;

--- a/src/renderHook.tsx
+++ b/src/renderHook.tsx
@@ -2,13 +2,17 @@ import React from 'react';
 import type { ComponentType } from 'react';
 import render from './render';
 
-interface RenderHookResult<Result, Props> {
+export interface RenderHookResult<Result, Props> {
   rerender: (props: Props) => void;
   result: { current: Result };
   unmount: () => void;
 }
 
-type RenderHookOptions<Props> = Props extends object | string | number | boolean
+export type RenderHookOptions<Props> = Props extends
+  | object
+  | string
+  | number
+  | boolean
   ? {
       initialProps: Props;
       wrapper?: ComponentType<any>;


### PR DESCRIPTION
### Summary

While writing helpers around the `render` and `renderHook` functions, I found myself wanting/needing the types for the options and the returns. This explicitly exports those types that weren't already exposed to avoid having to do something like the following:

```typescript
type RenderOptions = Parameters<typeof render>[1]
type RenderHookOptions = Parameters<typeof renderHook>[1]

// Copied/pasted from @testing-library/react-native
interface RenderHookResult<Result, Props> {
  result: {current: Result}
  rerender: (props: Props) => void
  unmount: () => void
}
```

These types are already documented, so this just fully exposes types that are already meant for users.

### Test plan

I'm not sure what additional tests would be needed for this. As long as type checking succeeds, these changes should be good.
