### PR TITLE
fix: do not use a real timeout in waitfor when using fake timers

### DIFF
--- a/src/__tests__/waitFor.test.tsx
+++ b/src/__tests__/waitFor.test.tsx
@@ -236,9 +236,9 @@ test.each([true, false])(
         })
     ).rejects.toThrow();
 
-    // Verify that even though time to perform check is longer than interval
-    // test won't timeout until number of checks * interval >= timeout
-    // i.e. fake timers have been advanced (at least?) by timeout when waitFor rejects
+    // Verify that the `waitFor` callback has been called the expected number of times
+    // (timeout / interval + 1), so it confirms that the real duration of callback did not
+    // cause the real clock timeout when running using fake timers.
     expect(mockErrorFn).toHaveBeenCalledTimes(
       WAIT_FOR_TIMEOUT / WAIT_FOR_INTERVAL + 1
     );

--- a/src/__tests__/waitFor.test.tsx
+++ b/src/__tests__/waitFor.test.tsx
@@ -221,15 +221,15 @@ test.each([true, false])(
     jest.useFakeTimers({ legacyFakeTimers });
 
     const mockErrorFn = jest.fn(() => {
-      // Wait 10 seconds so that check time is longer than interval
-      blockThread(10, legacyFakeTimers);
+      // Wait 5 seconds so that check time is longer than interval
+      blockThread(5, legacyFakeTimers);
       throw new Error('test');
     });
 
     try {
       await waitFor(() => mockErrorFn(), {
-        timeout: 200,
-        interval: 5,
+        timeout: 6,
+        interval: 2,
       });
     } catch (e) {
       // do nothing
@@ -238,7 +238,7 @@ test.each([true, false])(
     // Verify that even though time to perform check is longer than interval
     // test won't timeout until number of checks * interval >= timeout
     // ie fake timers have been advanced by timeout when waitfor rejects
-    expect(mockErrorFn).toHaveBeenCalledTimes(41);
+    expect(mockErrorFn).toHaveBeenCalledTimes(4);
   }
 );
 

--- a/src/__tests__/waitFor.test.tsx
+++ b/src/__tests__/waitFor.test.tsx
@@ -221,7 +221,7 @@ test.each([true, false])(
     jest.useFakeTimers({ legacyFakeTimers });
 
     const mockErrorFn = jest.fn(() => {
-      // Wait 5 seconds so that check time is longer than interval
+      // Wait 5 ms so that check time is longer than interval
       blockThread(5, legacyFakeTimers);
       throw new Error('test');
     });

--- a/src/__tests__/waitFor.test.tsx
+++ b/src/__tests__/waitFor.test.tsx
@@ -226,14 +226,13 @@ test.each([true, false])(
       throw new Error('test');
     });
 
-    try {
-      await waitFor(() => mockErrorFn(), {
-        timeout: 6,
-        interval: 2,
-      });
-    } catch (e) {
-      // do nothing
-    }
+    await expect(
+      async () =>
+        await waitFor(() => mockErrorFn(), {
+          timeout: 6,
+          interval: 2,
+        })
+    ).rejects.toThrow();
 
     // Verify that even though time to perform check is longer than interval
     // test won't timeout until number of checks * interval >= timeout

--- a/src/__tests__/waitFor.test.tsx
+++ b/src/__tests__/waitFor.test.tsx
@@ -219,25 +219,29 @@ test.each([true, false])(
   'it should not depend on real time when using fake timers (legacyFakeTimers = %s)',
   async (legacyFakeTimers) => {
     jest.useFakeTimers({ legacyFakeTimers });
+    const WAIT_FOR_INTERVAL = 20;
+    const WAIT_FOR_TIMEOUT = WAIT_FOR_INTERVAL * 5;
 
     const mockErrorFn = jest.fn(() => {
-      // Wait 5 ms so that check time is longer than interval
-      blockThread(5, legacyFakeTimers);
+      // Wait 2 times interval so that check time is longer than interval
+      blockThread(WAIT_FOR_INTERVAL * 2, legacyFakeTimers);
       throw new Error('test');
     });
 
     await expect(
       async () =>
         await waitFor(() => mockErrorFn(), {
-          timeout: 6,
-          interval: 2,
+          timeout: WAIT_FOR_TIMEOUT,
+          interval: WAIT_FOR_INTERVAL,
         })
     ).rejects.toThrow();
 
     // Verify that even though time to perform check is longer than interval
     // test won't timeout until number of checks * interval >= timeout
     // ie fake timers have been advanced by timeout when waitfor rejects
-    expect(mockErrorFn).toHaveBeenCalledTimes(4);
+    expect(mockErrorFn).toHaveBeenCalledTimes(
+      WAIT_FOR_TIMEOUT / WAIT_FOR_INTERVAL + 1
+    );
   }
 );
 

--- a/src/__tests__/waitFor.test.tsx
+++ b/src/__tests__/waitFor.test.tsx
@@ -230,7 +230,7 @@ test.each([true, false])(
 
     await expect(
       async () =>
-        await waitFor(() => mockErrorFn(), {
+        await waitFor(mockErrorFn, {
           timeout: WAIT_FOR_TIMEOUT,
           interval: WAIT_FOR_INTERVAL,
         })
@@ -238,7 +238,7 @@ test.each([true, false])(
 
     // Verify that even though time to perform check is longer than interval
     // test won't timeout until number of checks * interval >= timeout
-    // ie fake timers have been advanced by timeout when waitfor rejects
+    // i.e. fake timers have been advanced (at least?) by timeout when waitFor rejects
     expect(mockErrorFn).toHaveBeenCalledTimes(
       WAIT_FOR_TIMEOUT / WAIT_FOR_INTERVAL + 1
     );

--- a/src/__tests__/waitFor.test.tsx
+++ b/src/__tests__/waitFor.test.tsx
@@ -204,6 +204,37 @@ test.each([false, true])(
   }
 );
 
+const fibonaci = (n: number): number => {
+  if (n === 0 || n === 1) {
+    return 1;
+  }
+
+  return fibonaci(n - 1) + fibonaci(n - 2);
+};
+
+test.each([false, true])(
+  'it should not depend on real time when using fake timers (legacyFakeTimers = %s)',
+  async () => {
+    jest.useFakeTimers({ legacyFakeTimers: false });
+
+    const mockErrorFn = jest.fn(() => {
+      fibonaci(30);
+      throw new Error('test');
+    });
+
+    try {
+      await waitFor(() => mockErrorFn(), {
+        timeout: 200,
+        interval: 5,
+      });
+    } catch (error) {
+      // suppress
+    }
+
+    expect(mockErrorFn).toHaveBeenCalledTimes(41);
+  }
+);
+
 test.each([false, true])(
   'awaiting something that succeeds before timeout works with fake timers (legacyFakeTimers = %s)',
   async (legacyFakeTimers) => {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes #1176 

Use a timeout in waitFor only when using realTimers and timeout with fake timers only after fakeTimeRemaining is over

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

I added a test case that initially failed. I compute fibonaci suite so that it takes some time to perform the checks (it must take longer than interval for this bug to be visible)

This shouldn't be a breaking change, all tests that previously passed should still do because we're not performing any check after fakeTimeRemaining is over anyway

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
