### PR TITLE
feat: *ByRole a11y value option

### DIFF
--- a/src/helpers/__tests__/accessiblity.test.tsx
+++ b/src/helpers/__tests__/accessiblity.test.tsx
@@ -22,7 +22,7 @@ test('returns false for accessible elements', () => {
   ).toBe(false);
 });
 
-test('returns true for hidden elements', () => {
+test('returns true for null elements', () => {
   expect(isHiddenFromAccessibility(null)).toBe(true);
 });
 

--- a/src/helpers/accessiblity.ts
+++ b/src/helpers/accessiblity.ts
@@ -1,4 +1,8 @@
-import { AccessibilityState, StyleSheet } from 'react-native';
+import {
+  AccessibilityState,
+  AccessibilityValue,
+  StyleSheet,
+} from 'react-native';
 import { ReactTestInstance } from 'react-test-renderer';
 import { getHostSiblings } from './component-tree';
 
@@ -6,14 +10,19 @@ type IsInaccessibleOptions = {
   cache?: WeakMap<ReactTestInstance, boolean>;
 };
 
-export type AccessibilityStateKey = keyof AccessibilityState;
-
-export const accessibilityStateKeys: AccessibilityStateKey[] = [
+export const accessibilityStateKeys: (keyof AccessibilityState)[] = [
   'disabled',
   'selected',
   'checked',
   'busy',
   'expanded',
+];
+
+export const accessiblityValueKeys: (keyof AccessibilityValue)[] = [
+  'min',
+  'max',
+  'now',
+  'text',
 ];
 
 export function isHiddenFromAccessibility(

--- a/src/helpers/matchers/accessibilityValue.ts
+++ b/src/helpers/matchers/accessibilityValue.ts
@@ -14,7 +14,7 @@ export function matchAccessibilityValue(
   node: ReactTestInstance,
   matcher: AccessibilityValueMatcher
 ): boolean {
-  const value = (node.props.accessibilityValue ?? {}) as AccessibilityValue;
+  const value: AccessibilityValue = node.props.accessibilityValue ?? {};
   return (
     (matcher.min === undefined || matcher.min === value.min) &&
     (matcher.max === undefined || matcher.max === value.max) &&

--- a/src/helpers/matchers/accessibilityValue.ts
+++ b/src/helpers/matchers/accessibilityValue.ts
@@ -1,0 +1,24 @@
+import { AccessibilityValue } from 'react-native';
+import { ReactTestInstance } from 'react-test-renderer';
+import { TextMatch } from '../../matches';
+import { matchStringProp } from './matchStringProp';
+
+export interface AccessibilityValueMatcher {
+  min?: number;
+  max?: number;
+  now?: number;
+  text?: TextMatch;
+}
+
+export function matchAccessibilityValue(
+  node: ReactTestInstance,
+  matcher: AccessibilityValueMatcher
+): boolean {
+  const value = (node.props.accessibilityValue ?? {}) as AccessibilityValue;
+  return (
+    (matcher.min === undefined || matcher.min === value.min) &&
+    (matcher.max === undefined || matcher.max === value.max) &&
+    (matcher.now === undefined || matcher.now === value.now) &&
+    (matcher.text === undefined || matchStringProp(value.text, matcher.text))
+  );
+}

--- a/src/queries/__tests__/a11yValue.test.tsx
+++ b/src/queries/__tests__/a11yValue.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { TouchableOpacity, Text } from 'react-native';
+import { View, Text, TouchableOpacity } from 'react-native';
 import { render } from '../..';
 
 const TEXT_LABEL = 'cool text';
@@ -103,6 +103,30 @@ test('byA11yValue queries support hidden option', () => {
   expect(() =>
     getByA11yValue({ max: 10 }, { includeHiddenElements: false })
   ).toThrowErrorMatchingInlineSnapshot(
-    `"Unable to find an element with accessibilityValue: {"max":10}"`
+    `"Unable to find an element with max value: 10"`
+  );
+});
+
+test('byA11yValue error messages', () => {
+  const { getByA11yValue } = render(<View />);
+  expect(() =>
+    getByA11yValue({ min: 10, max: 10 })
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"Unable to find an element with min value: 10, max value: 10"`
+  );
+  expect(() =>
+    getByA11yValue({ max: 20, now: 5 })
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"Unable to find an element with max value: 20, now value: 5"`
+  );
+  expect(() =>
+    getByA11yValue({ min: 1, max: 2, now: 3 })
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"Unable to find an element with min value: 1, max value: 2, now value: 3"`
+  );
+  expect(() =>
+    getByA11yValue({ min: 1, max: 2, now: 3, text: /foo/i })
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"Unable to find an element with min value: 1, max value: 2, now value: 3, text value: /foo/i"`
   );
 });

--- a/src/queries/__tests__/a11yValue.test.tsx
+++ b/src/queries/__tests__/a11yValue.test.tsx
@@ -4,14 +4,6 @@ import { render } from '../..';
 
 const TEXT_LABEL = 'cool text';
 
-const getMultipleInstancesFoundMessage = (value: string) => {
-  return `Found multiple elements with accessibilityValue: ${value}`;
-};
-
-const getNoInstancesFoundMessage = (value: string) => {
-  return `Unable to find an element with accessibilityValue: ${value}`;
-};
-
 const Typography = ({ children, ...rest }: any) => {
   return <Text {...rest}>{children}</Text>;
 };
@@ -46,15 +38,15 @@ test('getByA11yValue, queryByA11yValue, findByA11yValue', async () => {
   });
 
   expect(() => getByA11yValue({ min: 50 })).toThrow(
-    getNoInstancesFoundMessage('{"min":50}')
+    'Unable to find an element with min value: 50'
   );
   expect(queryByA11yValue({ min: 50 })).toEqual(null);
 
   expect(() => getByA11yValue({ max: 60 })).toThrow(
-    getMultipleInstancesFoundMessage('{"max":60}')
+    'Found multiple elements with max value: 60'
   );
   expect(() => queryByA11yValue({ max: 60 })).toThrow(
-    getMultipleInstancesFoundMessage('{"max":60}')
+    'Found multiple elements with max value: 60'
   );
 
   const asyncElement = await findByA11yValue({ min: 40 });
@@ -63,10 +55,10 @@ test('getByA11yValue, queryByA11yValue, findByA11yValue', async () => {
     max: 60,
   });
   await expect(findByA11yValue({ min: 50 })).rejects.toThrow(
-    getNoInstancesFoundMessage('{"min":50}')
+    'Unable to find an element with min value: 50'
   );
   await expect(findByA11yValue({ max: 60 })).rejects.toThrow(
-    getMultipleInstancesFoundMessage('{"max":60}')
+    'Found multiple elements with max value: 60'
   );
 });
 
@@ -79,7 +71,7 @@ test('getAllByA11yValue, queryAllByA11yValue, findAllByA11yValue', async () => {
   expect(queryAllByA11yValue({ min: 40 })).toHaveLength(1);
 
   expect(() => getAllByA11yValue({ min: 50 })).toThrow(
-    getNoInstancesFoundMessage('{"min":50}')
+    'Unable to find an element with min value: 50'
   );
   expect(queryAllByA11yValue({ min: 50 })).toEqual([]);
 
@@ -88,7 +80,7 @@ test('getAllByA11yValue, queryAllByA11yValue, findAllByA11yValue', async () => {
 
   await expect(findAllByA11yValue({ min: 40 })).resolves.toHaveLength(1);
   await expect(findAllByA11yValue({ min: 50 })).rejects.toThrow(
-    getNoInstancesFoundMessage('{"min":50}')
+    'Unable to find an element with min value: 50'
   );
   await expect(findAllByA11yValue({ max: 60 })).resolves.toHaveLength(2);
 });

--- a/src/queries/__tests__/role-value.test.tsx
+++ b/src/queries/__tests__/role-value.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View } from 'react-native';
+import { View, Text } from 'react-native';
 import { render } from '../..';
 
 describe('accessibility value', () => {
@@ -57,5 +57,45 @@ describe('accessibility value', () => {
     expect(queryByRole('adjustable', { value: { now: 15 } })).toBeFalsy();
     expect(queryByRole('adjustable', { value: { text: 'No' } })).toBeFalsy();
     expect(queryByRole('adjustable', { value: { text: /no/ } })).toBeFalsy();
+  });
+
+  test('matches using single value and other options', () => {
+    const { getByRole } = render(
+      <Text
+        accessibilityRole="adjustable"
+        accessibilityState={{ disabled: true }}
+        accessibilityValue={{ min: 10, max: 20, now: 12, text: 'Hello' }}
+      >
+        Hello
+      </Text>
+    );
+
+    expect(
+      getByRole('adjustable', { name: 'Hello', value: { min: 10 } })
+    ).toBeTruthy();
+    expect(
+      getByRole('adjustable', { disabled: true, value: { min: 10 } })
+    ).toBeTruthy();
+
+    expect(() =>
+      getByRole('adjustable', { name: 'Hello', value: { min: 5 } })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unable to find an element with role: "adjustable", name: "Hello", min value: 5"`
+    );
+    expect(() =>
+      getByRole('adjustable', { name: 'World', value: { min: 10 } })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unable to find an element with role: "adjustable", name: "World", min value: 10"`
+    );
+    expect(() =>
+      getByRole('adjustable', { name: 'Hello', value: { min: 5 } })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unable to find an element with role: "adjustable", name: "Hello", min value: 5"`
+    );
+    expect(() =>
+      getByRole('adjustable', { selected: true, value: { min: 10 } })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unable to find an element with role: "adjustable", selected state: true, min value: 10"`
+    );
   });
 });

--- a/src/queries/__tests__/role-value.test.tsx
+++ b/src/queries/__tests__/role-value.test.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { View } from 'react-native';
+import { render } from '../..';
+
+describe('accessibility value', () => {
+  test('matches using all value props', () => {
+    const { getByRole, queryByRole } = render(
+      <View
+        accessibilityRole="adjustable"
+        accessibilityValue={{ min: 0, max: 100, now: 50, text: '50%' }}
+      />
+    );
+
+    expect(
+      getByRole('adjustable', {
+        value: { min: 0, max: 100, now: 50, text: '50%' },
+      })
+    ).toBeTruthy();
+    expect(
+      queryByRole('adjustable', {
+        value: { min: 1, max: 100, now: 50, text: '50%' },
+      })
+    ).toBeFalsy();
+    expect(
+      queryByRole('adjustable', {
+        value: { min: 0, max: 99, now: 50, text: '50%' },
+      })
+    ).toBeFalsy();
+    expect(
+      queryByRole('adjustable', {
+        value: { min: 0, max: 100, now: 45, text: '50%' },
+      })
+    ).toBeFalsy();
+    expect(
+      queryByRole('adjustable', {
+        value: { min: 0, max: 100, now: 50, text: '55%' },
+      })
+    ).toBeFalsy();
+  });
+
+  test('matches using single value', () => {
+    const { getByRole, queryByRole } = render(
+      <View
+        accessibilityRole="adjustable"
+        accessibilityValue={{ min: 10, max: 20, now: 12, text: 'Hello' }}
+      />
+    );
+
+    expect(getByRole('adjustable', { value: { min: 10 } })).toBeTruthy();
+    expect(getByRole('adjustable', { value: { max: 20 } })).toBeTruthy();
+    expect(getByRole('adjustable', { value: { now: 12 } })).toBeTruthy();
+    expect(getByRole('adjustable', { value: { text: 'Hello' } })).toBeTruthy();
+    expect(getByRole('adjustable', { value: { text: /hello/i } })).toBeTruthy();
+
+    expect(queryByRole('adjustable', { value: { min: 11 } })).toBeFalsy();
+    expect(queryByRole('adjustable', { value: { max: 19 } })).toBeFalsy();
+    expect(queryByRole('adjustable', { value: { now: 15 } })).toBeFalsy();
+    expect(queryByRole('adjustable', { value: { text: 'No' } })).toBeFalsy();
+    expect(queryByRole('adjustable', { value: { text: /no/ } })).toBeFalsy();
+  });
+});

--- a/src/queries/__tests__/role.test.tsx
+++ b/src/queries/__tests__/role.test.tsx
@@ -696,6 +696,24 @@ describe('error messages', () => {
       `"Unable to find an element with role: "button", disabled state: true"`
     );
   });
+
+  test('gives a descriptive error message when querying with a role and an accessibility value', () => {
+    const { getByRole } = render(<View />);
+
+    expect(() =>
+      getByRole('adjustable', { value: { min: 1 } })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unable to find an element with role: "adjustable", min value: 1"`
+    );
+
+    expect(() =>
+      getByRole('adjustable', {
+        value: { min: 1, max: 2, now: 1, text: /hello/ },
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unable to find an element with role: "adjustable", min value: 1, max value: 2, now value: 1, text value: /hello/"`
+    );
+  });
 });
 
 test('byRole queries support hidden option', () => {

--- a/src/queries/a11yValue.ts
+++ b/src/queries/a11yValue.ts
@@ -1,6 +1,10 @@
 import type { ReactTestInstance } from 'react-test-renderer';
+import { accessiblityValueKeys } from '../helpers/accessiblity';
 import { findAll } from '../helpers/findAll';
-import { matchObjectProp } from '../helpers/matchers/matchObjectProp';
+import {
+  AccessibilityValueMatcher,
+  matchAccessibilityValue,
+} from '../helpers/matchers/accessibilityValue';
 import { makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
@@ -12,33 +16,38 @@ import type {
 } from './makeQueries';
 import { CommonQueryOptions } from './options';
 
-type A11yValue = {
-  min?: number;
-  max?: number;
-  now?: number;
-  text?: string;
-};
-
 const queryAllByA11yValue = (
   instance: ReactTestInstance
 ): ((
-  value: A11yValue,
+  value: AccessibilityValueMatcher,
   queryOptions?: CommonQueryOptions
 ) => Array<ReactTestInstance>) =>
   function queryAllByA11yValueFn(value, queryOptions) {
     return findAll(
       instance,
       (node) =>
-        typeof node.type === 'string' &&
-        matchObjectProp(node.props.accessibilityValue, value),
+        typeof node.type === 'string' && matchAccessibilityValue(node, value),
       queryOptions
     );
   };
 
-const getMultipleError = (value: A11yValue) =>
-  `Found multiple elements with accessibilityValue: ${JSON.stringify(value)} `;
-const getMissingError = (value: A11yValue) =>
-  `Unable to find an element with accessibilityValue: ${JSON.stringify(value)}`;
+const buildErrorMessage = (value: AccessibilityValueMatcher) => {
+  const errors: string[] = [];
+
+  accessiblityValueKeys.forEach((valueKey) => {
+    if (value[valueKey] !== undefined) {
+      errors.push(`${valueKey} value: ${value[valueKey]}`);
+    }
+  });
+
+  return errors.join(', ');
+};
+
+const getMultipleError = (value: AccessibilityValueMatcher) =>
+  `Found multiple elements with ${buildErrorMessage(value)}`;
+
+const getMissingError = (value: AccessibilityValueMatcher) =>
+  `Unable to find an element with ${buildErrorMessage(value)}`;
 
 const { getBy, getAllBy, queryBy, queryAllBy, findBy, findAllBy } = makeQueries(
   queryAllByA11yValue,
@@ -47,19 +56,46 @@ const { getBy, getAllBy, queryBy, queryAllBy, findBy, findAllBy } = makeQueries(
 );
 
 export type ByA11yValueQueries = {
-  getByA11yValue: GetByQuery<A11yValue, CommonQueryOptions>;
-  getAllByA11yValue: GetAllByQuery<A11yValue, CommonQueryOptions>;
-  queryByA11yValue: QueryByQuery<A11yValue, CommonQueryOptions>;
-  queryAllByA11yValue: QueryAllByQuery<A11yValue, CommonQueryOptions>;
-  findByA11yValue: FindByQuery<A11yValue, CommonQueryOptions>;
-  findAllByA11yValue: FindAllByQuery<A11yValue, CommonQueryOptions>;
+  getByA11yValue: GetByQuery<AccessibilityValueMatcher, CommonQueryOptions>;
+  getAllByA11yValue: GetAllByQuery<
+    AccessibilityValueMatcher,
+    CommonQueryOptions
+  >;
+  queryByA11yValue: QueryByQuery<AccessibilityValueMatcher, CommonQueryOptions>;
+  queryAllByA11yValue: QueryAllByQuery<
+    AccessibilityValueMatcher,
+    CommonQueryOptions
+  >;
+  findByA11yValue: FindByQuery<AccessibilityValueMatcher, CommonQueryOptions>;
+  findAllByA11yValue: FindAllByQuery<
+    AccessibilityValueMatcher,
+    CommonQueryOptions
+  >;
 
-  getByAccessibilityValue: GetByQuery<A11yValue, CommonQueryOptions>;
-  getAllByAccessibilityValue: GetAllByQuery<A11yValue, CommonQueryOptions>;
-  queryByAccessibilityValue: QueryByQuery<A11yValue, CommonQueryOptions>;
-  queryAllByAccessibilityValue: QueryAllByQuery<A11yValue, CommonQueryOptions>;
-  findByAccessibilityValue: FindByQuery<A11yValue, CommonQueryOptions>;
-  findAllByAccessibilityValue: FindAllByQuery<A11yValue, CommonQueryOptions>;
+  getByAccessibilityValue: GetByQuery<
+    AccessibilityValueMatcher,
+    CommonQueryOptions
+  >;
+  getAllByAccessibilityValue: GetAllByQuery<
+    AccessibilityValueMatcher,
+    CommonQueryOptions
+  >;
+  queryByAccessibilityValue: QueryByQuery<
+    AccessibilityValueMatcher,
+    CommonQueryOptions
+  >;
+  queryAllByAccessibilityValue: QueryAllByQuery<
+    AccessibilityValueMatcher,
+    CommonQueryOptions
+  >;
+  findByAccessibilityValue: FindByQuery<
+    AccessibilityValueMatcher,
+    CommonQueryOptions
+  >;
+  findAllByAccessibilityValue: FindAllByQuery<
+    AccessibilityValueMatcher,
+    CommonQueryOptions
+  >;
 };
 
 export const bindByA11yValueQueries = (

--- a/src/queries/a11yValue.ts
+++ b/src/queries/a11yValue.ts
@@ -31,23 +31,23 @@ const queryAllByA11yValue = (
     );
   };
 
-const buildErrorMessage = (value: AccessibilityValueMatcher) => {
-  const errors: string[] = [];
+const formatQueryParams = (matcher: AccessibilityValueMatcher) => {
+  const params: string[] = [];
 
   accessiblityValueKeys.forEach((valueKey) => {
-    if (value[valueKey] !== undefined) {
-      errors.push(`${valueKey} value: ${value[valueKey]}`);
+    if (matcher[valueKey] !== undefined) {
+      params.push(`${valueKey} value: ${matcher[valueKey]}`);
     }
   });
 
-  return errors.join(', ');
+  return params.join(', ');
 };
 
-const getMultipleError = (value: AccessibilityValueMatcher) =>
-  `Found multiple elements with ${buildErrorMessage(value)}`;
+const getMultipleError = (matcher: AccessibilityValueMatcher) =>
+  `Found multiple elements with ${formatQueryParams(matcher)}`;
 
-const getMissingError = (value: AccessibilityValueMatcher) =>
-  `Unable to find an element with ${buildErrorMessage(value)}`;
+const getMissingError = (matcher: AccessibilityValueMatcher) =>
+  `Unable to find an element with ${formatQueryParams(matcher)}`;
 
 const { getBy, getAllBy, queryBy, queryAllBy, findBy, findAllBy } = makeQueries(
   queryAllByA11yValue,

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -73,33 +73,33 @@ const queryAllByRole = (
     );
   };
 
-const buildErrorMessage = (role: TextMatch, options: ByRoleOptions = {}) => {
-  const errors = [`role: "${String(role)}"`];
+const formatQueryParams = (role: TextMatch, options: ByRoleOptions = {}) => {
+  const params = [`role: "${String(role)}"`];
 
   if (options.name) {
-    errors.push(`name: "${String(options.name)}"`);
+    params.push(`name: "${String(options.name)}"`);
   }
 
   accessibilityStateKeys.forEach((stateKey) => {
     if (options[stateKey] !== undefined) {
-      errors.push(`${stateKey} state: ${options[stateKey]}`);
+      params.push(`${stateKey} state: ${options[stateKey]}`);
     }
   });
 
   accessiblityValueKeys.forEach((valueKey) => {
     if (options?.value?.[valueKey] !== undefined) {
-      errors.push(`${valueKey} value: ${options?.value?.[valueKey]}`);
+      params.push(`${valueKey} value: ${options?.value?.[valueKey]}`);
     }
   });
 
-  return errors.join(', ');
+  return params.join(', ');
 };
 
 const getMultipleError = (role: TextMatch, options?: ByRoleOptions) =>
-  `Found multiple elements with ${buildErrorMessage(role, options)}`;
+  `Found multiple elements with ${formatQueryParams(role, options)}`;
 
 const getMissingError = (role: TextMatch, options?: ByRoleOptions) =>
-  `Unable to find an element with ${buildErrorMessage(role, options)}`;
+  `Unable to find an element with ${formatQueryParams(role, options)}`;
 
 const { getBy, getAllBy, queryBy, queryAllBy, findBy, findAllBy } = makeQueries(
   queryAllByRole,

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -1,8 +1,15 @@
-import { type AccessibilityState } from 'react-native';
+import type { AccessibilityState } from 'react-native';
 import type { ReactTestInstance } from 'react-test-renderer';
-import { accessibilityStateKeys } from '../helpers/accessiblity';
+import {
+  accessibilityStateKeys,
+  accessiblityValueKeys,
+} from '../helpers/accessiblity';
 import { findAll } from '../helpers/findAll';
 import { matchAccessibilityState } from '../helpers/matchers/accessibilityState';
+import {
+  AccessibilityValueMatcher,
+  matchAccessibilityValue,
+} from '../helpers/matchers/accessibilityValue';
 import { matchStringProp } from '../helpers/matchers/matchStringProp';
 import type { TextMatch } from '../matches';
 import { getQueriesForElement } from '../within';
@@ -20,6 +27,7 @@ import { CommonQueryOptions } from './options';
 type ByRoleOptions = CommonQueryOptions &
   AccessibilityState & {
     name?: TextMatch;
+    value?: AccessibilityValueMatcher;
   };
 
 const matchAccessibleNameIfNeeded = (
@@ -41,6 +49,13 @@ const matchAccessibleStateIfNeeded = (
   return options != null ? matchAccessibilityState(node, options) : true;
 };
 
+const matchAccessibilityValueIfNeeded = (
+  node: ReactTestInstance,
+  value?: AccessibilityValueMatcher
+) => {
+  return value != null ? matchAccessibilityValue(node, value) : true;
+};
+
 const queryAllByRole = (
   instance: ReactTestInstance
 ): ((role: TextMatch, options?: ByRoleOptions) => Array<ReactTestInstance>) =>
@@ -49,10 +64,10 @@ const queryAllByRole = (
       instance,
       (node) =>
         // run the cheapest checks first, and early exit too avoid unneeded computations
-
         typeof node.type === 'string' &&
         matchStringProp(node.props.accessibilityRole, role) &&
         matchAccessibleStateIfNeeded(node, options) &&
+        matchAccessibilityValueIfNeeded(node, options?.value) &&
         matchAccessibleNameIfNeeded(node, options?.name),
       options
     );
@@ -68,6 +83,12 @@ const buildErrorMessage = (role: TextMatch, options: ByRoleOptions = {}) => {
   accessibilityStateKeys.forEach((stateKey) => {
     if (options[stateKey] !== undefined) {
       errors.push(`${stateKey} state: ${options[stateKey]}`);
+    }
+  });
+
+  accessiblityValueKeys.forEach((valueKey) => {
+    if (options?.value?.[valueKey] !== undefined) {
+      errors.push(`${valueKey} value: ${options?.value?.[valueKey]}`);
     }
   });
 

--- a/typings/index.flow.js
+++ b/typings/index.flow.js
@@ -64,7 +64,7 @@ declare type A11yValue = {
   min?: number,
   max?: number,
   now?: number,
-  text?: string,
+  text?: TextMatch,
 };
 
 type WaitForOptions = {
@@ -224,6 +224,7 @@ interface UnsafeByPropsQueries {
 type ByRoleOptions = CommonQueryOptions & {
   ...A11yState,
   name?: string,
+  value?: A11yValue,
 };
 
 type ByLabelTextOptions = CommonQueryOptions & TextMatchOptions;

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -381,7 +381,7 @@ getByA11yValue(
 
 Returns a host element with matching `accessibilityValue` prop entries. Only entires provided to the query will be used to match elements. Element might have additional accessibility value entries and still be matched.
 
-When querying by `text` entry a stirng or regex might be used.
+When querying by `text` entry a string or regex might be used.
 
 ```jsx
 import { render, screen } from '@testing-library/react-native';

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -261,6 +261,12 @@ getByRole(
     checked?: boolean | 'mixed',
     busy?: boolean,
     expanded?: boolean,
+    value: {
+      min?: number;
+      max?: number;
+      now?: number;
+      text?: TextMatch;
+    },
     hidden?: boolean;
   }
 ): ReactTestInstance;
@@ -271,8 +277,14 @@ Returns a `ReactTestInstance` with matching `accessibilityRole` prop.
 ```jsx
 import { render, screen } from '@testing-library/react-native';
 
-render(<MyComponent />);
+render(
+  <Pressable accessibilityRole="button" disabled>
+    <Text>Hello</Text>
+  </Pressable>
+);
 const element = screen.getByRole('button');
+const element2 = screen.getByRole('button', { name: "Hello" });
+const element3 = screen.getByRole('button', { name: "Hello", disabled: true });
 ```
 
 #### Options
@@ -288,6 +300,8 @@ const element = screen.getByRole('button');
 `busy`: You can filter elements by their busy state. The possible values are `true` or `false`. Querying `busy: false` will also match elements with `busy: undefined` (see the [wiki](https://github.com/callstack/react-native-testing-library/wiki/Accessibility:-State) for more details). See [React Native's accessibilityState](https://reactnative.dev/docs/accessibility#accessibilitystate) docs to learn more about the `busy` state.
 
 `expanded`: You can filter elements by their expanded state. The possible values are `true` or `false`. See [React Native's accessibilityState](https://reactnative.dev/docs/accessibility#accessibilitystate) docs to learn more about the `expanded` state.
+
+`value`: Filter elements by their accessibility, available value entries include numeric `min`, `max` & `now`, as well as string or regex `text` key. See React Native [accessibilityValue](https://reactnative.dev/docs/accessibility#accessibilityvalue) docs to learn more about this prop.
 
 ### `ByA11yState`, `ByAccessibilityState`
 
@@ -357,7 +371,7 @@ getByA11yValue(
     min?: number;
     max?: number;
     now?: number;
-    text?: string;
+    text?: TextMatch;
   },
   options?: {
     hidden?: boolean;
@@ -365,13 +379,16 @@ getByA11yValue(
 ): ReactTestInstance;
 ```
 
-Returns a `ReactTestInstance` with matching `accessibilityValue` prop.
+Returns a host element with matching `accessibilityValue` prop entries. Only entires provided to the query will be used to match elements. Element might have additional accessibility value entries and still be matched.
+
+When querying by `text` entry a stirng or regex might be used.
 
 ```jsx
 import { render, screen } from '@testing-library/react-native';
 
-render(<Component />);
-const element = screen.getByA11yValue({ min: 40 });
+render(<View accessibilityValue={{ min: 0, max: 100, now: 25, text: '25%' }} />);
+const element = screen.getByA11yValue({ now: 25 });
+const element2 = screen.getByA11yValue({ text: /25/ });
 ```
 
 ## Common options


### PR DESCRIPTION
### Summary

1. Add `value` option to `*ByRole` query
2. Improve `*ByA11yValue` query by allowing `text` entry to be string or regex

### Test plan

Added relevant tests for `*ByRole` query and `*ByA11yValue`.