### PR TITLE
Add alias to hidden in query options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+coverage
 *.log
 .eslintcache
 build

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -20,9 +20,17 @@ test('configure() overrides existing config values', () => {
 });
 
 test('resetToDefaults() resets config to defaults', () => {
-  configure({ asyncUtilTimeout: 5000 });
+  configure({
+    asyncUtilTimeout: 5000,
+    defaultIncludeHidden: false,
+    defaultHidden: false,
+  });
   expect(getConfig().asyncUtilTimeout).toEqual(5000);
+  expect(getConfig().defaultHidden).toEqual(false);
+  expect(getConfig().defaultIncludeHidden).toEqual(false);
 
   resetToDefaults();
   expect(getConfig().asyncUtilTimeout).toEqual(1000);
+  expect(getConfig().defaultHidden).toEqual(true);
+  expect(getConfig().defaultIncludeHidden).toEqual(true);
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -6,6 +6,7 @@ beforeEach(() => {
 
 test('getConfig() returns existing configuration', () => {
   expect(getConfig().asyncUtilTimeout).toEqual(1000);
+  expect(getConfig().defaultIncludeHiddenElements).toEqual(true);
 });
 
 test('configure() overrides existing config values', () => {
@@ -14,7 +15,6 @@ test('configure() overrides existing config values', () => {
   expect(getConfig()).toEqual({
     asyncUtilTimeout: 5000,
     defaultDebugOptions: { message: 'debug message' },
-    defaultHidden: true,
     defaultIncludeHiddenElements: true,
   });
 });
@@ -26,11 +26,15 @@ test('resetToDefaults() resets config to defaults', () => {
     defaultHidden: false,
   });
   expect(getConfig().asyncUtilTimeout).toEqual(5000);
-  expect(getConfig().defaultHidden).toEqual(false);
   expect(getConfig().defaultIncludeHiddenElements).toEqual(false);
 
   resetToDefaults();
   expect(getConfig().asyncUtilTimeout).toEqual(1000);
-  expect(getConfig().defaultHidden).toEqual(true);
   expect(getConfig().defaultIncludeHiddenElements).toEqual(true);
+});
+
+test('configure handles alias option defaultHidden', () => {
+  expect(getConfig().defaultIncludeHiddenElements).toEqual(true);
+  configure({ defaultHidden: false });
+  expect(getConfig().defaultIncludeHiddenElements).toEqual(false);
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -15,6 +15,7 @@ test('configure() overrides existing config values', () => {
     asyncUtilTimeout: 5000,
     defaultDebugOptions: { message: 'debug message' },
     defaultHidden: true,
+    defaultIncludeHidden: true,
   });
 });
 

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -23,7 +23,6 @@ test('resetToDefaults() resets config to defaults', () => {
   configure({
     asyncUtilTimeout: 5000,
     defaultIncludeHiddenElements: false,
-    defaultHidden: false,
   });
   expect(getConfig().asyncUtilTimeout).toEqual(5000);
   expect(getConfig().defaultIncludeHiddenElements).toEqual(false);
@@ -35,6 +34,7 @@ test('resetToDefaults() resets config to defaults', () => {
 
 test('configure handles alias option defaultHidden', () => {
   expect(getConfig().defaultIncludeHiddenElements).toEqual(true);
+
   configure({ defaultHidden: false });
   expect(getConfig().defaultIncludeHiddenElements).toEqual(false);
 });

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -15,22 +15,22 @@ test('configure() overrides existing config values', () => {
     asyncUtilTimeout: 5000,
     defaultDebugOptions: { message: 'debug message' },
     defaultHidden: true,
-    defaultIncludeHidden: true,
+    defaultIncludeHiddenElements: true,
   });
 });
 
 test('resetToDefaults() resets config to defaults', () => {
   configure({
     asyncUtilTimeout: 5000,
-    defaultIncludeHidden: false,
+    defaultIncludeHiddenElements: false,
     defaultHidden: false,
   });
   expect(getConfig().asyncUtilTimeout).toEqual(5000);
   expect(getConfig().defaultHidden).toEqual(false);
-  expect(getConfig().defaultIncludeHidden).toEqual(false);
+  expect(getConfig().defaultIncludeHiddenElements).toEqual(false);
 
   resetToDefaults();
   expect(getConfig().asyncUtilTimeout).toEqual(1000);
   expect(getConfig().defaultHidden).toEqual(true);
-  expect(getConfig().defaultIncludeHidden).toEqual(true);
+  expect(getConfig().defaultIncludeHiddenElements).toEqual(true);
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,13 @@ export type Config = {
   /** Default timeout, in ms, for `waitFor` and `findBy*` queries. */
   asyncUtilTimeout: number;
 
-  /** Default hidden value for all queries */
+  /** Default includeHidden value for all queries */
+  defaultIncludeHidden: boolean;
+
+  /** Default hidden value for all queries, alias to defaultIncludeHidden to respect react-testing-library API
+   * WARNING: if both defaultHidden and defaultIncludeHidden values are defined,
+   * then defaultIncludeHidden will take precedence
+   */
   defaultHidden: boolean;
 
   /** Default options for `debug` helper. */
@@ -14,6 +20,7 @@ export type Config = {
 const defaultConfig: Config = {
   asyncUtilTimeout: 1000,
   defaultHidden: true,
+  defaultIncludeHidden: true,
 };
 
 let config = { ...defaultConfig };

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,12 +4,12 @@ export type Config = {
   /** Default timeout, in ms, for `waitFor` and `findBy*` queries. */
   asyncUtilTimeout: number;
 
-  /** Default includeHidden value for all queries */
-  defaultIncludeHidden: boolean;
+  /** Default includeHiddenElements value for all queries */
+  defaultIncludeHiddenElements: boolean;
 
-  /** Default hidden value for all queries, alias to defaultIncludeHidden to respect react-testing-library API
-   * WARNING: if both defaultHidden and defaultIncludeHidden values are defined,
-   * then defaultIncludeHidden will take precedence
+  /** Default hidden value for all queries, alias to defaultIncludeHiddenElements to respect react-testing-library API
+   * WARNING: if both defaultHidden and defaultIncludeHiddenElements values are defined,
+   * then defaultIncludeHiddenElements will take precedence
    */
   defaultHidden: boolean;
 
@@ -20,7 +20,7 @@ export type Config = {
 const defaultConfig: Config = {
   asyncUtilTimeout: 1000,
   defaultHidden: true,
-  defaultIncludeHidden: true,
+  defaultIncludeHiddenElements: true,
 };
 
 let config = { ...defaultConfig };

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ export type Config = {
   /** Default timeout, in ms, for `waitFor` and `findBy*` queries. */
   asyncUtilTimeout: number;
 
-  /** Default includeHiddenElements value for all queries */
+  /** Default value for `includeHiddenElements` query option. */
   defaultIncludeHiddenElements: boolean;
 
   /** Default options for `debug` helper. */
@@ -12,10 +12,7 @@ export type Config = {
 };
 
 export type ConfigAliasOptions = {
-  /** Default hidden value for all queries, alias to defaultIncludeHiddenElements to respect react-testing-library API
-   * WARNING: if both defaultHidden and defaultIncludeHiddenElements values are defined,
-   * then defaultIncludeHiddenElements will take precedence
-   */
+  /** RTL-compatibility alias to `defaultIncludeHiddenElements` */
   defaultHidden: boolean;
 };
 
@@ -34,14 +31,10 @@ export function configure(options: Partial<Config & ConfigAliasOptions>) {
     defaultHidden ??
     config.defaultIncludeHiddenElements;
 
-  const optionsToSet = {
-    ...restOptions,
-    defaultIncludeHiddenElements,
-  };
-
   config = {
     ...config,
-    ...optionsToSet,
+    ...restOptions,
+    defaultIncludeHiddenElements,
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,42 +7,41 @@ export type Config = {
   /** Default includeHiddenElements value for all queries */
   defaultIncludeHiddenElements: boolean;
 
+  /** Default options for `debug` helper. */
+  defaultDebugOptions?: Partial<DebugOptions>;
+};
+
+export type ConfigAliasOptions = {
   /** Default hidden value for all queries, alias to defaultIncludeHiddenElements to respect react-testing-library API
    * WARNING: if both defaultHidden and defaultIncludeHiddenElements values are defined,
    * then defaultIncludeHiddenElements will take precedence
    */
   defaultHidden: boolean;
-
-  /** Default options for `debug` helper. */
-  defaultDebugOptions?: Partial<DebugOptions>;
 };
 
 const defaultConfig: Config = {
   asyncUtilTimeout: 1000,
-  defaultHidden: true,
   defaultIncludeHiddenElements: true,
 };
 
 let config = { ...defaultConfig };
 
-export function configure(options: Partial<Config>) {
-  if (
-    options.defaultHidden !== undefined &&
-    options.defaultIncludeHiddenElements === undefined
-  ) {
-    options.defaultIncludeHiddenElements = options.defaultHidden;
-  }
+export function configure(options: Partial<Config & ConfigAliasOptions>) {
+  const { defaultHidden, ...restOptions } = options;
 
-  if (
-    options.defaultIncludeHiddenElements !== undefined &&
-    options.defaultHidden === undefined
-  ) {
-    options.defaultHidden = options.defaultIncludeHiddenElements;
-  }
+  const defaultIncludeHiddenElements =
+    restOptions.defaultIncludeHiddenElements ??
+    defaultHidden ??
+    config.defaultIncludeHiddenElements;
+
+  const optionsToSet = {
+    ...restOptions,
+    defaultIncludeHiddenElements,
+  };
 
   config = {
     ...config,
-    ...options,
+    ...optionsToSet,
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,6 +26,20 @@ const defaultConfig: Config = {
 let config = { ...defaultConfig };
 
 export function configure(options: Partial<Config>) {
+  if (
+    options.defaultHidden !== undefined &&
+    options.defaultIncludeHiddenElements === undefined
+  ) {
+    options.defaultIncludeHiddenElements = options.defaultHidden;
+  }
+
+  if (
+    options.defaultIncludeHiddenElements !== undefined &&
+    options.defaultHidden === undefined
+  ) {
+    options.defaultHidden = options.defaultIncludeHiddenElements;
+  }
+
   config = {
     ...config,
     ...options,

--- a/src/helpers/__tests__/component-tree.test.tsx
+++ b/src/helpers/__tests__/component-tree.test.tsx
@@ -45,6 +45,10 @@ describe('getHostParent()', () => {
     expect(getHostParent(hostGrandparent)).toBe(null);
   });
 
+  it('returns host parent for null', () => {
+    expect(getHostParent(null)).toBe(null);
+  });
+
   it('returns host parent for composite component', () => {
     const view = render(
       <View testID="parent">
@@ -65,7 +69,7 @@ describe('getHostChildren()', () => {
       <View testID="grandparent">
         <View testID="parent">
           <View testID="subject" />
-          <View testID="sibling" />
+          <Text testID="sibling">Hello</Text>
         </View>
       </View>
     );
@@ -74,6 +78,8 @@ describe('getHostChildren()', () => {
     expect(getHostChildren(hostSubject)).toEqual([]);
 
     const hostSibling = view.getByTestId('sibling');
+    expect(getHostChildren(hostSibling)).toEqual([]);
+
     const hostParent = view.getByTestId('parent');
     expect(getHostChildren(hostParent)).toEqual([hostSubject, hostSibling]);
 

--- a/src/helpers/__tests__/includeHiddenElements.test.tsx
+++ b/src/helpers/__tests__/includeHiddenElements.test.tsx
@@ -1,9 +1,6 @@
-import { View } from 'react-native';
 import React from 'react';
-
-import render from '../../render';
-import { screen } from '../../screen';
-import { configure } from '../../config';
+import { View } from 'react-native';
+import { configure, render, screen } from '../..';
 
 test('includeHiddenElements query option takes priority over hidden option and global config', () => {
   configure({ defaultHidden: true, defaultIncludeHiddenElements: true });

--- a/src/helpers/__tests__/includeHiddenElements.test.tsx
+++ b/src/helpers/__tests__/includeHiddenElements.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import render from '../../render';
 import { screen } from '../../screen';
-import { configure } from '../../config';
+import { configure, getConfig } from '../../config';
 
 test('includeHiddenElements query option takes priority over hidden option and global config', () => {
   configure({ defaultHidden: true, defaultIncludeHiddenElements: true });
@@ -23,4 +23,20 @@ test('global config defaultIncludeElements option takes priority over defaultHid
   configure({ defaultHidden: false, defaultIncludeHiddenElements: true });
   render(<View testID="view" style={{ display: 'none' }} />);
   expect(screen.getByTestId('view')).toBeTruthy();
+});
+
+test('defaultHidden takes priority when it was set last', () => {
+  // also simulates the case when defaultIncludeHiddenElements is true by default in the config
+  configure({ defaultIncludeHiddenElements: true });
+  configure({ defaultHidden: false });
+  render(<View testID="view" style={{ display: 'none' }} />);
+  expect(screen.queryByTestId('view')).toBeFalsy();
+});
+
+test('defaultIncludeHiddenElements takes priority when it was set last', () => {
+  // also simulates the case when defaultHidden is true by default in the config
+  configure({ defaultHidden: true });
+  configure({ defaultIncludeHiddenElements: false });
+  render(<View testID="view" style={{ display: 'none' }} />);
+  expect(screen.queryByTestId('view')).toBeFalsy();
 });

--- a/src/helpers/__tests__/includeHiddenElements.test.tsx
+++ b/src/helpers/__tests__/includeHiddenElements.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import render from '../../render';
 import { screen } from '../../screen';
-import { configure, getConfig } from '../../config';
+import { configure } from '../../config';
 
 test('includeHiddenElements query option takes priority over hidden option and global config', () => {
   configure({ defaultHidden: true, defaultIncludeHiddenElements: true });

--- a/src/helpers/__tests__/includeHiddenElements.test.tsx
+++ b/src/helpers/__tests__/includeHiddenElements.test.tsx
@@ -1,0 +1,26 @@
+import { View } from 'react-native';
+import React from 'react';
+
+import render from '../../render';
+import { screen } from '../../screen';
+import { configure } from '../../config';
+
+test('includeHiddenElements query option takes priority over hidden option and global config', () => {
+  configure({ defaultHidden: true, defaultIncludeHiddenElements: true });
+  render(<View testID="view" style={{ display: 'none' }} />);
+  expect(
+    screen.queryByTestId('view', { includeHiddenElements: false, hidden: true })
+  ).toBeFalsy();
+});
+
+test('hidden option takes priority over global config when includeHiddenElements is not defined', () => {
+  configure({ defaultHidden: true, defaultIncludeHiddenElements: true });
+  render(<View testID="view" style={{ display: 'none' }} />);
+  expect(screen.queryByTestId('view', { hidden: false })).toBeFalsy();
+});
+
+test('global config defaultIncludeElements option takes priority over defaultHidden when set at the same time', () => {
+  configure({ defaultHidden: false, defaultIncludeHiddenElements: true });
+  render(<View testID="view" style={{ display: 'none' }} />);
+  expect(screen.getByTestId('view')).toBeTruthy();
+});

--- a/src/helpers/findAll.ts
+++ b/src/helpers/findAll.ts
@@ -17,8 +17,7 @@ export function findAll(
   const hidden =
     options?.includeHiddenElements ??
     options?.hidden ??
-    getConfig()?.defaultIncludeHiddenElements ??
-    getConfig()?.defaultHidden;
+    getConfig()?.defaultIncludeHiddenElements;
 
   if (hidden) {
     return results;

--- a/src/helpers/findAll.ts
+++ b/src/helpers/findAll.ts
@@ -15,12 +15,12 @@ export function findAll(
 ) {
   const results = root.findAll(predicate);
 
-  const hidden =
+  const includeHiddenElements =
     options?.includeHiddenElements ??
     options?.hidden ??
     getConfig()?.defaultIncludeHiddenElements;
 
-  if (hidden) {
+  if (includeHiddenElements) {
     return results;
   }
 

--- a/src/helpers/findAll.ts
+++ b/src/helpers/findAll.ts
@@ -4,7 +4,7 @@ import { isHiddenFromAccessibility } from './accessiblity';
 
 interface FindAllOptions {
   hidden?: boolean;
-  includeHidden?: boolean;
+  includeHiddenElements?: boolean;
 }
 
 export function findAll(
@@ -13,11 +13,13 @@ export function findAll(
   options?: FindAllOptions
 ) {
   const results = root.findAll(predicate);
-  const includeHiddenQueryOption = options?.includeHidden ?? options?.hidden;
-  const defaultIncludeHidden =
-    getConfig()?.defaultIncludeHidden ?? getConfig()?.defaultHidden;
+  const includeHiddenElementsQueryOption =
+    options?.includeHiddenElements ?? options?.hidden;
+  const defaultIncludeHiddenElements =
+    getConfig()?.defaultIncludeHiddenElements ?? getConfig()?.defaultHidden;
 
-  const hidden = includeHiddenQueryOption ?? defaultIncludeHidden;
+  const hidden =
+    includeHiddenElementsQueryOption ?? defaultIncludeHiddenElements;
   if (hidden) {
     return results;
   }

--- a/src/helpers/findAll.ts
+++ b/src/helpers/findAll.ts
@@ -3,8 +3,9 @@ import { getConfig } from '../config';
 import { isHiddenFromAccessibility } from './accessiblity';
 
 interface FindAllOptions {
-  hidden?: boolean;
   includeHiddenElements?: boolean;
+  /** RTL-compatible alias to `includeHiddenElements` */
+  hidden?: boolean;
 }
 
 export function findAll(

--- a/src/helpers/findAll.ts
+++ b/src/helpers/findAll.ts
@@ -13,13 +13,13 @@ export function findAll(
   options?: FindAllOptions
 ) {
   const results = root.findAll(predicate);
-  const includeHiddenElementsQueryOption =
-    options?.includeHiddenElements ?? options?.hidden;
-  const defaultIncludeHiddenElements =
-    getConfig()?.defaultIncludeHiddenElements ?? getConfig()?.defaultHidden;
 
   const hidden =
-    includeHiddenElementsQueryOption ?? defaultIncludeHiddenElements;
+    options?.includeHiddenElements ??
+    options?.hidden ??
+    getConfig()?.defaultIncludeHiddenElements ??
+    getConfig()?.defaultHidden;
+
   if (hidden) {
     return results;
   }

--- a/src/helpers/findAll.ts
+++ b/src/helpers/findAll.ts
@@ -4,6 +4,7 @@ import { isHiddenFromAccessibility } from './accessiblity';
 
 interface FindAllOptions {
   hidden?: boolean;
+  includeHidden?: boolean;
 }
 
 export function findAll(
@@ -12,8 +13,8 @@ export function findAll(
   options?: FindAllOptions
 ) {
   const results = root.findAll(predicate);
-
-  const hidden = options?.hidden ?? getConfig().defaultHidden;
+  const includeHiddenQueryOption = options?.includeHidden ?? options?.hidden;
+  const hidden = includeHiddenQueryOption ?? getConfig().defaultHidden;
   if (hidden) {
     return results;
   }

--- a/src/helpers/findAll.ts
+++ b/src/helpers/findAll.ts
@@ -14,7 +14,10 @@ export function findAll(
 ) {
   const results = root.findAll(predicate);
   const includeHiddenQueryOption = options?.includeHidden ?? options?.hidden;
-  const hidden = includeHiddenQueryOption ?? getConfig().defaultHidden;
+  const defaultIncludeHidden =
+    getConfig()?.defaultIncludeHidden ?? getConfig()?.defaultHidden;
+
+  const hidden = includeHiddenQueryOption ?? defaultIncludeHidden;
   if (hidden) {
     return results;
   }

--- a/src/queries/__tests__/a11yState.test.tsx
+++ b/src/queries/__tests__/a11yState.test.tsx
@@ -239,9 +239,18 @@ test('byA11yState queries support hidden option', () => {
 
   expect(getByA11yState({ expanded: false })).toBeTruthy();
   expect(getByA11yState({ expanded: false }, { hidden: true })).toBeTruthy();
+  expect(
+    getByA11yState({ expanded: false }, { includeHidden: true })
+  ).toBeTruthy();
 
   expect(queryByA11yState({ expanded: false }, { hidden: false })).toBeFalsy();
   expect(() =>
     getByA11yState({ expanded: false }, { hidden: false })
+  ).toThrow();
+  expect(
+    queryByA11yState({ expanded: false }, { includeHidden: false })
+  ).toBeFalsy();
+  expect(() =>
+    getByA11yState({ expanded: false }, { includeHidden: false })
   ).toThrow();
 });

--- a/src/queries/__tests__/a11yState.test.tsx
+++ b/src/queries/__tests__/a11yState.test.tsx
@@ -240,7 +240,7 @@ test('byA11yState queries support hidden option', () => {
   expect(getByA11yState({ expanded: false })).toBeTruthy();
   expect(getByA11yState({ expanded: false }, { hidden: true })).toBeTruthy();
   expect(
-    getByA11yState({ expanded: false }, { includeHidden: true })
+    getByA11yState({ expanded: false }, { includeHiddenElements: true })
   ).toBeTruthy();
 
   expect(queryByA11yState({ expanded: false }, { hidden: false })).toBeFalsy();
@@ -248,9 +248,9 @@ test('byA11yState queries support hidden option', () => {
     getByA11yState({ expanded: false }, { hidden: false })
   ).toThrow();
   expect(
-    queryByA11yState({ expanded: false }, { includeHidden: false })
+    queryByA11yState({ expanded: false }, { includeHiddenElements: false })
   ).toBeFalsy();
   expect(() =>
-    getByA11yState({ expanded: false }, { includeHidden: false })
+    getByA11yState({ expanded: false }, { includeHiddenElements: false })
   ).toThrow();
 });

--- a/src/queries/__tests__/a11yState.test.tsx
+++ b/src/queries/__tests__/a11yState.test.tsx
@@ -238,15 +238,10 @@ test('byA11yState queries support hidden option', () => {
   );
 
   expect(getByA11yState({ expanded: false })).toBeTruthy();
-  expect(getByA11yState({ expanded: false }, { hidden: true })).toBeTruthy();
   expect(
     getByA11yState({ expanded: false }, { includeHiddenElements: true })
   ).toBeTruthy();
 
-  expect(queryByA11yState({ expanded: false }, { hidden: false })).toBeFalsy();
-  expect(() =>
-    getByA11yState({ expanded: false }, { hidden: false })
-  ).toThrow();
   expect(
     queryByA11yState({ expanded: false }, { includeHiddenElements: false })
   ).toBeFalsy();

--- a/src/queries/__tests__/a11yState.test.tsx
+++ b/src/queries/__tests__/a11yState.test.tsx
@@ -247,5 +247,7 @@ test('byA11yState queries support hidden option', () => {
   ).toBeFalsy();
   expect(() =>
     getByA11yState({ expanded: false }, { includeHiddenElements: false })
-  ).toThrow();
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"Unable to find an element with expanded state: false"`
+  );
 });

--- a/src/queries/__tests__/a11yValue.test.tsx
+++ b/src/queries/__tests__/a11yValue.test.tsx
@@ -102,7 +102,10 @@ test('byA11yValue queries support hidden option', () => {
 
   expect(getByA11yValue({ max: 10 })).toBeTruthy();
   expect(getByA11yValue({ max: 10 }, { hidden: true })).toBeTruthy();
+  expect(getByA11yValue({ max: 10 }, { includeHidden: true })).toBeTruthy();
 
   expect(queryByA11yValue({ max: 10 }, { hidden: false })).toBeFalsy();
   expect(() => getByA11yValue({ max: 10 }, { hidden: false })).toThrow();
+  expect(queryByA11yValue({ max: 10 }, { includeHidden: false })).toBeFalsy();
+  expect(() => getByA11yValue({ max: 10 }, { includeHidden: false })).toThrow();
 });

--- a/src/queries/__tests__/a11yValue.test.tsx
+++ b/src/queries/__tests__/a11yValue.test.tsx
@@ -110,5 +110,7 @@ test('byA11yValue queries support hidden option', () => {
   ).toBeFalsy();
   expect(() =>
     getByA11yValue({ max: 10 }, { includeHiddenElements: false })
-  ).toThrow();
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"Unable to find an element with accessibilityValue: {"max":10}"`
+  );
 });

--- a/src/queries/__tests__/a11yValue.test.tsx
+++ b/src/queries/__tests__/a11yValue.test.tsx
@@ -101,13 +101,10 @@ test('byA11yValue queries support hidden option', () => {
   );
 
   expect(getByA11yValue({ max: 10 })).toBeTruthy();
-  expect(getByA11yValue({ max: 10 }, { hidden: true })).toBeTruthy();
   expect(
     getByA11yValue({ max: 10 }, { includeHiddenElements: true })
   ).toBeTruthy();
 
-  expect(queryByA11yValue({ max: 10 }, { hidden: false })).toBeFalsy();
-  expect(() => getByA11yValue({ max: 10 }, { hidden: false })).toThrow();
   expect(
     queryByA11yValue({ max: 10 }, { includeHiddenElements: false })
   ).toBeFalsy();

--- a/src/queries/__tests__/a11yValue.test.tsx
+++ b/src/queries/__tests__/a11yValue.test.tsx
@@ -102,10 +102,16 @@ test('byA11yValue queries support hidden option', () => {
 
   expect(getByA11yValue({ max: 10 })).toBeTruthy();
   expect(getByA11yValue({ max: 10 }, { hidden: true })).toBeTruthy();
-  expect(getByA11yValue({ max: 10 }, { includeHidden: true })).toBeTruthy();
+  expect(
+    getByA11yValue({ max: 10 }, { includeHiddenElements: true })
+  ).toBeTruthy();
 
   expect(queryByA11yValue({ max: 10 }, { hidden: false })).toBeFalsy();
   expect(() => getByA11yValue({ max: 10 }, { hidden: false })).toThrow();
-  expect(queryByA11yValue({ max: 10 }, { includeHidden: false })).toBeFalsy();
-  expect(() => getByA11yValue({ max: 10 }, { includeHidden: false })).toThrow();
+  expect(
+    queryByA11yValue({ max: 10 }, { includeHiddenElements: false })
+  ).toBeFalsy();
+  expect(() =>
+    getByA11yValue({ max: 10 }, { includeHiddenElements: false })
+  ).toThrow();
 });

--- a/src/queries/__tests__/displayValue.test.tsx
+++ b/src/queries/__tests__/displayValue.test.tsx
@@ -107,7 +107,10 @@ test('byDisplayValue queries support hidden option', () => {
 
   expect(getByDisplayValue('hidden')).toBeTruthy();
   expect(getByDisplayValue('hidden', { hidden: true })).toBeTruthy();
+  expect(getByDisplayValue('hidden', { includeHidden: true })).toBeTruthy();
 
   expect(queryByDisplayValue('hidden', { hidden: false })).toBeFalsy();
   expect(() => getByDisplayValue('hidden', { hidden: false })).toThrow();
+  expect(queryByDisplayValue('hidden', { includeHidden: false })).toBeFalsy();
+  expect(() => getByDisplayValue('hidden', { includeHidden: false })).toThrow();
 });

--- a/src/queries/__tests__/displayValue.test.tsx
+++ b/src/queries/__tests__/displayValue.test.tsx
@@ -107,10 +107,16 @@ test('byDisplayValue queries support hidden option', () => {
 
   expect(getByDisplayValue('hidden')).toBeTruthy();
   expect(getByDisplayValue('hidden', { hidden: true })).toBeTruthy();
-  expect(getByDisplayValue('hidden', { includeHidden: true })).toBeTruthy();
+  expect(
+    getByDisplayValue('hidden', { includeHiddenElements: true })
+  ).toBeTruthy();
 
   expect(queryByDisplayValue('hidden', { hidden: false })).toBeFalsy();
   expect(() => getByDisplayValue('hidden', { hidden: false })).toThrow();
-  expect(queryByDisplayValue('hidden', { includeHidden: false })).toBeFalsy();
-  expect(() => getByDisplayValue('hidden', { includeHidden: false })).toThrow();
+  expect(
+    queryByDisplayValue('hidden', { includeHiddenElements: false })
+  ).toBeFalsy();
+  expect(() =>
+    getByDisplayValue('hidden', { includeHiddenElements: false })
+  ).toThrow();
 });

--- a/src/queries/__tests__/displayValue.test.tsx
+++ b/src/queries/__tests__/displayValue.test.tsx
@@ -106,13 +106,10 @@ test('byDisplayValue queries support hidden option', () => {
   );
 
   expect(getByDisplayValue('hidden')).toBeTruthy();
-  expect(getByDisplayValue('hidden', { hidden: true })).toBeTruthy();
   expect(
     getByDisplayValue('hidden', { includeHiddenElements: true })
   ).toBeTruthy();
 
-  expect(queryByDisplayValue('hidden', { hidden: false })).toBeFalsy();
-  expect(() => getByDisplayValue('hidden', { hidden: false })).toThrow();
   expect(
     queryByDisplayValue('hidden', { includeHiddenElements: false })
   ).toBeFalsy();

--- a/src/queries/__tests__/displayValue.test.tsx
+++ b/src/queries/__tests__/displayValue.test.tsx
@@ -115,5 +115,7 @@ test('byDisplayValue queries support hidden option', () => {
   ).toBeFalsy();
   expect(() =>
     getByDisplayValue('hidden', { includeHiddenElements: false })
-  ).toThrow();
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"Unable to find an element with displayValue: hidden"`
+  );
 });

--- a/src/queries/__tests__/hintText.test.tsx
+++ b/src/queries/__tests__/hintText.test.tsx
@@ -115,11 +115,8 @@ test('byHintText queries support hidden option', () => {
   );
 
   expect(getByHintText('hidden')).toBeTruthy();
-  expect(getByHintText('hidden', { hidden: true })).toBeTruthy();
   expect(getByHintText('hidden', { includeHiddenElements: true })).toBeTruthy();
 
-  expect(queryByHintText('hidden', { hidden: false })).toBeFalsy();
-  expect(() => getByHintText('hidden', { hidden: false })).toThrow();
   expect(
     queryByHintText('hidden', { includeHiddenElements: false })
   ).toBeFalsy();

--- a/src/queries/__tests__/hintText.test.tsx
+++ b/src/queries/__tests__/hintText.test.tsx
@@ -116,7 +116,10 @@ test('byHintText queries support hidden option', () => {
 
   expect(getByHintText('hidden')).toBeTruthy();
   expect(getByHintText('hidden', { hidden: true })).toBeTruthy();
+  expect(getByHintText('hidden', { includeHidden: true })).toBeTruthy();
 
   expect(queryByHintText('hidden', { hidden: false })).toBeFalsy();
   expect(() => getByHintText('hidden', { hidden: false })).toThrow();
+  expect(queryByHintText('hidden', { includeHidden: false })).toBeFalsy();
+  expect(() => getByHintText('hidden', { includeHidden: false })).toThrow();
 });

--- a/src/queries/__tests__/hintText.test.tsx
+++ b/src/queries/__tests__/hintText.test.tsx
@@ -122,5 +122,7 @@ test('byHintText queries support hidden option', () => {
   ).toBeFalsy();
   expect(() =>
     getByHintText('hidden', { includeHiddenElements: false })
-  ).toThrow();
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"Unable to find an element with accessibilityHint: hidden"`
+  );
 });

--- a/src/queries/__tests__/hintText.test.tsx
+++ b/src/queries/__tests__/hintText.test.tsx
@@ -116,10 +116,14 @@ test('byHintText queries support hidden option', () => {
 
   expect(getByHintText('hidden')).toBeTruthy();
   expect(getByHintText('hidden', { hidden: true })).toBeTruthy();
-  expect(getByHintText('hidden', { includeHidden: true })).toBeTruthy();
+  expect(getByHintText('hidden', { includeHiddenElements: true })).toBeTruthy();
 
   expect(queryByHintText('hidden', { hidden: false })).toBeFalsy();
   expect(() => getByHintText('hidden', { hidden: false })).toThrow();
-  expect(queryByHintText('hidden', { includeHidden: false })).toBeFalsy();
-  expect(() => getByHintText('hidden', { includeHidden: false })).toThrow();
+  expect(
+    queryByHintText('hidden', { includeHiddenElements: false })
+  ).toBeFalsy();
+  expect(() =>
+    getByHintText('hidden', { includeHiddenElements: false })
+  ).toThrow();
 });

--- a/src/queries/__tests__/labelText.test.tsx
+++ b/src/queries/__tests__/labelText.test.tsx
@@ -161,5 +161,7 @@ test('byLabelText queries support hidden option', () => {
   ).toBeFalsy();
   expect(() =>
     getByLabelText('hidden', { includeHiddenElements: false })
-  ).toThrow();
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"Unable to find an element with accessibilityLabel: hidden"`
+  );
 });

--- a/src/queries/__tests__/labelText.test.tsx
+++ b/src/queries/__tests__/labelText.test.tsx
@@ -153,10 +153,16 @@ test('byLabelText queries support hidden option', () => {
 
   expect(getByLabelText('hidden')).toBeTruthy();
   expect(getByLabelText('hidden', { hidden: true })).toBeTruthy();
-  expect(getByLabelText('hidden', { includeHidden: true })).toBeTruthy();
+  expect(
+    getByLabelText('hidden', { includeHiddenElements: true })
+  ).toBeTruthy();
 
   expect(queryByLabelText('hidden', { hidden: false })).toBeFalsy();
   expect(() => getByLabelText('hidden', { hidden: false })).toThrow();
-  expect(queryByLabelText('hidden', { includeHidden: false })).toBeFalsy();
-  expect(() => getByLabelText('hidden', { includeHidden: false })).toThrow();
+  expect(
+    queryByLabelText('hidden', { includeHiddenElements: false })
+  ).toBeFalsy();
+  expect(() =>
+    getByLabelText('hidden', { includeHiddenElements: false })
+  ).toThrow();
 });

--- a/src/queries/__tests__/labelText.test.tsx
+++ b/src/queries/__tests__/labelText.test.tsx
@@ -152,13 +152,10 @@ test('byLabelText queries support hidden option', () => {
   );
 
   expect(getByLabelText('hidden')).toBeTruthy();
-  expect(getByLabelText('hidden', { hidden: true })).toBeTruthy();
   expect(
     getByLabelText('hidden', { includeHiddenElements: true })
   ).toBeTruthy();
 
-  expect(queryByLabelText('hidden', { hidden: false })).toBeFalsy();
-  expect(() => getByLabelText('hidden', { hidden: false })).toThrow();
   expect(
     queryByLabelText('hidden', { includeHiddenElements: false })
   ).toBeFalsy();

--- a/src/queries/__tests__/labelText.test.tsx
+++ b/src/queries/__tests__/labelText.test.tsx
@@ -153,7 +153,10 @@ test('byLabelText queries support hidden option', () => {
 
   expect(getByLabelText('hidden')).toBeTruthy();
   expect(getByLabelText('hidden', { hidden: true })).toBeTruthy();
+  expect(getByLabelText('hidden', { includeHidden: true })).toBeTruthy();
 
   expect(queryByLabelText('hidden', { hidden: false })).toBeFalsy();
   expect(() => getByLabelText('hidden', { hidden: false })).toThrow();
+  expect(queryByLabelText('hidden', { includeHidden: false })).toBeFalsy();
+  expect(() => getByLabelText('hidden', { includeHidden: false })).toThrow();
 });

--- a/src/queries/__tests__/placeholderText.test.tsx
+++ b/src/queries/__tests__/placeholderText.test.tsx
@@ -74,5 +74,7 @@ test('byPlaceholderText queries support hidden option', () => {
   ).toBeFalsy();
   expect(() =>
     getByPlaceholderText('hidden', { includeHiddenElements: false })
-  ).toThrow();
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"Unable to find an element with placeholder: hidden"`
+  );
 });

--- a/src/queries/__tests__/placeholderText.test.tsx
+++ b/src/queries/__tests__/placeholderText.test.tsx
@@ -66,14 +66,16 @@ test('byPlaceholderText queries support hidden option', () => {
 
   expect(getByPlaceholderText('hidden')).toBeTruthy();
   expect(getByPlaceholderText('hidden', { hidden: true })).toBeTruthy();
-  expect(getByPlaceholderText('hidden', { includeHidden: true })).toBeTruthy();
+  expect(
+    getByPlaceholderText('hidden', { includeHiddenElements: true })
+  ).toBeTruthy();
 
   expect(queryByPlaceholderText('hidden', { hidden: false })).toBeFalsy();
   expect(() => getByPlaceholderText('hidden', { hidden: false })).toThrow();
   expect(
-    queryByPlaceholderText('hidden', { includeHidden: false })
+    queryByPlaceholderText('hidden', { includeHiddenElements: false })
   ).toBeFalsy();
   expect(() =>
-    getByPlaceholderText('hidden', { includeHidden: false })
+    getByPlaceholderText('hidden', { includeHiddenElements: false })
   ).toThrow();
 });

--- a/src/queries/__tests__/placeholderText.test.tsx
+++ b/src/queries/__tests__/placeholderText.test.tsx
@@ -66,7 +66,14 @@ test('byPlaceholderText queries support hidden option', () => {
 
   expect(getByPlaceholderText('hidden')).toBeTruthy();
   expect(getByPlaceholderText('hidden', { hidden: true })).toBeTruthy();
+  expect(getByPlaceholderText('hidden', { includeHidden: true })).toBeTruthy();
 
   expect(queryByPlaceholderText('hidden', { hidden: false })).toBeFalsy();
   expect(() => getByPlaceholderText('hidden', { hidden: false })).toThrow();
+  expect(
+    queryByPlaceholderText('hidden', { includeHidden: false })
+  ).toBeFalsy();
+  expect(() =>
+    getByPlaceholderText('hidden', { includeHidden: false })
+  ).toThrow();
 });

--- a/src/queries/__tests__/placeholderText.test.tsx
+++ b/src/queries/__tests__/placeholderText.test.tsx
@@ -65,13 +65,10 @@ test('byPlaceholderText queries support hidden option', () => {
   );
 
   expect(getByPlaceholderText('hidden')).toBeTruthy();
-  expect(getByPlaceholderText('hidden', { hidden: true })).toBeTruthy();
   expect(
     getByPlaceholderText('hidden', { includeHiddenElements: true })
   ).toBeTruthy();
 
-  expect(queryByPlaceholderText('hidden', { hidden: false })).toBeFalsy();
-  expect(() => getByPlaceholderText('hidden', { hidden: false })).toThrow();
   expect(
     queryByPlaceholderText('hidden', { includeHiddenElements: false })
   ).toBeFalsy();

--- a/src/queries/__tests__/role.test.tsx
+++ b/src/queries/__tests__/role.test.tsx
@@ -707,7 +707,9 @@ test('byRole queries support hidden option', () => {
 
   expect(getByRole('button')).toBeTruthy();
   expect(getByRole('button', { hidden: true })).toBeTruthy();
+  expect(getByRole('button', { includeHidden: true })).toBeTruthy();
 
   expect(queryByRole('button', { hidden: false })).toBeFalsy();
   expect(() => getByRole('button', { hidden: false })).toThrow();
+  expect(() => getByRole('button', { includeHidden: false })).toThrow();
 });

--- a/src/queries/__tests__/role.test.tsx
+++ b/src/queries/__tests__/role.test.tsx
@@ -707,9 +707,9 @@ test('byRole queries support hidden option', () => {
 
   expect(getByRole('button')).toBeTruthy();
   expect(getByRole('button', { hidden: true })).toBeTruthy();
-  expect(getByRole('button', { includeHidden: true })).toBeTruthy();
+  expect(getByRole('button', { includeHiddenElements: true })).toBeTruthy();
 
   expect(queryByRole('button', { hidden: false })).toBeFalsy();
   expect(() => getByRole('button', { hidden: false })).toThrow();
-  expect(() => getByRole('button', { includeHidden: false })).toThrow();
+  expect(() => getByRole('button', { includeHiddenElements: false })).toThrow();
 });

--- a/src/queries/__tests__/role.test.tsx
+++ b/src/queries/__tests__/role.test.tsx
@@ -709,5 +709,9 @@ test('byRole queries support hidden option', () => {
   expect(getByRole('button', { includeHiddenElements: true })).toBeTruthy();
 
   expect(queryByRole('button', { includeHiddenElements: false })).toBeFalsy();
-  expect(() => getByRole('button', { includeHiddenElements: false })).toThrow();
+  expect(() =>
+    getByRole('button', { includeHiddenElements: false })
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"Unable to find an element with role: "button""`
+  );
 });

--- a/src/queries/__tests__/role.test.tsx
+++ b/src/queries/__tests__/role.test.tsx
@@ -706,10 +706,8 @@ test('byRole queries support hidden option', () => {
   );
 
   expect(getByRole('button')).toBeTruthy();
-  expect(getByRole('button', { hidden: true })).toBeTruthy();
   expect(getByRole('button', { includeHiddenElements: true })).toBeTruthy();
 
-  expect(queryByRole('button', { hidden: false })).toBeFalsy();
-  expect(() => getByRole('button', { hidden: false })).toThrow();
+  expect(queryByRole('button', { includeHiddenElements: false })).toBeFalsy();
   expect(() => getByRole('button', { includeHiddenElements: false })).toThrow();
 });

--- a/src/queries/__tests__/testId.test.tsx
+++ b/src/queries/__tests__/testId.test.tsx
@@ -146,5 +146,7 @@ test('byTestId queries support hidden option', () => {
   expect(queryByTestId('hidden', { includeHiddenElements: false })).toBeFalsy();
   expect(() =>
     getByTestId('hidden', { includeHiddenElements: false })
-  ).toThrow();
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"Unable to find an element with testID: hidden"`
+  );
 });

--- a/src/queries/__tests__/testId.test.tsx
+++ b/src/queries/__tests__/testId.test.tsx
@@ -142,9 +142,11 @@ test('byTestId queries support hidden option', () => {
 
   expect(getByTestId('hidden')).toBeTruthy();
   expect(getByTestId('hidden', { hidden: true })).toBeTruthy();
-  expect(getByTestId('hidden', { includeHidden: true })).toBeTruthy();
+  expect(getByTestId('hidden', { includeHiddenElements: true })).toBeTruthy();
 
   expect(queryByTestId('hidden', { hidden: false })).toBeFalsy();
   expect(() => getByTestId('hidden', { hidden: false })).toThrow();
-  expect(() => getByTestId('hidden', { includeHidden: false })).toThrow();
+  expect(() =>
+    getByTestId('hidden', { includeHiddenElements: false })
+  ).toThrow();
 });

--- a/src/queries/__tests__/testId.test.tsx
+++ b/src/queries/__tests__/testId.test.tsx
@@ -142,7 +142,9 @@ test('byTestId queries support hidden option', () => {
 
   expect(getByTestId('hidden')).toBeTruthy();
   expect(getByTestId('hidden', { hidden: true })).toBeTruthy();
+  expect(getByTestId('hidden', { includeHidden: true })).toBeTruthy();
 
   expect(queryByTestId('hidden', { hidden: false })).toBeFalsy();
   expect(() => getByTestId('hidden', { hidden: false })).toThrow();
+  expect(() => getByTestId('hidden', { includeHidden: false })).toThrow();
 });

--- a/src/queries/__tests__/testId.test.tsx
+++ b/src/queries/__tests__/testId.test.tsx
@@ -141,11 +141,9 @@ test('byTestId queries support hidden option', () => {
   );
 
   expect(getByTestId('hidden')).toBeTruthy();
-  expect(getByTestId('hidden', { hidden: true })).toBeTruthy();
   expect(getByTestId('hidden', { includeHiddenElements: true })).toBeTruthy();
 
-  expect(queryByTestId('hidden', { hidden: false })).toBeFalsy();
-  expect(() => getByTestId('hidden', { hidden: false })).toThrow();
+  expect(queryByTestId('hidden', { includeHiddenElements: false })).toBeFalsy();
   expect(() =>
     getByTestId('hidden', { includeHiddenElements: false })
   ).toThrow();

--- a/src/queries/__tests__/text.test.tsx
+++ b/src/queries/__tests__/text.test.tsx
@@ -478,5 +478,7 @@ test('byText support hidden option', () => {
   expect(queryByText(/hidden/i, { includeHiddenElements: false })).toBeFalsy();
   expect(() =>
     getByText(/hidden/i, { includeHiddenElements: false })
-  ).toThrow();
+  ).toThrowErrorMatchingInlineSnapshot(
+    `"Unable to find an element with text: /hidden/i"`
+  );
 });

--- a/src/queries/__tests__/text.test.tsx
+++ b/src/queries/__tests__/text.test.tsx
@@ -474,10 +474,12 @@ test('byText support hidden option', () => {
 
   expect(getByText(/hidden/i)).toBeTruthy();
   expect(getByText(/hidden/i, { hidden: true })).toBeTruthy();
-  expect(getByText(/hidden/i, { includeHidden: true })).toBeTruthy();
+  expect(getByText(/hidden/i, { includeHiddenElements: true })).toBeTruthy();
 
   expect(queryByText(/hidden/i, { hidden: false })).toBeFalsy();
-  expect(queryByText(/hidden/i, { includeHidden: false })).toBeFalsy();
+  expect(queryByText(/hidden/i, { includeHiddenElements: false })).toBeFalsy();
   expect(() => getByText(/hidden/i, { hidden: false })).toThrow();
-  expect(() => getByText(/hidden/i, { includeHidden: false })).toThrow();
+  expect(() =>
+    getByText(/hidden/i, { includeHiddenElements: false })
+  ).toThrow();
 });

--- a/src/queries/__tests__/text.test.tsx
+++ b/src/queries/__tests__/text.test.tsx
@@ -473,12 +473,9 @@ test('byText support hidden option', () => {
   );
 
   expect(getByText(/hidden/i)).toBeTruthy();
-  expect(getByText(/hidden/i, { hidden: true })).toBeTruthy();
   expect(getByText(/hidden/i, { includeHiddenElements: true })).toBeTruthy();
 
-  expect(queryByText(/hidden/i, { hidden: false })).toBeFalsy();
   expect(queryByText(/hidden/i, { includeHiddenElements: false })).toBeFalsy();
-  expect(() => getByText(/hidden/i, { hidden: false })).toThrow();
   expect(() =>
     getByText(/hidden/i, { includeHiddenElements: false })
   ).toThrow();

--- a/src/queries/__tests__/text.test.tsx
+++ b/src/queries/__tests__/text.test.tsx
@@ -474,7 +474,10 @@ test('byText support hidden option', () => {
 
   expect(getByText(/hidden/i)).toBeTruthy();
   expect(getByText(/hidden/i, { hidden: true })).toBeTruthy();
+  expect(getByText(/hidden/i, { includeHidden: true })).toBeTruthy();
 
   expect(queryByText(/hidden/i, { hidden: false })).toBeFalsy();
+  expect(queryByText(/hidden/i, { includeHidden: false })).toBeFalsy();
   expect(() => getByText(/hidden/i, { hidden: false })).toThrow();
+  expect(() => getByText(/hidden/i, { includeHidden: false })).toThrow();
 });

--- a/src/queries/options.ts
+++ b/src/queries/options.ts
@@ -1,12 +1,11 @@
 import { NormalizerFn } from '../matches';
 
-/**
- * hidden is an alias for includeHiddenElements that exists only to match react-testing-library API
- * if both hidden and includeHiddenElements values are defined, then includeHiddenElements will take precedence
- */
 export type CommonQueryOptions = {
-  hidden?: boolean;
+  /** Should query include elements hidden from accessibility. */
   includeHiddenElements?: boolean;
+
+  /** RTL-compatibile alias to `includeHiddenElements`. */
+  hidden?: boolean;
 };
 
 export type TextMatchOptions = {

--- a/src/queries/options.ts
+++ b/src/queries/options.ts
@@ -1,6 +1,10 @@
 import { NormalizerFn } from '../matches';
 
-export type CommonQueryOptions = { hidden?: boolean };
+/**
+ * hidden is an alias for includeHidden that exists only to match react-testing-library API
+ * if both hidden and includeHidden values are defined, then includeHidden will take precedence
+ */
+export type CommonQueryOptions = { hidden?: boolean; includeHidden?: boolean };
 
 export type TextMatchOptions = {
   exact?: boolean;

--- a/src/queries/options.ts
+++ b/src/queries/options.ts
@@ -1,10 +1,13 @@
 import { NormalizerFn } from '../matches';
 
 /**
- * hidden is an alias for includeHidden that exists only to match react-testing-library API
- * if both hidden and includeHidden values are defined, then includeHidden will take precedence
+ * hidden is an alias for includeHiddenElements that exists only to match react-testing-library API
+ * if both hidden and includeHiddenElements values are defined, then includeHiddenElements will take precedence
  */
-export type CommonQueryOptions = { hidden?: boolean; includeHidden?: boolean };
+export type CommonQueryOptions = {
+  hidden?: boolean;
+  includeHiddenElements?: boolean;
+};
 
 export type TextMatchOptions = {
   exact?: boolean;

--- a/typings/index.flow.js
+++ b/typings/index.flow.js
@@ -8,7 +8,7 @@ type QueryAllReturn = Array<ReactTestInstance> | [];
 type FindReturn = Promise<ReactTestInstance>;
 type FindAllReturn = Promise<ReactTestInstance[]>;
 
-type CommonQueryOptions = { hidden?: boolean };
+type CommonQueryOptions = { hidden?: boolean, includeHidden?: boolean };
 type TextMatch = string | RegExp;
 
 declare type NormalizerFn = (textToNormalize: string) => string;

--- a/typings/index.flow.js
+++ b/typings/index.flow.js
@@ -468,12 +468,17 @@ declare module '@testing-library/react-native' {
   declare interface Config {
     asyncUtilTimeout: number;
     defaultIncludeHiddenElements: boolean;
-    /** Alias to `defaultIncludeHiddenElements` for RTL compatibility */
-    defaultHidden: boolean;
     defaultDebugOptions?: $Shape<DebugOptions>;
   }
 
-  declare export var configure: (options: $Shape<Config>) => void;
+  declare interface ConfigAliasOptions {
+    /** Alias to `defaultIncludeHiddenElements` for RTL compatibility */
+    defaultHidden: boolean;
+  }
+
+  declare export var configure: (
+    options: $Shape<Config & ConfigAliasOptions>
+  ) => void;
   declare export var resetToDefaults: () => void;
 
   declare export var act: (callback: () => void) => Thenable;

--- a/typings/index.flow.js
+++ b/typings/index.flow.js
@@ -10,7 +10,6 @@ type FindAllReturn = Promise<ReactTestInstance[]>;
 
 type CommonQueryOptions = {
   includeHiddenElements?: boolean,
-  /** Alias to `includeHiddenElements` for RTL compatibility */
   hidden?: boolean,
 };
 type TextMatch = string | RegExp;

--- a/typings/index.flow.js
+++ b/typings/index.flow.js
@@ -9,8 +9,9 @@ type FindReturn = Promise<ReactTestInstance>;
 type FindAllReturn = Promise<ReactTestInstance[]>;
 
 type CommonQueryOptions = {
-  hidden?: boolean,
   includeHiddenElements?: boolean,
+  /** Alias to `includeHiddenElements` for RTL compatibility */
+  hidden?: boolean,
 };
 type TextMatch = string | RegExp;
 
@@ -466,8 +467,9 @@ declare module '@testing-library/react-native' {
 
   declare interface Config {
     asyncUtilTimeout: number;
-    defaultHidden: boolean;
     defaultIncludeHiddenElements: boolean;
+    /** Alias to `defaultIncludeHiddenElements` for RTL compatibility */
+    defaultHidden: boolean;
     defaultDebugOptions?: $Shape<DebugOptions>;
   }
 

--- a/typings/index.flow.js
+++ b/typings/index.flow.js
@@ -8,7 +8,10 @@ type QueryAllReturn = Array<ReactTestInstance> | [];
 type FindReturn = Promise<ReactTestInstance>;
 type FindAllReturn = Promise<ReactTestInstance[]>;
 
-type CommonQueryOptions = { hidden?: boolean, includeHidden?: boolean };
+type CommonQueryOptions = {
+  hidden?: boolean,
+  includeHiddenElements?: boolean,
+};
 type TextMatch = string | RegExp;
 
 declare type NormalizerFn = (textToNormalize: string) => string;
@@ -464,7 +467,7 @@ declare module '@testing-library/react-native' {
   declare interface Config {
     asyncUtilTimeout: number;
     defaultHidden: boolean;
-    defaultIncludeHidden: boolean;
+    defaultIncludeHiddenElements: boolean;
     defaultDebugOptions?: $Shape<DebugOptions>;
   }
 

--- a/typings/index.flow.js
+++ b/typings/index.flow.js
@@ -463,6 +463,8 @@ declare module '@testing-library/react-native' {
 
   declare interface Config {
     asyncUtilTimeout: number;
+    defaultHidden: boolean;
+    defaultIncludeHidden: boolean;
     defaultDebugOptions?: $Shape<DebugOptions>;
   }
 

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -793,9 +793,11 @@ Default timeout, in ms, for async helper functions (`waitFor`, `waitForElementTo
 
 #### `defaultIncludeHiddenElements` option
 
-Default [includeHiddenElements](Queries.md#includehidden-option) query option for all queries. This default option will be overridden by the one you specify directly when using your query.
+Default value for [includeHiddenElements](Queries.md#includehidden-option) query option for all queries. Defaults to `true`, which means that queries will match [elements hidden from accessibility](#ishiddenfromaccessibility) by default.
 
-There is an alias to this option named `defaultHidden` that exists only for compatibility with [react-testing-library](https://testing-library.com/docs/dom-testing-library/api-configuration/#defaulthidden).
+Currently this option is set to `true` which means that queries will also match hidden elements. This is done to avoid breaking changes. However, we plan to change the default behavior to exclude hidden elements in the next major release.
+
+This option is also available as `defaultHidden` alias for compatibility with [React Testing Library](https://testing-library.com/docs/dom-testing-library/api-configuration/#defaulthidden).
 
 #### `defaultDebugOptions` option
 

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -50,7 +50,7 @@ title: API
 - [Configuration](#configuration)
   - [`configure`](#configure)
     - [`asyncUtilTimeout` option](#asyncutiltimeout-option)
-    - [`defaultIncludeHidden` option](#defaultincludehidden-option)
+    - [`defaultIncludeHiddenElements` option](#defaultincludehidden-option)
     - [`defaultHidden` option](#defaulthidden-option)
     - [`defaultDebugOptions` option](#defaultdebugoptions-option)
   - [`resetToDefaults()`](#resettodefaults)
@@ -792,13 +792,13 @@ function configure(options: Partial<Config>) {}
 
 Default timeout, in ms, for async helper functions (`waitFor`, `waitForElementToBeRemoved`) and `findBy*` queries. Defaults to 1000 ms.
 
-#### `defaultIncludeHidden` option
+#### `defaultIncludeHiddenElements` option
 
-Default [includeHidden](Queries.md#includehidden-option) query option for all queries. This default option will be overridden by the one you specify directly when using your query.
+Default [includeHiddenElements](Queries.md#includehidden-option) query option for all queries. This default option will be overridden by the one you specify directly when using your query.
 
 #### `defaultHidden` option
 
-This is just an alias to the `defaultIncludeHidden` option. It only exists to match react-testing-library naming used in the [configuration options](https://testing-library.com/docs/dom-testing-library/api-configuration/#defaulthidden). Prefer the use of `defaultIncludeHidden` if possible as `defaultIncludeHidden: true` is clearer than `defaultHidden: true`.
+This is just an alias to the `defaultIncludeHiddenElements` option. It only exists to match react-testing-library naming used in the [configuration options](https://testing-library.com/docs/dom-testing-library/api-configuration/#defaulthidden). Prefer the use of `defaultIncludeHiddenElements` if possible as `defaultIncludeHiddenElements: true` is clearer than `defaultHidden: true`.
 
 #### `defaultDebugOptions` option
 

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -50,6 +50,7 @@ title: API
 - [Configuration](#configuration)
   - [`configure`](#configure)
     - [`asyncUtilTimeout` option](#asyncutiltimeout-option)
+    - [`defaultIncludeHidden` option](#defaultincludehidden-option)
     - [`defaultHidden` option](#defaulthidden-option)
     - [`defaultDebugOptions` option](#defaultdebugoptions-option)
   - [`resetToDefaults()`](#resettodefaults)
@@ -791,9 +792,13 @@ function configure(options: Partial<Config>) {}
 
 Default timeout, in ms, for async helper functions (`waitFor`, `waitForElementToBeRemoved`) and `findBy*` queries. Defaults to 1000 ms.
 
+#### `defaultIncludeHidden` option
+
+Default [includeHidden](Queries.md#includehidden-option) query option for all queries. This default option will be overridden by the one you specify directly when using your query.
+
 #### `defaultHidden` option
 
-Default [hidden](Queries.md#hidden-option) query option for all queries. This default option will be overridden by the one you specify directly when using your query.
+This is just an alias to the `defaultIncludeHidden` option. It only exists to match react-testing-library naming used in the [configuration options](https://testing-library.com/docs/dom-testing-library/api-configuration/#defaulthidden). Prefer the use of `defaultIncludeHidden` if possible as `defaultIncludeHidden: true` is clearer than `defaultHidden: true`.
 
 #### `defaultDebugOptions` option
 

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -50,8 +50,7 @@ title: API
 - [Configuration](#configuration)
   - [`configure`](#configure)
     - [`asyncUtilTimeout` option](#asyncutiltimeout-option)
-    - [`defaultIncludeHiddenElements` option](#defaultincludehidden-option)
-    - [`defaultHidden` option](#defaulthidden-option)
+    - [`defaultIncludeHiddenElements` option](#defaultincludehiddenelements-option)
     - [`defaultDebugOptions` option](#defaultdebugoptions-option)
   - [`resetToDefaults()`](#resettodefaults)
   - [Environment variables](#environment-variables)
@@ -796,9 +795,7 @@ Default timeout, in ms, for async helper functions (`waitFor`, `waitForElementTo
 
 Default [includeHiddenElements](Queries.md#includehidden-option) query option for all queries. This default option will be overridden by the one you specify directly when using your query.
 
-#### `defaultHidden` option
-
-This is just an alias to the `defaultIncludeHiddenElements` option. It only exists to match react-testing-library naming used in the [configuration options](https://testing-library.com/docs/dom-testing-library/api-configuration/#defaulthidden). Prefer the use of `defaultIncludeHiddenElements` if possible as `defaultIncludeHiddenElements: true` is clearer than `defaultHidden: true`.
+There is an alias to this option named `defaultHidden` that exists only for compatibility with [react-testing-library](https://testing-library.com/docs/dom-testing-library/api-configuration/#defaulthidden).
 
 #### `defaultDebugOptions` option
 

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -378,28 +378,26 @@ const element = screen.getByA11yValue({ min: 40 });
 
 ### `includeHiddenElements` option
 
-All queries have the `includeHiddenElements` option which enables them to respect accessibility props on components when it is set to `false`. If you set `includeHiddenElements` to `true`, elements that are normally excluded from the accessibility tree are considered for the query as well. Currently `includeHiddenElements` option is set `true` by default, which means that elements includeHiddenElements from accessibility will be included by default. However, we plan to change the default value to `includeHiddenElements: false` in the next major release.
+All queries have the `includeHiddenElements` option which affects whether [elements hidden from accessibility](./API.md#ishiddenfromaccessibility) are matched by the query.
 
 You can configure the default value with the [`configure` function](API.md#configure).
 
-An element is considered to be hidden from accessibility based on [`isHiddenFromAccessibility()`](./API.md#ishiddenfromaccessibility) function.
-
-There is an alias to this option named `hidden` that exists only for compatibility with [react-testing-library](https://testing-library.com/docs/dom-testing-library/api-configuration/#defaulthidden).
+This option is also available as `hidden` alias for compatibility with [React Testing Library](https://testing-library.com/docs/queries/byrole#hidden).
 
 **Examples**
 
 ```tsx
-render(<Text style={{ display: 'none' }}>I am hidden from accessibility</Text>);
+render(<Text style={{ display: 'none' }}>Hidden from accessibility</Text>);
 
-// Include hidden elements
+// Exclude hidden elements
 expect(
-  screen.queryByText('I am hidden from accessibility', { includeHiddenElements: false })
+  screen.queryByText('Hidden from accessibility', { includeHiddenElements: false })
 ).toBeFalsy();
 
-// Match hidden elements
-expect(screen.getByText('I am hidden from accessibility')).toBeTruthy(); // Defaults to includeHiddenElements: true for now
+// Include hidden elements
+expect(screen.getByText('Hidden from accessibility')).toBeTruthy();
 expect(
-  screen.getByText('I am hidden from accessibility', { includeHiddenElements: true })
+  screen.getByText('Hidden from accessibility', { includeHiddenElements: true })
 ).toBeTruthy();
 ```
 

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -27,8 +27,7 @@ title: Queries
     - [Default state for: `checked` and `expanded` keys](#default-state-for-checked-and-expanded-keys)
   - [`ByA11Value`, `ByAccessibilityValue`](#bya11value-byaccessibilityvalue)
 - [Common options](#common-options)
-  - [`includeHiddenElements` option](#includehidden-option)
-  - [`hidden` option](#hidden-option)
+  - [`includeHiddenElements` option](#includehiddenelements-option)
 - [TextMatch](#textmatch)
   - [Examples](#examples)
   - [Precision](#precision)
@@ -385,6 +384,8 @@ You can configure the default value with the [`configure` function](API.md#confi
 
 An element is considered to be hidden from accessibility based on [`isHiddenFromAccessibility()`](./API.md#ishiddenfromaccessibility) function.
 
+There is an alias to this option named `hidden` that exists only for compatibility with [react-testing-library](https://testing-library.com/docs/dom-testing-library/api-configuration/#defaulthidden).
+
 **Examples**
 
 ```tsx
@@ -401,10 +402,6 @@ expect(
   screen.getByText('I am hidden from accessibility', { includeHiddenElements: true })
 ).toBeTruthy();
 ```
-
-### `hidden` option
-
-This is just an alias to the `includeHiddenElements` option. It only exists to match react-testing-library naming used in [byRole](https://testing-library.com/docs/queries/byrole/#hidden). Prefer the use of `includeHiddenElements` if possible as `includeHiddenElements: true` is clearer than `hidden: true`.
 
 ## TextMatch
 

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -27,6 +27,7 @@ title: Queries
     - [Default state for: `checked` and `expanded` keys](#default-state-for-checked-and-expanded-keys)
   - [`ByA11Value`, `ByAccessibilityValue`](#bya11value-byaccessibilityvalue)
 - [Common options](#common-options)
+  - [`includeHidden` option](#includehidden-option)
   - [`hidden` option](#hidden-option)
 - [TextMatch](#textmatch)
   - [Examples](#examples)
@@ -376,9 +377,9 @@ const element = screen.getByA11yValue({ min: 40 });
 
 ## Common options
 
-### `hidden` option
+### `includeHidden` option
 
-All queries have the `hidden` option which enables them to respect accessibility props on components when it is set to `false`. If you set `hidden` to `true`, elements that are normally excluded from the accessibility tree are considered for the query as well. Currently `hidden` option is set `true` by default, which means that elements hidden from accessibility will be included by default. However, we plan to change the default value to `hidden: false` in the next major release.
+All queries have the `includeHidden` option which enables them to respect accessibility props on components when it is set to `false`. If you set `includeHidden` to `true`, elements that are normally excluded from the accessibility tree are considered for the query as well. Currently `includeHidden` option is set `true` by default, which means that elements includeHidden from accessibility will be included by default. However, we plan to change the default value to `includeHidden: false` in the next major release.
 
 You can configure the default value with the [`configure` function](API.md#configure).
 
@@ -389,17 +390,21 @@ An element is considered to be hidden from accessibility based on [`isHiddenFrom
 ```tsx
 render(<Text style={{ display: 'none' }}>I am hidden from accessibility</Text>);
 
-// Ignore hidden elements
+// Include hidden elements
 expect(
-  screen.queryByText('I am hidden from accessibility', { hidden: false })
+  screen.queryByText('I am hidden from accessibility', { includeHidden: false })
 ).toBeFalsy();
 
 // Match hidden elements
-expect(screen.getByText('I am hidden from accessibility')).toBeTruthy(); // Defaults to hidden: true for now
+expect(screen.getByText('I am hidden from accessibility')).toBeTruthy(); // Defaults to includeHidden: true for now
 expect(
-  screen.getByText('I am hidden from accessibility', { hidden: true })
+  screen.getByText('I am hidden from accessibility', { includeHidden: true })
 ).toBeTruthy();
 ```
+
+### `hidden` option
+
+This is just an alias to the `includeHidden` option. It only exists to match react-testing-library naming used in [byRole](https://testing-library.com/docs/queries/byrole/#hidden). Prefer the use of `includeHidden` if possible as `includeHidden: true` is clearer than `hidden: true`.
 
 ## TextMatch
 

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -27,7 +27,7 @@ title: Queries
     - [Default state for: `checked` and `expanded` keys](#default-state-for-checked-and-expanded-keys)
   - [`ByA11Value`, `ByAccessibilityValue`](#bya11value-byaccessibilityvalue)
 - [Common options](#common-options)
-  - [`includeHidden` option](#includehidden-option)
+  - [`includeHiddenElements` option](#includehidden-option)
   - [`hidden` option](#hidden-option)
 - [TextMatch](#textmatch)
   - [Examples](#examples)
@@ -377,9 +377,9 @@ const element = screen.getByA11yValue({ min: 40 });
 
 ## Common options
 
-### `includeHidden` option
+### `includeHiddenElements` option
 
-All queries have the `includeHidden` option which enables them to respect accessibility props on components when it is set to `false`. If you set `includeHidden` to `true`, elements that are normally excluded from the accessibility tree are considered for the query as well. Currently `includeHidden` option is set `true` by default, which means that elements includeHidden from accessibility will be included by default. However, we plan to change the default value to `includeHidden: false` in the next major release.
+All queries have the `includeHiddenElements` option which enables them to respect accessibility props on components when it is set to `false`. If you set `includeHiddenElements` to `true`, elements that are normally excluded from the accessibility tree are considered for the query as well. Currently `includeHiddenElements` option is set `true` by default, which means that elements includeHiddenElements from accessibility will be included by default. However, we plan to change the default value to `includeHiddenElements: false` in the next major release.
 
 You can configure the default value with the [`configure` function](API.md#configure).
 
@@ -392,19 +392,19 @@ render(<Text style={{ display: 'none' }}>I am hidden from accessibility</Text>);
 
 // Include hidden elements
 expect(
-  screen.queryByText('I am hidden from accessibility', { includeHidden: false })
+  screen.queryByText('I am hidden from accessibility', { includeHiddenElements: false })
 ).toBeFalsy();
 
 // Match hidden elements
-expect(screen.getByText('I am hidden from accessibility')).toBeTruthy(); // Defaults to includeHidden: true for now
+expect(screen.getByText('I am hidden from accessibility')).toBeTruthy(); // Defaults to includeHiddenElements: true for now
 expect(
-  screen.getByText('I am hidden from accessibility', { includeHidden: true })
+  screen.getByText('I am hidden from accessibility', { includeHiddenElements: true })
 ).toBeTruthy();
 ```
 
 ### `hidden` option
 
-This is just an alias to the `includeHidden` option. It only exists to match react-testing-library naming used in [byRole](https://testing-library.com/docs/queries/byrole/#hidden). Prefer the use of `includeHidden` if possible as `includeHidden: true` is clearer than `hidden: true`.
+This is just an alias to the `includeHiddenElements` option. It only exists to match react-testing-library naming used in [byRole](https://testing-library.com/docs/queries/byrole/#hidden). Prefer the use of `includeHiddenElements` if possible as `includeHiddenElements: true` is clearer than `hidden: true`.
 
 ## TextMatch
 


### PR DESCRIPTION
This PR aims to tackle [this issue](https://github.com/callstack/react-native-testing-library/issues/1194). Basically the idea is to add a new option `includeHidden` that will be an alias to the query option `hidden` but much clearer. We keep the old name `hidden` for compatibility with RTL

### Summary

- [x] Alias `hidden` query option to `hidden`
- [x] Alias `defaultHidden` config to `defaultIncludeHidden`
- [x] add new alias to docs

### Test plan

- [x] Check new `includeHidden` option is working for all queries
- [x] Check new `defaultIncludeHidden` option is working

### Remaining work

- [x] Choose a naming between `includeHidden` and `includeHiddenFromAccessibility`

Resolves #1194
