### PR TITLE
feature: configure API from DTL

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -8,12 +8,12 @@ test('getConfig() returns existing configuration', () => {
   expect(getConfig().asyncUtilTimeout).toEqual(1000);
 });
 
-test('configure() overrides existing values', () => {
+test('configure() overrides existing config values', () => {
   configure({ asyncUtilTimeout: 5000 });
   expect(getConfig().asyncUtilTimeout).toEqual(5000);
 });
 
-test('resetToDefaults() resets to defaults', () => {
+test('resetToDefaults() resets config to defaults', () => {
   configure({ asyncUtilTimeout: 5000 });
   expect(getConfig().asyncUtilTimeout).toEqual(5000);
 

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,0 +1,22 @@
+import { getConfig, configure, resetToDefaults } from '../config';
+
+beforeEach(() => {
+  resetToDefaults();
+});
+
+test('getConfig() returns existing configuration', () => {
+  expect(getConfig().asyncUtilTimeout).toEqual(1000);
+});
+
+test('configure() overrides existing values', () => {
+  configure({ asyncUtilTimeout: 5000 });
+  expect(getConfig().asyncUtilTimeout).toEqual(5000);
+});
+
+test('resetToDefaults() resets to defaults', () => {
+  configure({ asyncUtilTimeout: 5000 });
+  expect(getConfig().asyncUtilTimeout).toEqual(5000);
+
+  resetToDefaults();
+  expect(getConfig().asyncUtilTimeout).toEqual(1000);
+});

--- a/src/__tests__/waitFor.test.tsx
+++ b/src/__tests__/waitFor.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Text, TouchableOpacity, View, Pressable } from 'react-native';
+import { Text, TouchableOpacity, View } from 'react-native';
 import { fireEvent, render, waitFor, configure, resetToDefaults } from '..';
 
 class Banana extends React.Component<any> {

--- a/src/__tests__/waitFor.test.tsx
+++ b/src/__tests__/waitFor.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import { Text, TouchableOpacity, View, Pressable } from 'react-native';
 import { fireEvent, render, waitFor, configure, resetToDefaults } from '..';
 
 class Banana extends React.Component<any> {
@@ -42,6 +42,18 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
+test('waits for element until it stops throwing', async () => {
+  const { getByText, queryByText } = render(<BananaContainer />);
+
+  fireEvent.press(getByText('Change freshness!'));
+
+  expect(queryByText('Fresh')).toBeNull();
+
+  const freshBananaText = await waitFor(() => getByText('Fresh'));
+
+  expect(freshBananaText.props.children).toBe('Fresh');
+});
+
 test('waits for element until timeout is met', async () => {
   const { getByText } = render(<BananaContainer />);
 
@@ -81,3 +93,136 @@ test('waitFor timeout option takes precendence over `asyncWaitTimeout` config op
   // for the remaining async actions to finish
   await waitFor(() => getByText('Fresh'));
 });
+
+test('waits for element with custom interval', async () => {
+  const mockFn = jest.fn(() => {
+    throw Error('test');
+  });
+
+  try {
+    await waitFor(() => mockFn(), { timeout: 400, interval: 200 });
+  } catch (e) {
+    // suppress
+  }
+
+  expect(mockFn).toHaveBeenCalledTimes(2);
+});
+
+// this component is convoluted on purpose. It is not a good react pattern, but it is valid
+// react code that will run differently between different react versions (17 and 18), so we need
+// explicit tests for it
+const Comp = ({ onPress }: { onPress: () => void }) => {
+  const [state, setState] = React.useState(false);
+
+  React.useEffect(() => {
+    if (state) {
+      onPress();
+    }
+  }, [state, onPress]);
+
+  return (
+    <Pressable
+      onPress={async () => {
+        await Promise.resolve();
+        setState(true);
+      }}
+    >
+      <Text>Trigger</Text>
+    </Pressable>
+  );
+};
+
+test('waits for async event with fireEvent', async () => {
+  const spy = jest.fn();
+  const { getByText } = render(<Comp onPress={spy} />);
+
+  fireEvent.press(getByText('Trigger'));
+
+  await waitFor(() => {
+    expect(spy).toHaveBeenCalled();
+  });
+});
+
+test.each([false, true])(
+  'waits for element until it stops throwing using fake timers (legacyFakeTimers = %s)',
+  async (legacyFakeTimers) => {
+    jest.useFakeTimers({ legacyFakeTimers });
+    const { getByText, queryByText } = render(<BananaContainer />);
+
+    fireEvent.press(getByText('Change freshness!'));
+    expect(queryByText('Fresh')).toBeNull();
+
+    jest.advanceTimersByTime(300);
+    const freshBananaText = await waitFor(() => getByText('Fresh'));
+
+    expect(freshBananaText.props.children).toBe('Fresh');
+  }
+);
+
+test.each([false, true])(
+  'waits for assertion until timeout is met with fake timers (legacyFakeTimers = %s)',
+  async (legacyFakeTimers) => {
+    jest.useFakeTimers({ legacyFakeTimers });
+
+    const mockFn = jest.fn(() => {
+      throw Error('test');
+    });
+
+    try {
+      await waitFor(() => mockFn(), { timeout: 400, interval: 200 });
+    } catch (error) {
+      // suppress
+    }
+
+    expect(mockFn).toHaveBeenCalledTimes(3);
+  }
+);
+
+test.each([false, true])(
+  'waits for assertion until timeout is met with fake timers (legacyFakeTimers = %s)',
+  async (legacyFakeTimers) => {
+    jest.useFakeTimers({ legacyFakeTimers });
+
+    const mockErrorFn = jest.fn(() => {
+      throw Error('test');
+    });
+
+    const mockHandleFn = jest.fn((e) => e);
+
+    try {
+      await waitFor(() => mockErrorFn(), {
+        timeout: 400,
+        interval: 200,
+        onTimeout: mockHandleFn,
+      });
+    } catch (error) {
+      // suppress
+    }
+
+    expect(mockErrorFn).toHaveBeenCalledTimes(3);
+    expect(mockHandleFn).toHaveBeenCalledTimes(1);
+  }
+);
+
+test.each([false, true])(
+  'awaiting something that succeeds before timeout works with fake timers (legacyFakeTimers = %s)',
+  async (legacyFakeTimers) => {
+    jest.useFakeTimers({ legacyFakeTimers });
+
+    let calls = 0;
+    const mockFn = jest.fn(() => {
+      calls += 1;
+      if (calls < 3) {
+        throw Error('test');
+      }
+    });
+
+    try {
+      await waitFor(() => mockFn(), { timeout: 400, interval: 200 });
+    } catch (error) {
+      // suppress
+    }
+
+    expect(mockFn).toHaveBeenCalledTimes(3);
+  }
+);

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,7 @@ export function configure(options: Partial<Config>) {
   };
 }
 
-export function resetToDefault() {
+export function resetToDefaults() {
   config = defaultConfig;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,27 @@
+export type Config = {
+  /** Default timeout, in ms, for `waitFor` and `findBy*` queries. */
+  asyncUtilTimeout: number;
+};
+
+const defaultConfig: Config = {
+  asyncUtilTimeout: 1000,
+};
+
+let config = {
+  ...defaultConfig,
+};
+
+export function configure(options: Partial<Config>) {
+  config = {
+    ...config,
+    ...options,
+  };
+}
+
+export function resetToDefault() {
+  config = defaultConfig;
+}
+
+export function getConfig() {
+  return config;
+}

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -16,9 +16,11 @@ export type {
   RenderResult as RenderAPI,
 } from './render';
 export type { RenderHookOptions, RenderHookResult } from './renderHook';
+export type { Config } from './config';
 
 export { act };
 export { cleanup };
+export { configure, resetToDefault } from './config';
 export { fireEvent };
 export { render };
 export { waitFor };

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -20,7 +20,7 @@ export type { Config } from './config';
 
 export { act };
 export { cleanup };
-export { configure, resetToDefault } from './config';
+export { configure, resetToDefaults } from './config';
 export { fireEvent };
 export { render };
 export { waitFor };

--- a/src/waitFor.ts
+++ b/src/waitFor.ts
@@ -1,5 +1,6 @@
 /* globals jest */
 import act, { setReactActEnvironment, getIsReactActEnvironment } from './act';
+import { getConfig } from './config';
 import { ErrorWithStack, copyStackTrace } from './helpers/errors';
 import {
   setTimeout,
@@ -9,7 +10,6 @@ import {
 } from './helpers/timers';
 import { checkReactVersionAtLeast } from './react-versions';
 
-const DEFAULT_TIMEOUT = 1000;
 const DEFAULT_INTERVAL = 50;
 
 export type WaitForOptions = {
@@ -22,7 +22,7 @@ export type WaitForOptions = {
 function waitForInternal<T>(
   expectation: () => T,
   {
-    timeout = DEFAULT_TIMEOUT,
+    timeout = getConfig().asyncUtilTimeout,
     interval = DEFAULT_INTERVAL,
     stackTraceError,
     onTimeout,

--- a/typings/index.flow.js
+++ b/typings/index.flow.js
@@ -367,6 +367,13 @@ declare module '@testing-library/react-native' {
 
   declare export var waitForElementToBeRemoved: WaitForElementToBeRemovedFunction;
 
+  declare interface Config {
+    asyncUtilTimeout: number;
+  }
+
+  declare export var configure: (options: $Shape<Config>) => void;
+  declare export var resetToDefaults: () => void;
+
   declare export var act: (callback: () => void) => Thenable;
   declare export var within: (instance: ReactTestInstance) => Queries;
   declare export var getQueriesForElement: (

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -45,6 +45,10 @@ title: API
   - [Examples](#examples)
     - [With `initialProps`](#with-initialprops)
     - [With `wrapper`](#with-wrapper)
+- [Configuration](#configuration)
+  - [`configure`](#configure)
+    - [`asyncUtilTimeout` option](#asyncutiltimeout-option)
+  - [`resetToDefaults()`](#resettodefaults)
 - [Accessibility](#accessibility)
   - [`isInaccessible`](#isinaccessible)
 
@@ -712,6 +716,30 @@ it('should use context value', () => {
   const { result } = renderHook(() => useHook(), { wrapper: Wrapper });
   // ...
 });
+```
+
+
+## Configuration
+
+### `configure`
+
+```ts
+type Config = {
+  asyncUtilTimeout: number;
+};
+
+function configure(options: Partial<Config>)  {}
+```
+
+#### `asyncUtilTimeout` option
+
+Default timeout, in ms, for async helper functions (`waitFor`, `waitForElementToBeRemoved`) and `findBy*` queries.
+
+
+### `resetToDefaults()`
+
+```ts
+function resetToDefaults() {}
 ```
 
 ## Accessibility

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -733,7 +733,7 @@ function configure(options: Partial<Config>)  {}
 
 #### `asyncUtilTimeout` option
 
-Default timeout, in ms, for async helper functions (`waitFor`, `waitForElementToBeRemoved`) and `findBy*` queries.
+Default timeout, in ms, for async helper functions (`waitFor`, `waitForElementToBeRemoved`) and `findBy*` queries. Defaults to 1000 ms.
 
 
 ### `resetToDefaults()`


### PR DESCRIPTION
### Summary

Implement `configure` API based on [similar API in DTL](https://testing-library.com/docs/dom-testing-library/api-configuration).

Added initial option for [`asyncWaitTimeout`](https://testing-library.com/docs/dom-testing-library/api-configuration/#asyncutiltimeout).

### Test plan

* Added tests for `config` module functions
* Added tests for `waitFor` consuming `asyncWaitTimeout` option