### PR TITLE
fix: remounting root (when using screen)

### DIFF
--- a/src/__tests__/screen.test.tsx
+++ b/src/__tests__/screen.test.tsx
@@ -23,12 +23,22 @@ test('screen holds last render result', () => {
   expect(screen.queryByText('Mt. Blanc')).toBeFalsy();
 });
 
-test('screen works with updating rerender', () => {
+test('screen works with rerender', () => {
   const result = render(<Text>Mt. Everest</Text>);
   expect(screen).toBe(result);
+  expect(screen.getByText('Mt. Everest')).toBeTruthy();
 
   screen.rerender(<Text>Śnieżka</Text>);
   expect(screen).toBe(result);
+  expect(screen.getByText('Śnieżka')).toBeTruthy();
+});
+
+test('screen works with re-mounting root', () => {
+  const result = render(<Text key="1">Mt. Everest</Text>);
+  expect(screen).toBe(result);
+  expect(screen.getByText('Mt. Everest')).toBeTruthy();
+
+  screen.rerender(<Text key="2">Śnieżka</Text>);
   expect(screen.getByText('Śnieżka')).toBeTruthy();
 });
 

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -132,6 +132,19 @@ function updateWithAct(
     act(() => {
       renderer.update(wrap(component));
     });
+
+    // Rebind queries and helper only when root instance changes.
+    // This will not affect render calls using `wrapper` or
+    // `unstable_validateStringsRenderedWithinText` options as they will create
+    // a wrapping root that does not change.
+    if (screen.container !== renderer.root) {
+      setRenderResult({
+        ...screen,
+        ...getQueriesForElement(renderer.root),
+        container: renderer.root,
+        debug: debug(renderer.root, renderer),
+      });
+    }
   };
 }
 


### PR DESCRIPTION
### Summary

This partially resolves #996.

1. Supported use case:
```tsx
test('screen works with re-mounting root', () => {
  render(<Text key="1">Mt. Everest</Text>);
  expect(screen.getByText('Mt. Everest')).toBeTruthy();

  screen.rerender(<Text key="2">Śnieżka</Text>);
  expect(screen.getByText('Śnieżka')).toBeTruthy();
});
```

2. Not supported use case:
```tsx
test('render result works with re-mounting root', () => {
  const { rerender, getByText } = render(<Text key="1">Mt. Everest</Text>);
  expect(getByText('Mt. Everest')).toBeTruthy();

  rerender(<Text key="2">Śnieżka</Text>);
  // Next line throws "Unable to find node on an unmounted component."
  expect(getByText('Śnieżka')).toBeTruthy();
});
```
This fix rebinds `screen` on `update`/`rerender` call that change the `root` instance. In order to maintain current behaviour, queries are not re-bound when `root` instance is the same.

Due to our code structure it's quite complex to support 2. as the queries returned from `render` are already bound when captured by the user. This could be mitigated by applying some form of delegation but that would be quite complex change for edge case issue. I think that supporting `screen` use case is good enough for user that might encounter this issue. 

Resolves #996 

### Test plan

Added test covering the relevant case.