### PR TITLE
chore: update deps to expo 46

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -9,22 +9,22 @@
     "test": "jest"
   },
   "dependencies": {
-    "expo": "~45.0.0",
-    "expo-status-bar": "~1.3.0",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
-    "react-native": "0.68.2",
-    "react-native-web": "0.17.7"
+    "expo": "^46.0.0",
+    "expo-status-bar": "~1.4.0",
+    "react": "18.0.0",
+    "react-dom": "18.0.0",
+    "react-native": "0.69.4",
+    "react-native-web": "~0.18.7"
   },
   "devDependencies": {
-    "@babel/core": "^7.12.9",
-    "@testing-library/jest-native": "^4.0.5",
+    "@babel/core": "^7.18.6",
+    "@testing-library/jest-native": "^4.0.10",
     "@testing-library/react-native": "^11.0.0",
-    "@types/react": "~17.0.21",
-    "@types/react-native": "~0.67.6",
+    "@types/react": "~18.0.0",
+    "@types/react-native": "~0.69.1",
     "jest": "^28.0.0",
-    "react-test-renderer": "^17.0.2",
-    "typescript": "~4.3.5"
+    "react-test-renderer": "18.0.0",
+    "typescript": "^4.6.3"
   },
   "private": true
 }


### PR DESCRIPTION
### Summary

Update basic example app to use Expo 46. Should also fix running example apps due to "Jest not exited error"
 
### Test plan

All checks pass.