### PR TITLE
fix: prevent non editable textinputs from being updated through getByTestID

### DIFF
--- a/src/__tests__/fireEvent.test.tsx
+++ b/src/__tests__/fireEvent.test.tsx
@@ -235,6 +235,24 @@ test('should not fire on non-editable TextInput', () => {
   expect(onChangeTextMock).not.toHaveBeenCalled();
 });
 
+test('should not fire on non-editable TextInput getting by testID', () => {
+  const testID = 'my-text-input';
+  const onChangeTextMock = jest.fn();
+  const NEW_TEXT = 'New text';
+
+  const { getByTestId } = render(
+    <TextInput
+      editable={false}
+      testID={testID}
+      onChangeText={onChangeTextMock}
+      placeholder="placeholder"
+    />
+  );
+
+  fireEvent.changeText(getByTestId(testID), NEW_TEXT);
+  expect(onChangeTextMock).not.toHaveBeenCalled();
+});
+
 test('should not fire on non-editable TextInput with nested Text', () => {
   const placeholder = 'Test placeholder';
   const onChangeTextMock = jest.fn();

--- a/src/__tests__/fireEvent.test.tsx
+++ b/src/__tests__/fireEvent.test.tsx
@@ -235,7 +235,7 @@ test('should not fire on non-editable TextInput', () => {
   expect(onChangeTextMock).not.toHaveBeenCalled();
 });
 
-test('should not fire on non-editable TextInput getting by testID', () => {
+test('should not fire on non-editable host TextInput, () => {
   const testID = 'my-text-input';
   const onChangeTextMock = jest.fn();
   const NEW_TEXT = 'New text';

--- a/src/__tests__/fireEvent.test.tsx
+++ b/src/__tests__/fireEvent.test.tsx
@@ -235,7 +235,7 @@ test('should not fire on non-editable TextInput', () => {
   expect(onChangeTextMock).not.toHaveBeenCalled();
 });
 
-test('should not fire on non-editable host TextInput, () => {
+test('should not fire on non-editable host TextInput', () => {
   const testID = 'my-text-input';
   const onChangeTextMock = jest.fn();
   const NEW_TEXT = 'New text';

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -1,5 +1,6 @@
 import { ReactTestInstance } from 'react-test-renderer';
 import act from './act';
+import { filterNodeByType } from './helpers/filterNodeByType';
 
 type EventHandler = (...args: any) => unknown;
 
@@ -8,8 +9,15 @@ const isHostElement = (element?: ReactTestInstance) => {
 };
 
 const isTextInput = (element?: ReactTestInstance) => {
+  if (!element) {
+    return false;
+  }
+
   const { TextInput } = require('react-native');
-  return element?.type === TextInput;
+  return (
+    filterNodeByType(element, TextInput) ||
+    filterNodeByType(element, 'TextInput')
+  );
 };
 
 const isTouchResponder = (element?: ReactTestInstance) => {

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -14,6 +14,12 @@ const isTextInput = (element?: ReactTestInstance) => {
   }
 
   const { TextInput } = require('react-native');
+  // We have to test if the element type is either the TextInput component
+  // (which would if it is a composite component) or the string
+  // TextInput (which would be true if it is a host component)
+  // All queries but the one by testID return composite component and event
+  // if all queries returned host components, since fireEvent bubbles up
+  // it would trigger the parent prop without the composite component check
   return (
     filterNodeByType(element, TextInput) ||
     filterNodeByType(element, 'TextInput')

--- a/src/helpers/filterNodeByType.ts
+++ b/src/helpers/filterNodeByType.ts
@@ -3,5 +3,5 @@ import * as React from 'react';
 
 export const filterNodeByType = (
   node: ReactTestInstance | React.ReactElement,
-  type: React.ElementType
+  type: React.ElementType | string
 ) => node.type === type;


### PR DESCRIPTION


<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Related to issue #476 

It is possible to modify non editable TextInputs when querying them with a testID because the testID queries return host components whose type is of type string, therefore isTextInput is always returning false. This fixes it by checking in isTextInput if the type is either the component TextInput or the string TextInput.  

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

Added a test case to check non editable text inputs cannot be changed when queried by testID

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
