### PR TITLE
chore: add test to ensure it is possible to trigger native event

### DIFF
--- a/src/__tests__/fireEvent.test.tsx
+++ b/src/__tests__/fireEvent.test.tsx
@@ -475,3 +475,53 @@ test('has only onMove', () => {
   });
   expect(handleDrag).toHaveBeenCalled();
 });
+
+// Those events ideally should be triggered through `fireEvent.scroll`, but they are handled at the
+// native level, so we need to support manually triggering them
+describe('native events', () => {
+  test('triggers onScrollBeginDrag', () => {
+    const onScrollBeginDragSpy = jest.fn();
+    const { getByTestId } = render(
+      <ScrollView testID="test-id" onScrollBeginDrag={onScrollBeginDragSpy} />
+    );
+
+    fireEvent(getByTestId('test-id'), 'onScrollBeginDrag');
+    expect(onScrollBeginDragSpy).toHaveBeenCalled();
+  });
+
+  test('triggers onScrollEndDrag', () => {
+    const onScrollEndDragSpy = jest.fn();
+    const { getByTestId } = render(
+      <ScrollView testID="test-id" onScrollEndDrag={onScrollEndDragSpy} />
+    );
+
+    fireEvent(getByTestId('test-id'), 'onScrollEndDrag');
+    expect(onScrollEndDragSpy).toHaveBeenCalled();
+  });
+
+  test('triggers onMomentumScrollBegin', () => {
+    const onMomentumScrollBeginSpy = jest.fn();
+    const { getByTestId } = render(
+      <ScrollView
+        testID="test-id"
+        onMomentumScrollBegin={onMomentumScrollBeginSpy}
+      />
+    );
+
+    fireEvent(getByTestId('test-id'), 'onMomentumScrollBegin');
+    expect(onMomentumScrollBeginSpy).toHaveBeenCalled();
+  });
+
+  test('triggers onMomentumScrollEnd', () => {
+    const onMomentumScrollEndSpy = jest.fn();
+    const { getByTestId } = render(
+      <ScrollView
+        testID="test-id"
+        onMomentumScrollEnd={onMomentumScrollEndSpy}
+      />
+    );
+
+    fireEvent(getByTestId('test-id'), 'onMomentumScrollEnd');
+    expect(onMomentumScrollEndSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This PR adds tests for a behaviour we support (triggering event that don't exist on the JS side but are handled natively). It is however not tested, so I want to add test to make sure we don't lose this feature by mistake (see discussions in https://github.com/callstack/react-native-testing-library/pull/1080#issuecomment-1241207946). 