### PR TITLE
feat: check accessibilityLabelledBy in *ByLabelText queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,9 @@
   },
   "jest": {
     "preset": "./jest-preset",
-    "setupFilesAfterEnv": ["./jest-setup.ts"],
+    "setupFilesAfterEnv": [
+      "./jest-setup.ts"
+    ],
     "testPathIgnorePatterns": [
       "timerUtils",
       "examples/"

--- a/src/helpers/matchers/matchLabelText.ts
+++ b/src/helpers/matchers/matchLabelText.ts
@@ -42,9 +42,10 @@ function matchAccessibilityLabelledBy(
   return (
     findAll(
       root,
-      (element) =>
-        element.props?.nativeID === nativeId &&
-        matchTextContent(element, text, options)
+      (node) =>
+        typeof node.type === 'string' &&
+        node.props?.nativeID === nativeId &&
+        matchTextContent(node, text, options)
     ).length > 0
   );
 }

--- a/src/helpers/matchers/matchLabelText.ts
+++ b/src/helpers/matchers/matchLabelText.ts
@@ -1,47 +1,50 @@
 import { ReactTestInstance } from 'react-test-renderer';
 import { matches, TextMatch, TextMatchOptions } from '../../matches';
+import { findAll } from '../findAll';
 import { matchTextContent } from './matchTextContent';
 
 export function matchLabelText(
-  rootInstance: ReactTestInstance,
-  node: ReactTestInstance,
+  root: ReactTestInstance,
+  element: ReactTestInstance,
   text: TextMatch,
   options: TextMatchOptions = {}
 ) {
   return (
-    matchAccessibilityLabel(node, text, options) ||
+    matchAccessibilityLabel(element, text, options) ||
     matchAccessibilityLabelledBy(
-      rootInstance,
-      node.props.accessibilityLabelledBy,
+      root,
+      element.props.accessibilityLabelledBy,
       text,
       options
     )
   );
 }
 
-export function matchAccessibilityLabel(
-  node: ReactTestInstance,
+function matchAccessibilityLabel(
+  element: ReactTestInstance,
   text: TextMatch,
   options: TextMatchOptions
 ) {
   const { exact, normalizer } = options;
-  return matches(text, node.props.accessibilityLabel, normalizer, exact);
+  return matches(text, element.props.accessibilityLabel, normalizer, exact);
 }
 
-export function matchAccessibilityLabelledBy(
-  rootInstance: ReactTestInstance,
-  nativeID: string | undefined,
+function matchAccessibilityLabelledBy(
+  root: ReactTestInstance,
+  nativeId: string | undefined,
   text: TextMatch,
   options: TextMatchOptions
 ) {
-  if (!nativeID) {
+  if (!nativeId) {
     return false;
   }
 
-  const { exact, normalizer } = options;
-  return rootInstance
-    .findAll((node) =>
-      matches(nativeID, node.props?.nativeID, normalizer, exact)
-    )
-    .some((node) => matchTextContent(node, text));
+  return (
+    findAll(
+      root,
+      (element) =>
+        element.props?.nativeID === nativeId &&
+        matchTextContent(element, text, options)
+    ).length > 0
+  );
 }

--- a/src/helpers/matchers/matchLabelText.ts
+++ b/src/helpers/matchers/matchLabelText.ts
@@ -1,0 +1,47 @@
+import { ReactTestInstance } from 'react-test-renderer';
+import { matches, TextMatch, TextMatchOptions } from '../../matches';
+import { matchTextContent } from './matchTextContent';
+
+export function matchLabelText(
+  rootInstance: ReactTestInstance,
+  node: ReactTestInstance,
+  text: TextMatch,
+  options: TextMatchOptions = {}
+) {
+  return (
+    matchAccessibilityLabel(node, text, options) ||
+    matchAccessibilityLabelledBy(
+      rootInstance,
+      node.props.accessibilityLabelledBy,
+      text,
+      options
+    )
+  );
+}
+
+export function matchAccessibilityLabel(
+  node: ReactTestInstance,
+  text: TextMatch,
+  options: TextMatchOptions
+) {
+  const { exact, normalizer } = options;
+  return matches(text, node.props.accessibilityLabel, normalizer, exact);
+}
+
+export function matchAccessibilityLabelledBy(
+  rootInstance: ReactTestInstance,
+  nativeID: string | undefined,
+  text: TextMatch,
+  options: TextMatchOptions
+) {
+  if (!nativeID) {
+    return false;
+  }
+
+  const { exact, normalizer } = options;
+  return rootInstance
+    .findAll((node) =>
+      matches(nativeID, node.props?.nativeID, normalizer, exact)
+    )
+    .some((node) => matchTextContent(node, text));
+}

--- a/src/helpers/matchers/matchLabelText.ts
+++ b/src/helpers/matchers/matchLabelText.ts
@@ -44,7 +44,7 @@ function matchAccessibilityLabelledBy(
       root,
       (node) =>
         typeof node.type === 'string' &&
-        node.props?.nativeID === nativeId &&
+        node.props.nativeID === nativeId &&
         matchTextContent(node, text, options)
     ).length > 0
   );

--- a/src/helpers/matchers/matchTextContent.ts
+++ b/src/helpers/matchers/matchTextContent.ts
@@ -6,6 +6,13 @@ import { filterNodeByType } from '../filterNodeByType';
 import { getTextContent } from '../getTextContent';
 import { getHostComponentNames } from '../host-component-names';
 
+/**
+ * Matches the given node's text content against string or regex matcher.
+ *
+ * @param node - Node which text content will be matched
+ * @param text - The string or regex to match.
+ * @returns - Whether the node's text content matches the given string or regex.
+ */
 export function matchTextContent(
   node: ReactTestInstance,
   text: TextMatch,

--- a/src/helpers/matchers/matchTextContent.ts
+++ b/src/helpers/matchers/matchTextContent.ts
@@ -1,10 +1,6 @@
-import { Text } from 'react-native';
 import type { ReactTestInstance } from 'react-test-renderer';
-import { getConfig } from '../../config';
 import { matches, TextMatch, TextMatchOptions } from '../../matches';
-import { filterNodeByType } from '../filterNodeByType';
 import { getTextContent } from '../getTextContent';
-import { getHostComponentNames } from '../host-component-names';
 
 /**
  * Matches the given node's text content against string or regex matcher.
@@ -18,13 +14,6 @@ export function matchTextContent(
   text: TextMatch,
   options: TextMatchOptions = {}
 ) {
-  const textType = getConfig().useBreakingChanges
-    ? getHostComponentNames().text
-    : Text;
-  if (!filterNodeByType(node, textType)) {
-    return false;
-  }
-
   const textContent = getTextContent(node);
   const { exact, normalizer } = options;
   return matches(text, textContent, normalizer, exact);

--- a/src/matches.ts
+++ b/src/matches.ts
@@ -8,7 +8,7 @@ export type TextMatchOptions = {
 
 export function matches(
   matcher: TextMatch,
-  text: string | undefined,
+  text: string,
   normalizer: NormalizerFn = getDefaultNormalizer(),
   exact: boolean = true
 ): boolean {

--- a/src/matches.ts
+++ b/src/matches.ts
@@ -8,7 +8,7 @@ export type TextMatchOptions = {
 
 export function matches(
   matcher: TextMatch,
-  text: string,
+  text: string | undefined,
   normalizer: NormalizerFn = getDefaultNormalizer(),
   exact: boolean = true
 ): boolean {

--- a/src/queries/__tests__/labelText.test.tsx
+++ b/src/queries/__tests__/labelText.test.tsx
@@ -170,6 +170,7 @@ test('getByLabelText supports accessibilityLabelledBy', async () => {
   const { getByLabelText, getByTestId } = render(
     <>
       <Text nativeID="label">Label for input</Text>
+      {/* @ts-expect-error: waiting for RN 0.71.2 to fix incorrectly omitted `accessibilityLabelledBy` typedef. */}
       <TextInput testID="textInput" accessibilityLabelledBy="label" />
     </>
   );
@@ -184,6 +185,7 @@ test('getByLabelText supports nested accessibilityLabelledBy', async () => {
       <View nativeID="label">
         <Text>Label for input</Text>
       </View>
+      {/* @ts-expect-error: waiting for RN 0.71.2 to fix incorrectly omitted `accessibilityLabelledBy` typedef. */}
       <TextInput testID="textInput" accessibilityLabelledBy="label" />
     </>
   );

--- a/src/queries/__tests__/labelText.test.tsx
+++ b/src/queries/__tests__/labelText.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, Text, TouchableOpacity, TextInput } from 'react-native';
+import { View, Text, TextInput, TouchableOpacity } from 'react-native';
 import { render } from '../..';
 
 const BUTTON_LABEL = 'cool button';
@@ -173,8 +173,9 @@ test('getByLabelText supports accessibilityLabelledBy', async () => {
       <TextInput testID="textInput" accessibilityLabelledBy="label" />
     </>
   );
-  expect(getByLabelText('Label for input')).toEqual(getByTestId('textInput'));
-  expect(getByLabelText(/input/)).toEqual(getByTestId('textInput'));
+
+  expect(getByLabelText('Label for input')).toBe(getByTestId('textInput'));
+  expect(getByLabelText(/input/)).toBe(getByTestId('textInput'));
 });
 
 test('getByLabelText supports nested accessibilityLabelledBy', async () => {
@@ -187,6 +188,6 @@ test('getByLabelText supports nested accessibilityLabelledBy', async () => {
     </>
   );
 
-  expect(getByLabelText('Label for input')).toEqual(getByTestId('textInput'));
-  expect(getByLabelText(/input/)).toEqual(getByTestId('textInput'));
+  expect(getByLabelText('Label for input')).toBe(getByTestId('textInput'));
+  expect(getByLabelText(/input/)).toBe(getByTestId('textInput'));
 });

--- a/src/queries/__tests__/labelText.test.tsx
+++ b/src/queries/__tests__/labelText.test.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import { View, Text, TouchableOpacity } from 'react-native';
+import { View, Text, TouchableOpacity, TextInput } from 'react-native';
 import { render } from '../..';
 
 const BUTTON_LABEL = 'cool button';
 const BUTTON_HINT = 'click this button';
 const TEXT_LABEL = 'cool text';
 const TEXT_HINT = 'static text';
+const INPUT_LABEL = 'cool input';
+const INPUT_LABELLED_BY = 'formLabel';
 // Little hack to make all the methods happy with type
 const NO_MATCHES_TEXT: any = 'not-existent-element';
 
@@ -38,6 +40,15 @@ const Section = () => (
       Title
     </Typography>
     <Button>{TEXT_LABEL}</Button>
+  </>
+);
+
+const FormInput = () => (
+  <>
+    <View nativeID={INPUT_LABELLED_BY}>
+      <Text>{INPUT_LABEL}</Text>
+    </View>
+    <TextInput accessibilityLabelledBy={INPUT_LABELLED_BY} />
   </>
 );
 
@@ -164,4 +175,13 @@ test('byLabelText queries support hidden option', () => {
   ).toThrowErrorMatchingInlineSnapshot(
     `"Unable to find an element with accessibilityLabel: hidden"`
   );
+});
+test('getByLabelText supports accessibilityLabelledBy', async () => {
+  const { getByLabelText, queryByLabelText } = render(<FormInput />);
+
+  expect(getByLabelText(INPUT_LABEL).props.accessibilityLabelledBy).toEqual(
+    INPUT_LABELLED_BY
+  );
+  const textInput = queryByLabelText(/input/g);
+  expect(textInput?.props.accessibilityLabelledBy).toEqual(INPUT_LABELLED_BY);
 });

--- a/src/queries/__tests__/labelText.test.tsx
+++ b/src/queries/__tests__/labelText.test.tsx
@@ -6,8 +6,6 @@ const BUTTON_LABEL = 'cool button';
 const BUTTON_HINT = 'click this button';
 const TEXT_LABEL = 'cool text';
 const TEXT_HINT = 'static text';
-const INPUT_LABEL = 'cool input';
-const INPUT_LABELLED_BY = 'formLabel';
 // Little hack to make all the methods happy with type
 const NO_MATCHES_TEXT: any = 'not-existent-element';
 
@@ -40,15 +38,6 @@ const Section = () => (
       Title
     </Typography>
     <Button>{TEXT_LABEL}</Button>
-  </>
-);
-
-const FormInput = () => (
-  <>
-    <View nativeID={INPUT_LABELLED_BY}>
-      <Text>{INPUT_LABEL}</Text>
-    </View>
-    <TextInput accessibilityLabelledBy={INPUT_LABELLED_BY} />
   </>
 );
 
@@ -176,12 +165,28 @@ test('byLabelText queries support hidden option', () => {
     `"Unable to find an element with accessibilityLabel: hidden"`
   );
 });
-test('getByLabelText supports accessibilityLabelledBy', async () => {
-  const { getByLabelText, queryByLabelText } = render(<FormInput />);
 
-  expect(getByLabelText(INPUT_LABEL).props.accessibilityLabelledBy).toEqual(
-    INPUT_LABELLED_BY
+test('getByLabelText supports accessibilityLabelledBy', async () => {
+  const { getByLabelText, getByTestId } = render(
+    <>
+      <Text nativeID="label">Label for input</Text>
+      <TextInput testID="textInput" accessibilityLabelledBy="label" />
+    </>
   );
-  const textInput = queryByLabelText(/input/g);
-  expect(textInput?.props.accessibilityLabelledBy).toEqual(INPUT_LABELLED_BY);
+  expect(getByLabelText('Label for input')).toEqual(getByTestId('textInput'));
+  expect(getByLabelText(/input/)).toEqual(getByTestId('textInput'));
+});
+
+test('getByLabelText supports nested accessibilityLabelledBy', async () => {
+  const { getByLabelText, getByTestId } = render(
+    <>
+      <View nativeID="label">
+        <Text>Label for input</Text>
+      </View>
+      <TextInput testID="textInput" accessibilityLabelledBy="label" />
+    </>
+  );
+
+  expect(getByLabelText('Label for input')).toEqual(getByTestId('textInput'));
+  expect(getByLabelText(/input/)).toEqual(getByTestId('textInput'));
 });

--- a/src/queries/__tests__/text.breaking.test.tsx
+++ b/src/queries/__tests__/text.breaking.test.tsx
@@ -510,6 +510,5 @@ test('byText support hidden option', () => {
 
 test('byText should return host component', () => {
   const { getByText } = render(<Text>hello</Text>);
-
   expect(getByText('hello').type).toBe('Text');
 });

--- a/src/queries/__tests__/text.test.tsx
+++ b/src/queries/__tests__/text.test.tsx
@@ -8,7 +8,6 @@ import {
   TextInput,
 } from 'react-native';
 import { render, getDefaultNormalizer, within } from '../..';
-import { getConfig } from '../../config';
 
 test('byText matches simple text', () => {
   const { getByText } = render(<Text testID="text">Hello World</Text>);
@@ -505,10 +504,6 @@ test('byText support hidden option', () => {
 });
 
 test('byText should return composite Text', () => {
-  const textType = getConfig().useBreakingChanges
-    ? getHostComponentNames().text
-    : Text;
-  console.log('BB', getConfig().useBreakingChanges, textType);
   const { getByText } = render(<Text>hello</Text>);
   expect(getByText('hello').type).toBe(Text);
 });

--- a/src/queries/__tests__/text.test.tsx
+++ b/src/queries/__tests__/text.test.tsx
@@ -8,6 +8,7 @@ import {
   TextInput,
 } from 'react-native';
 import { render, getDefaultNormalizer, within } from '../..';
+import { getConfig } from '../../config';
 
 test('byText matches simple text', () => {
   const { getByText } = render(<Text testID="text">Hello World</Text>);
@@ -504,7 +505,10 @@ test('byText support hidden option', () => {
 });
 
 test('byText should return composite Text', () => {
+  const textType = getConfig().useBreakingChanges
+    ? getHostComponentNames().text
+    : Text;
+  console.log('BB', getConfig().useBreakingChanges, textType);
   const { getByText } = render(<Text>hello</Text>);
-
   expect(getByText('hello').type).toBe(Text);
 });

--- a/src/queries/labelText.ts
+++ b/src/queries/labelText.ts
@@ -1,7 +1,7 @@
 import type { ReactTestInstance } from 'react-test-renderer';
 import { findAll } from '../helpers/findAll';
-import { matches, TextMatch, TextMatchOptions } from '../matches';
-import { matchTextContent } from '../helpers/matchers/matchTextContent';
+import { TextMatch, TextMatchOptions } from '../matches';
+import { matchLabelText } from '../helpers/matchers/matchLabelText';
 import { makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
@@ -15,66 +15,17 @@ import { CommonQueryOptions } from './options';
 
 type ByLabelTextOptions = CommonQueryOptions & TextMatchOptions;
 
-const getNodeByLabelText = (
-  node: ReactTestInstance,
-  text: TextMatch,
-  options: TextMatchOptions
-) => {
-  const { exact, normalizer } = options;
-  return matches(text, node.props.accessibilityLabel, normalizer, exact);
-};
-
-const matchAccessibilityLabelledByText = (
-  rootInstance: ReactTestInstance,
-  nativeID: string | undefined,
-  text: TextMatch,
-  options: TextMatchOptions
-) => {
-  if (!nativeID) {
-    return false;
-  }
-
-  const { exact, normalizer } = options;
-
-  return rootInstance
-    .findAll((node) =>
-      matches(nativeID, node.props?.nativeID, normalizer, exact)
-    )
-    .some((node) => node.findAll((n) => matchTextContent(n, text)).length > 0);
-};
-
-const matchAccessibilityLabel = (
-  rootInstance: ReactTestInstance,
-  node: ReactTestInstance,
-  text: TextMatch,
-  options: TextMatchOptions = {}
-) => {
-  return (
-    getNodeByLabelText(node, text, options) ||
-    matchAccessibilityLabelledByText(
-      rootInstance,
-      node.props.accessibilityLabelledBy,
-      text,
-      options
-    )
-  );
-};
-
-const queryAllByLabelText = (
-  instance: ReactTestInstance
-): ((
-  text: TextMatch,
-  queryOptions?: ByLabelTextOptions
-) => Array<ReactTestInstance>) =>
-  function queryAllByLabelTextFn(text, queryOptions) {
+function queryAllByLabelText(instance: ReactTestInstance) {
+  return (text: TextMatch, queryOptions?: ByLabelTextOptions) => {
     return findAll(
       instance,
       (node) =>
         typeof node.type === 'string' &&
-        matchAccessibilityLabel(instance, node, text, queryOptions),
+        matchLabelText(instance, node, text, queryOptions),
       queryOptions
     );
   };
+}
 
 const getMultipleError = (labelText: TextMatch) =>
   `Found multiple elements with accessibilityLabel: ${String(labelText)} `;

--- a/src/queries/labelText.ts
+++ b/src/queries/labelText.ts
@@ -1,8 +1,8 @@
 import type { ReactTestInstance } from 'react-test-renderer';
 import { findAll } from '../helpers/findAll';
 import { matches, TextMatch, TextMatchOptions } from '../matches';
+import { matchTextContent } from '../helpers/matchers/matchTextContent';
 import { makeQueries } from './makeQueries';
-import { getNodeByText } from './text';
 import type {
   FindAllByQuery,
   FindByQuery,
@@ -40,7 +40,7 @@ const matchAccessibilityLabelledByText = (
     .findAll((node) =>
       matches(nativeID, node.props.nativeID, normalizer, exact)
     )
-    .some((node) => node.findAll((n) => getNodeByText(n, text)).length > 0);
+    .some((node) => node.findAll((n) => matchTextContent(n, text)).length > 0);
 };
 
 const matchAccessibilityLabel = (

--- a/src/queries/labelText.ts
+++ b/src/queries/labelText.ts
@@ -38,7 +38,7 @@ const matchAccessibilityLabelledByText = (
 
   return rootInstance
     .findAll((node) =>
-      matches(nativeID, node.props.nativeID, normalizer, exact)
+      matches(nativeID, node.props?.nativeID, normalizer, exact)
     )
     .some((node) => node.findAll((n) => matchTextContent(n, text)).length > 0);
 };

--- a/src/queries/testId.ts
+++ b/src/queries/testId.ts
@@ -20,7 +20,7 @@ const getNodeByTestId = (
   options: TextMatchOptions = {}
 ) => {
   const { exact, normalizer } = options;
-  return matches(testID, node.props.testID, normalizer, exact);
+  return matches(testID, node.props?.testID, normalizer, exact);
 };
 
 const queryAllByTestId = (

--- a/src/queries/testId.ts
+++ b/src/queries/testId.ts
@@ -20,7 +20,7 @@ const getNodeByTestId = (
   options: TextMatchOptions = {}
 ) => {
   const { exact, normalizer } = options;
-  return matches(testID, node.props?.testID, normalizer, exact);
+  return matches(testID, node.props.testID, normalizer, exact);
 };
 
 const queryAllByTestId = (
@@ -30,13 +30,13 @@ const queryAllByTestId = (
   queryOptions?: ByTestIdOptions
 ) => Array<ReactTestInstance>) =>
   function queryAllByTestIdFn(testId, queryOptions) {
-    const results = findAll(
+    return findAll(
       instance,
-      (node) => getNodeByTestId(node, testId, queryOptions),
+      (node) =>
+        typeof node.type === 'string' &&
+        getNodeByTestId(node, testId, queryOptions),
       queryOptions
     );
-
-    return results.filter((element) => typeof element.type === 'string');
   };
 
 const getMultipleError = (testId: TextMatch) =>

--- a/src/queries/text.ts
+++ b/src/queries/text.ts
@@ -1,6 +1,6 @@
 import type { ReactTestInstance } from 'react-test-renderer';
 import { Text } from 'react-native';
-import { getConfig, resetToDefaults } from '../config';
+import { getConfig } from '../config';
 import {
   getCompositeParentOfType,
   isHostElementForType,

--- a/src/queries/text.ts
+++ b/src/queries/text.ts
@@ -21,10 +21,6 @@ import type {
 } from './makeQueries';
 import type { CommonQueryOptions } from './options';
 
-beforeEach(() => {
-  resetToDefaults();
-});
-
 type ByTextOptions = CommonQueryOptions & TextMatchOptions;
 
 const queryAllByText = (

--- a/src/queries/text.ts
+++ b/src/queries/text.ts
@@ -61,7 +61,6 @@ const queryAllByText = (
         matchDeepestOnly: true,
       }
     );
-
   };
 
 const getMultipleError = (text: TextMatch) =>

--- a/src/queries/text.ts
+++ b/src/queries/text.ts
@@ -1,6 +1,7 @@
 import type { ReactTestInstance } from 'react-test-renderer';
 import { Text } from 'react-native';
 import { findAll } from '../helpers/findAll';
+import { filterNodeByType } from '../helpers/filterNodeByType';
 import { matchTextContent } from '../helpers/matchers/matchTextContent';
 import { TextMatch, TextMatchOptions } from '../matches';
 import {
@@ -18,6 +19,7 @@ import type {
   QueryByQuery,
 } from './makeQueries';
 import type { CommonQueryOptions } from './options';
+import { getHostComponentNames } from '../helpers/host-component-names';
 
 type ByTextOptions = CommonQueryOptions & TextMatchOptions;
 
@@ -47,10 +49,19 @@ const queryAllByText = (
     }
 
     // vNext version: returns host Text
-    return findAll(instance, (node) => matchTextContent(node, text, options), {
-      ...options,
-      matchDeepestOnly: true,
-    });
+    const textType = getConfig().useBreakingChanges
+      ? getHostComponentNames().text
+      : Text;
+
+    return findAll(
+      instance,
+      (node) => node.type === textType && matchTextContent(node, text, options),
+      {
+        ...options,
+        matchDeepestOnly: true,
+      }
+    );
+
   };
 
 const getMultipleError = (text: TextMatch) =>

--- a/src/queries/text.ts
+++ b/src/queries/text.ts
@@ -1,14 +1,15 @@
 import type { ReactTestInstance } from 'react-test-renderer';
 import { Text } from 'react-native';
-import { findAll } from '../helpers/findAll';
-import { filterNodeByType } from '../helpers/filterNodeByType';
-import { matchTextContent } from '../helpers/matchers/matchTextContent';
-import { TextMatch, TextMatchOptions } from '../matches';
+import { getConfig, resetToDefaults } from '../config';
 import {
   getCompositeParentOfType,
   isHostElementForType,
 } from '../helpers/component-tree';
-import { getConfig } from '../config';
+import { filterNodeByType } from '../helpers/filterNodeByType';
+import { findAll } from '../helpers/findAll';
+import { getHostComponentNames } from '../helpers/host-component-names';
+import { matchTextContent } from '../helpers/matchers/matchTextContent';
+import { TextMatch, TextMatchOptions } from '../matches';
 import { makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
@@ -19,7 +20,10 @@ import type {
   QueryByQuery,
 } from './makeQueries';
 import type { CommonQueryOptions } from './options';
-import { getHostComponentNames } from '../helpers/host-component-names';
+
+beforeEach(() => {
+  resetToDefaults();
+});
 
 type ByTextOptions = CommonQueryOptions & TextMatchOptions;
 
@@ -41,7 +45,8 @@ const queryAllByText = (
 
       const results = findAll(
         baseInstance,
-        (node) => matchTextContent(node, text, options),
+        (node) =>
+          filterNodeByType(node, Text) && matchTextContent(node, text, options),
         { ...options, matchDeepestOnly: true }
       );
 
@@ -49,13 +54,11 @@ const queryAllByText = (
     }
 
     // vNext version: returns host Text
-    const textType = getConfig().useBreakingChanges
-      ? getHostComponentNames().text
-      : Text;
-
     return findAll(
       instance,
-      (node) => node.type === textType && matchTextContent(node, text, options),
+      (node) =>
+        filterNodeByType(node, getHostComponentNames().text) &&
+        matchTextContent(node, text, options),
       {
         ...options,
         matchDeepestOnly: true,

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -212,7 +212,10 @@ getByLabelText(
 ): ReactTestInstance;
 ```
 
-Returns a `ReactTestInstance` with matching `accessibilityLabel` prop.
+Returns a `ReactTestInstance` with matching label:
+
+- by matching `accessibilityLabel` prop
+- or by matching text content of text view referenced by `accessibilityLabelledBy` prop
 
 ```jsx
 import { render, screen } from '@testing-library/react-native';

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -213,9 +213,8 @@ getByLabelText(
 ```
 
 Returns a `ReactTestInstance` with matching label:
-
-- by matching `accessibilityLabel` prop
-- or by matching text content of text view referenced by `accessibilityLabelledBy` prop
+- either by matching [`accessibilityLabel`](https://reactnative.dev/docs/accessibility#accessibilitylabel) prop
+- or by matching text content of view referenced by [`accessibilityLabelledBy`](https://reactnative.dev/docs/accessibility#accessibilitylabelledby-android) prop
 
 ```jsx
 import { render, screen } from '@testing-library/react-native';


### PR DESCRIPTION
### Summary
Adds support for [accessibilityLabelledBy](https://reactnative.dev/docs/accessibility#accessibilitylabelledby-android) in `*ByLabelText` queries as in #1183.