### PR TITLE
fix: update render flow type with new option unstable_validateStringsRenderedWithinText

### DIFF
--- a/typings/index.flow.js
+++ b/typings/index.flow.js
@@ -346,6 +346,7 @@ declare module '@testing-library/react-native' {
   declare interface RenderOptions {
     wrapper?: React.ComponentType<any>;
     createNodeMock?: (element: React.Element<any>) => any;
+    unstable_validateStringsRenderedWithinText?: boolean;
   }
 
   declare export var render: (


### PR DESCRIPTION


<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Adds new option unstable_validateStringsRenderedWithinText to renderOptions type in flow types

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

I don't know how to test flow types, is there a recommended way to do so ? 

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
