### PR TITLE
add tests to should not fire on non-editable TextInput getting by testID

### DIFF
--- a/src/__tests__/fireEvent.test.tsx
+++ b/src/__tests__/fireEvent.test.tsx
@@ -216,42 +216,28 @@ test('should not fire on disabled Pressable', () => {
   expect(handlePress).not.toHaveBeenCalled();
 });
 
-test('should not fire on non-editable TextInput', () => {
-  const placeholder = 'Test placeholder';
-  const onChangeTextMock = jest.fn();
-  const NEW_TEXT = 'New text';
-
-  const { getByPlaceholderText } = render(
-    <View>
-      <TextInput
-        editable={false}
-        placeholder={placeholder}
-        onChangeText={onChangeTextMock}
-      />
-    </View>
+test('should not fire on non-editable composite TextInput', () => {
+  const onChangeText = jest.fn();
+  const view = render(
+    <TextInput
+      editable={false}
+      placeholder="subject"
+      onChangeText={onChangeText}
+    />
   );
 
-  fireEvent.changeText(getByPlaceholderText(placeholder), NEW_TEXT);
-  expect(onChangeTextMock).not.toHaveBeenCalled();
+  fireEvent.changeText(view.getByPlaceholderText('subject'), 'new text');
+  expect(onChangeText).not.toHaveBeenCalled();
 });
 
-test('should not fire on non-editable TextInput getting by testID', () => {
-  const testID = 'my-text-input';
-  const onChangeTextMock = jest.fn();
-  const NEW_TEXT = 'New text';
-
-  const { getByTestId } = render(
-    <View>
-      <TextInput
-        editable={false}
-        testID={testID}
-        onChangeText={onChangeTextMock}
-      />
-    </View>
+test('should not fire on non-editable host TextInput', () => {
+  const onChangeText = jest.fn();
+  const view = render(
+    <TextInput editable={false} onChangeText={onChangeText} testID="subject" />
   );
 
-  fireEvent.changeText(getByTestId(testID), NEW_TEXT);
-  expect(onChangeTextMock).not.toHaveBeenCalled();
+  fireEvent.changeText(view.getByTestId('subject'), 'new text');
+  expect(onChangeText).not.toHaveBeenCalled();
 });
 
 test('should not fire on non-editable TextInput with nested Text', () => {

--- a/src/__tests__/fireEvent.test.tsx
+++ b/src/__tests__/fireEvent.test.tsx
@@ -235,6 +235,25 @@ test('should not fire on non-editable TextInput', () => {
   expect(onChangeTextMock).not.toHaveBeenCalled();
 });
 
+test('should not fire on non-editable TextInput getting by testID', () => {
+  const testID = 'my-text-input';
+  const onChangeTextMock = jest.fn();
+  const NEW_TEXT = 'New text';
+
+  const { getByTestId } = render(
+    <View>
+      <TextInput
+        editable={false}
+        testID={testID}
+        onChangeText={onChangeTextMock}
+      />
+    </View>
+  );
+
+  fireEvent.changeText(getByTestId(testID), NEW_TEXT);
+  expect(onChangeTextMock).not.toHaveBeenCalled();
+});
+
 test('should not fire on non-editable TextInput with nested Text', () => {
   const placeholder = 'Test placeholder';
   const onChangeTextMock = jest.fn();

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -7,9 +7,16 @@ const isHostElement = (element?: ReactTestInstance) => {
   return typeof element?.type === 'string';
 };
 
+// Rendering TextInput results in having composite `TextInput` component with
+// child text input host component. Both will have the same `editable` and
+// `onChangeText` props.
 const isTextInput = (element?: ReactTestInstance) => {
   const { TextInput } = require('react-native');
-  return element?.type === TextInput;
+
+  const isExportedCompositeTextInput = element?.type === TextInput;
+  const isChildHostTextInput = element?.parent?.type === TextInput;
+
+  return isExportedCompositeTextInput || isChildHostTextInput;
 };
 
 const isTouchResponder = (element?: ReactTestInstance) => {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

Add tests to simulate the problem related in issue #476 

If you get the component instance using `getByTestID` the `editable={false}` is ignored.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Just clone the repo and run `yarn test`.
