### PR TITLE
feature: export options types and renderHook result type

### DIFF
--- a/src/pure.ts
+++ b/src/pure.ts
@@ -1,15 +1,15 @@
 import act from './act';
 import cleanup from './cleanup';
 import fireEvent from './fireEvent';
-import render, { RenderResult } from './render';
+import render, { RenderResult, RenderOptions } from './render';
 import waitFor from './waitFor';
 import waitForElementToBeRemoved from './waitForElementToBeRemoved';
 import { within, getQueriesForElement } from './within';
 import { getDefaultNormalizer } from './matches';
-import { renderHook } from './renderHook';
+import { renderHook, RenderHookOptions, RenderHookResult } from './renderHook';
 import { screen } from './screen';
 
-export type { RenderResult };
+export type { RenderOptions, RenderResult };
 export type RenderAPI = RenderResult;
 
 export { act };
@@ -20,5 +20,5 @@ export { waitFor };
 export { waitForElementToBeRemoved };
 export { within, getQueriesForElement };
 export { getDefaultNormalizer };
-export { renderHook };
+export { renderHook, RenderHookOptions, RenderHookResult };
 export { screen };

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -1,16 +1,20 @@
 import act from './act';
 import cleanup from './cleanup';
 import fireEvent from './fireEvent';
-import render, { RenderResult, RenderOptions } from './render';
+import render from './render';
 import waitFor from './waitFor';
 import waitForElementToBeRemoved from './waitForElementToBeRemoved';
 import { within, getQueriesForElement } from './within';
 import { getDefaultNormalizer } from './matches';
-import { renderHook, RenderHookOptions, RenderHookResult } from './renderHook';
+import { renderHook } from './renderHook';
 import { screen } from './screen';
 
-export type { RenderOptions, RenderResult };
-export type RenderAPI = RenderResult;
+export type {
+  RenderOptions,
+  RenderResult,
+  RenderResult as RenderAPI,
+} from './render';
+export type { RenderHookOptions, RenderHookResult } from './renderHook';
 
 export { act };
 export { cleanup };
@@ -20,5 +24,5 @@ export { waitFor };
 export { waitForElementToBeRemoved };
 export { within, getQueriesForElement };
 export { getDefaultNormalizer };
-export { renderHook, RenderHookOptions, RenderHookResult };
+export { renderHook };
 export { screen };

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -12,6 +12,7 @@ export type RenderOptions = {
   wrapper?: React.ComponentType<any>;
   createNodeMock?: (element: React.ReactElement) => any;
 };
+
 type TestRendererOptions = {
   createNodeMock: (element: React.ReactElement) => any;
 };

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -8,7 +8,7 @@ import debugDeep from './helpers/debugDeep';
 import { getQueriesForElement } from './within';
 import { setRenderResult } from './screen';
 
-type Options = {
+export type RenderOptions = {
   wrapper?: React.ComponentType<any>;
   createNodeMock?: (element: React.ReactElement) => any;
 };
@@ -24,7 +24,7 @@ export type RenderResult = ReturnType<typeof render>;
  */
 export default function render<T>(
   component: React.ReactElement<T>,
-  { wrapper: Wrapper, createNodeMock }: Options = {}
+  { wrapper: Wrapper, createNodeMock }: RenderOptions = {}
 ) {
   const wrap = (innerElement: React.ReactElement) =>
     Wrapper ? <Wrapper>{innerElement}</Wrapper> : innerElement;

--- a/src/renderHook.tsx
+++ b/src/renderHook.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import type { ComponentType } from 'react';
 import render from './render';
 
-export interface RenderHookResult<Result, Props> {
+export type RenderHookResult<Result, Props> = {
   rerender: (props: Props) => void;
   result: { current: Result };
   unmount: () => void;
-}
+};
 
 export type RenderHookOptions<Props> = Props extends
   | object

--- a/src/renderHook.tsx
+++ b/src/renderHook.tsx
@@ -2,13 +2,17 @@ import React from 'react';
 import type { ComponentType } from 'react';
 import render from './render';
 
-interface RenderHookResult<Result, Props> {
+export interface RenderHookResult<Result, Props> {
   rerender: (props: Props) => void;
   result: { current: Result };
   unmount: () => void;
 }
 
-type RenderHookOptions<Props> = Props extends object | string | number | boolean
+export type RenderHookOptions<Props> = Props extends
+  | object
+  | string
+  | number
+  | boolean
   ? {
       initialProps: Props;
       wrapper?: ComponentType<any>;

--- a/typings/index.flow.js
+++ b/typings/index.flow.js
@@ -68,6 +68,7 @@ type WaitForOptions = {
   interval?: number,
   onTimeout?: (error: mixed) => Error,
 };
+
 type WaitForFunction = <T = any>(
   expectation: () => T,
   options?: WaitForOptions
@@ -289,11 +290,6 @@ interface Thenable {
   then: (resolve: () => any, reject?: () => any) => any;
 }
 
-interface RenderOptions {
-  wrapper?: React.ComponentType<any>;
-  createNodeMock?: (element: React.Element<any>) => any;
-}
-
 type Debug = {
   (message?: string): void,
   shallow: (message?: string) => void,
@@ -307,15 +303,6 @@ type Queries = ByTextQueries &
   UnsafeByPropsQueries &
   A11yAPI;
 
-interface RenderAPI extends Queries {
-  update(nextElement: React.Element<any>): void;
-  rerender(nextElement: React.Element<any>): void;
-  unmount(nextElement?: React.Element<any>): void;
-  toJSON(): ReactTestRendererJSON[] | ReactTestRendererJSON | null;
-  debug: Debug;
-  container: ReactTestInstance;
-}
-
 type FireEventFunction = (
   element: ReactTestInstance,
   eventName: string,
@@ -328,24 +315,29 @@ type FireEventAPI = FireEventFunction & {
   scroll: (element: ReactTestInstance, ...data: Array<any>) => any,
 };
 
-type RenderHookResult<Result, Props> = {
-  rerender: (props: Props) => void,
-  result: { current: Result },
-  unmount: () => void,
-};
-
-type RenderHookOptions<Props> = {
-  initialProps?: Props,
-  wrapper?: React.ComponentType<any>,
-};
-
 declare module '@testing-library/react-native' {
+  declare interface RenderResult extends Queries {
+    update(nextElement: React.Element<any>): void;
+    rerender(nextElement: React.Element<any>): void;
+    unmount(nextElement?: React.Element<any>): void;
+    toJSON(): ReactTestRendererJSON[] | ReactTestRendererJSON | null;
+    debug: Debug;
+    container: ReactTestInstance;
+  }
+
+  declare type RenderAPI = RenderResult;
+
+  declare interface RenderOptions {
+    wrapper?: React.ComponentType<any>;
+    createNodeMock?: (element: React.Element<any>) => any;
+  }
+
   declare export var render: (
     component: React.Element<any>,
     options?: RenderOptions
-  ) => RenderAPI;
+  ) => RenderResult;
 
-  declare export var screen: RenderAPI;
+  declare export var screen: RenderResult;
 
   declare export var cleanup: () => void;
   declare export var fireEvent: FireEventAPI;
@@ -368,6 +360,17 @@ declare module '@testing-library/react-native' {
   declare export var getDefaultNormalizer: (
     normalizerConfig?: NormalizerConfig
   ) => NormalizerFn;
+
+  declare type RenderHookResult<Result, Props> = {
+    rerender: (props: Props) => void,
+    result: { current: Result },
+    unmount: () => void,
+  };
+
+  declare type RenderHookOptions<Props> = {
+    initialProps?: Props,
+    wrapper?: React.ComponentType<any>,
+  };
 
   declare type RenderHookFunction = <Result, Props>(
     renderCallback: (props: Props) => Result,


### PR DESCRIPTION
Resubmitting #1034 as almost done but have to write access to forked PR-repo and OP @evanwalsh is not responsive.

Original description below:

## Summary
While writing helpers around the render and renderHook functions, I found myself wanting/needing the types for the options and the returns. This explicitly exports those types that weren't already exposed to avoid having to do something like the following:
```ts
type RenderOptions = Parameters<typeof render>[1]
type RenderHookOptions = Parameters<typeof renderHook>[1]

// Copied/pasted from @testing-library/react-native
interface RenderHookResult<Result, Props> {
  result: {current: Result}
  rerender: (props: Props) => void
  unmount: () => void
}
```
These types are already documented, so this just fully exposes types that are already meant for users.

## Test plan
I'm not sure what additional tests would be needed for this. As long as type checking succeeds, these changes should be good.
