### PR TITLE
chore: deprecate some a11y queries

### DIFF
--- a/src/helpers/__tests__/query-name.test.ts
+++ b/src/helpers/__tests__/query-name.test.ts
@@ -1,0 +1,10 @@
+import { getQueryPrefix } from '../query-name';
+
+test('getQueryPrefix should return correct prefix', () => {
+  expect(getQueryPrefix('getByRole')).toBe('get');
+  expect(getQueryPrefix('getAllByText')).toEqual('getAll');
+  expect(getQueryPrefix('queryByTestId')).toEqual('query');
+  expect(getQueryPrefix('queryAllByPlaceholderText')).toEqual('queryAll');
+  expect(getQueryPrefix('findByHintText')).toEqual('find');
+  expect(getQueryPrefix('findAllByDisplayValue')).toEqual('findAll');
+});

--- a/src/helpers/deprecation.ts
+++ b/src/helpers/deprecation.ts
@@ -1,12 +1,12 @@
+import { getQueryPrefix } from './query-name';
+
 export function deprecateAllQueries<Queries extends Record<string, any>>(
   queriesObject: Queries,
-  querySuffix: string,
-  recommendationSuffix: string
+  recommendation: string
 ): Queries {
   const result = {} as Queries;
   Object.keys(queriesObject).forEach((queryName) => {
     const queryFn = queriesObject[queryName];
-    const recommendation = queryName.replace(querySuffix, recommendationSuffix);
     // @ts-expect-error: generic typing is hard
     result[queryName] = deprecateQuery(queryFn, queryName, recommendation);
   });
@@ -19,13 +19,16 @@ export function deprecateQuery<QueryFn extends (...args: any) => any>(
   queryName: string,
   recommendation: string
 ): QueryFn {
+  const formattedRecommendation = recommendation.replace(
+    /{queryPrefix}/g,
+    getQueryPrefix(queryName)
+  );
+
   // @ts-expect-error: generic typing is hard
   const wrapper: QueryFn = (...args: any) => {
+    const errorMessage = `${queryName}(...) is deprecated.\n\n${formattedRecommendation}`;
     // eslint-disable-next-line no-console
-    console.warn(
-      `${queryName}(...) is deprecated.\n\nPlease use ${recommendation} instead.`
-    );
-
+    console.warn(errorMessage);
     return queryFn(...args);
   };
 

--- a/src/helpers/deprecation.ts
+++ b/src/helpers/deprecation.ts
@@ -23,7 +23,7 @@ export function deprecateQuery<QueryFn extends (...args: any) => any>(
   const wrapper: QueryFn = (...args: any) => {
     // eslint-disable-next-line no-console
     console.warn(
-      `${queryName}(...) is deprecated. Please use ${recommendation} instead.`
+      `${queryName}(...) is deprecated.\n\nPlease use ${recommendation} instead.`
     );
 
     return queryFn(...args);

--- a/src/helpers/deprecation.ts
+++ b/src/helpers/deprecation.ts
@@ -1,6 +1,6 @@
 import { getQueryPrefix } from './query-name';
 
-export function deprecateAllQueries<Queries extends Record<string, any>>(
+export function deprecateQueries<Queries extends Record<string, any>>(
   queriesObject: Queries,
   recommendation: string
 ): Queries {
@@ -14,7 +14,7 @@ export function deprecateAllQueries<Queries extends Record<string, any>>(
   return result;
 }
 
-export function deprecateQuery<QueryFn extends (...args: any) => any>(
+function deprecateQuery<QueryFn extends (...args: any) => any>(
   queryFn: QueryFn,
   queryName: string,
   recommendation: string
@@ -26,7 +26,7 @@ export function deprecateQuery<QueryFn extends (...args: any) => any>(
 
   // @ts-expect-error: generic typing is hard
   const wrapper: QueryFn = (...args: any) => {
-    const errorMessage = `${queryName}(...) is deprecated.\n\n${formattedRecommendation}`;
+    const errorMessage = `${queryName}(...) is deprecated and will be removed in the future.\n\n${formattedRecommendation}`;
     // eslint-disable-next-line no-console
     console.warn(errorMessage);
     return queryFn(...args);

--- a/src/helpers/deprecation.ts
+++ b/src/helpers/deprecation.ts
@@ -1,0 +1,33 @@
+export function deprecateAllQueries<Queries extends Record<string, any>>(
+  queriesObject: Queries,
+  querySuffix: string,
+  recommendationSuffix: string
+): Queries {
+  const result = {} as Queries;
+  Object.keys(queriesObject).forEach((queryName) => {
+    const queryFn = queriesObject[queryName];
+    const recommendation = queryName.replace(querySuffix, recommendationSuffix);
+    // @ts-expect-error: generic typing is hard
+    result[queryName] = deprecateQuery(queryFn, queryName, recommendation);
+  });
+
+  return result;
+}
+
+export function deprecateQuery<QueryFn extends (...args: any) => any>(
+  queryFn: QueryFn,
+  queryName: string,
+  recommendation: string
+): QueryFn {
+  // @ts-expect-error: generic typing is hard
+  const wrapper: QueryFn = (...args: any) => {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `${queryName}(...) is deprecated. Please use ${recommendation} instead.`
+    );
+
+    return queryFn(...args);
+  };
+
+  return wrapper;
+}

--- a/src/helpers/query-name.ts
+++ b/src/helpers/query-name.ts
@@ -1,0 +1,4 @@
+export function getQueryPrefix(queryName: string) {
+  const parts = queryName.split('By');
+  return parts[0];
+}

--- a/src/queries/__tests__/a11yState.test.tsx
+++ b/src/queries/__tests__/a11yState.test.tsx
@@ -267,42 +267,42 @@ test('*ByA11yState deprecation warnings', () => {
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
     "getByA11yState(...) is deprecated.
 
-    Please use getByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use getByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.getAllByA11yState({ disabled: true });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
     "getAllByA11yState(...) is deprecated.
 
-    Please use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.queryByA11yState({ disabled: true });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
     "queryByA11yState(...) is deprecated.
 
-    Please use queryByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use queryByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.queryAllByA11yState({ disabled: true });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
     "queryAllByA11yState(...) is deprecated.
 
-    Please use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.findByA11yState({ disabled: true });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
     "findByA11yState(...) is deprecated.
 
-    Please use findByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use findByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.findAllByA11yState({ disabled: true });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
     "findAllByA11yState(...) is deprecated.
 
-    Please use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 });
 
@@ -314,41 +314,41 @@ test('*ByAccessibilityState deprecation warnings', () => {
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
     "getByAccessibilityState(...) is deprecated.
 
-    Please use getByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use getByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.getAllByAccessibilityState({ disabled: true });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
     "getAllByAccessibilityState(...) is deprecated.
 
-    Please use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.queryByAccessibilityState({ disabled: true });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
     "queryByAccessibilityState(...) is deprecated.
 
-    Please use queryByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use queryByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.queryAllByAccessibilityState({ disabled: true });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
     "queryAllByAccessibilityState(...) is deprecated.
 
-    Please use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.findByAccessibilityState({ disabled: true });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
     "findByAccessibilityState(...) is deprecated.
 
-    Please use findByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use findByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.findAllByAccessibilityState({ disabled: true });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
     "findAllByAccessibilityState(...) is deprecated.
 
-    Please use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 });

--- a/src/queries/__tests__/a11yState.test.tsx
+++ b/src/queries/__tests__/a11yState.test.tsx
@@ -264,34 +264,52 @@ test('*ByA11yState deprecation warnings', () => {
   const view = render(<View accessibilityState={{ disabled: true }} />);
 
   view.getByA11yState({ disabled: true });
-  expect(mockCalls[0][0]).toMatchInlineSnapshot(
-    `"getByA11yState(...) is deprecated. Please use getByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
-  );
+  expect(mockCalls[0][0]).toMatchInlineSnapshot(`
+    "getByA11yState(...) is deprecated.
+
+    Please use getByRole(role, { disabled, selected, checked, busy, expanded }) query
+    or expect(...).toHaveAccessibilityState(...) matcher instead."
+  `);
 
   view.getAllByA11yState({ disabled: true });
-  expect(mockCalls[1][0]).toMatchInlineSnapshot(
-    `"getAllByA11yState(...) is deprecated. Please use getAllByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
-  );
+  expect(mockCalls[1][0]).toMatchInlineSnapshot(`
+    "getAllByA11yState(...) is deprecated.
+
+    Please use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query
+    or expect(...).toHaveAccessibilityState(...) matcher instead."
+  `);
 
   view.queryByA11yState({ disabled: true });
-  expect(mockCalls[2][0]).toMatchInlineSnapshot(
-    `"queryByA11yState(...) is deprecated. Please use queryByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
-  );
+  expect(mockCalls[2][0]).toMatchInlineSnapshot(`
+    "queryByA11yState(...) is deprecated.
+
+    Please use queryByRole(role, { disabled, selected, checked, busy, expanded }) query
+    or expect(...).toHaveAccessibilityState(...) matcher instead."
+  `);
 
   view.queryAllByA11yState({ disabled: true });
-  expect(mockCalls[3][0]).toMatchInlineSnapshot(
-    `"queryAllByA11yState(...) is deprecated. Please use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
-  );
+  expect(mockCalls[3][0]).toMatchInlineSnapshot(`
+    "queryAllByA11yState(...) is deprecated.
+
+    Please use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query
+    or expect(...).toHaveAccessibilityState(...) matcher instead."
+  `);
 
   view.findByA11yState({ disabled: true });
-  expect(mockCalls[4][0]).toMatchInlineSnapshot(
-    `"findByA11yState(...) is deprecated. Please use findByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
-  );
+  expect(mockCalls[4][0]).toMatchInlineSnapshot(`
+    "findByA11yState(...) is deprecated.
+
+    Please use findByRole(role, { disabled, selected, checked, busy, expanded }) query
+    or expect(...).toHaveAccessibilityState(...) matcher instead."
+  `);
 
   view.findAllByA11yState({ disabled: true });
-  expect(mockCalls[5][0]).toMatchInlineSnapshot(
-    `"findAllByA11yState(...) is deprecated. Please use findAllByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
-  );
+  expect(mockCalls[5][0]).toMatchInlineSnapshot(`
+    "findAllByA11yState(...) is deprecated.
+
+    Please use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query
+    or expect(...).toHaveAccessibilityState(...) matcher instead."
+  `);
 });
 
 test('*ByAccessibilityState deprecation warnings', () => {
@@ -299,32 +317,50 @@ test('*ByAccessibilityState deprecation warnings', () => {
   const view = render(<View accessibilityState={{ disabled: true }} />);
 
   view.getByAccessibilityState({ disabled: true });
-  expect(mockCalls[0][0]).toMatchInlineSnapshot(
-    `"getByAccessibilityState(...) is deprecated. Please use getByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
-  );
+  expect(mockCalls[0][0]).toMatchInlineSnapshot(`
+    "getByAccessibilityState(...) is deprecated.
+
+    Please use getByRole(role, { disabled, selected, checked, busy, expanded }) query
+    or expect(...).toHaveAccessibilityState(...) matcher instead."
+  `);
 
   view.getAllByAccessibilityState({ disabled: true });
-  expect(mockCalls[1][0]).toMatchInlineSnapshot(
-    `"getAllByAccessibilityState(...) is deprecated. Please use getAllByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
-  );
+  expect(mockCalls[1][0]).toMatchInlineSnapshot(`
+    "getAllByAccessibilityState(...) is deprecated.
+
+    Please use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query
+    or expect(...).toHaveAccessibilityState(...) matcher instead."
+  `);
 
   view.queryByAccessibilityState({ disabled: true });
-  expect(mockCalls[2][0]).toMatchInlineSnapshot(
-    `"queryByAccessibilityState(...) is deprecated. Please use queryByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
-  );
+  expect(mockCalls[2][0]).toMatchInlineSnapshot(`
+    "queryByAccessibilityState(...) is deprecated.
+
+    Please use queryByRole(role, { disabled, selected, checked, busy, expanded }) query
+    or expect(...).toHaveAccessibilityState(...) matcher instead."
+  `);
 
   view.queryAllByAccessibilityState({ disabled: true });
-  expect(mockCalls[3][0]).toMatchInlineSnapshot(
-    `"queryAllByAccessibilityState(...) is deprecated. Please use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
-  );
+  expect(mockCalls[3][0]).toMatchInlineSnapshot(`
+    "queryAllByAccessibilityState(...) is deprecated.
+
+    Please use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query
+    or expect(...).toHaveAccessibilityState(...) matcher instead."
+  `);
 
   view.findByAccessibilityState({ disabled: true });
-  expect(mockCalls[4][0]).toMatchInlineSnapshot(
-    `"findByAccessibilityState(...) is deprecated. Please use findByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
-  );
+  expect(mockCalls[4][0]).toMatchInlineSnapshot(`
+    "findByAccessibilityState(...) is deprecated.
+
+    Please use findByRole(role, { disabled, selected, checked, busy, expanded }) query
+    or expect(...).toHaveAccessibilityState(...) matcher instead."
+  `);
 
   view.findAllByAccessibilityState({ disabled: true });
-  expect(mockCalls[5][0]).toMatchInlineSnapshot(
-    `"findAllByAccessibilityState(...) is deprecated. Please use findAllByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
-  );
+  expect(mockCalls[5][0]).toMatchInlineSnapshot(`
+    "findAllByAccessibilityState(...) is deprecated.
+
+    Please use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query
+    or expect(...).toHaveAccessibilityState(...) matcher instead."
+  `);
 });

--- a/src/queries/__tests__/a11yState.test.tsx
+++ b/src/queries/__tests__/a11yState.test.tsx
@@ -265,42 +265,42 @@ test('*ByA11yState deprecation warnings', () => {
 
   view.getByA11yState({ disabled: true });
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
-    "getByA11yState(...) is deprecated.
+    "getByA11yState(...) is deprecated and will be removed in the future.
 
     Use getByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.getAllByA11yState({ disabled: true });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
-    "getAllByA11yState(...) is deprecated.
+    "getAllByA11yState(...) is deprecated and will be removed in the future.
 
     Use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.queryByA11yState({ disabled: true });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
-    "queryByA11yState(...) is deprecated.
+    "queryByA11yState(...) is deprecated and will be removed in the future.
 
     Use queryByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.queryAllByA11yState({ disabled: true });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
-    "queryAllByA11yState(...) is deprecated.
+    "queryAllByA11yState(...) is deprecated and will be removed in the future.
 
     Use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.findByA11yState({ disabled: true });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
-    "findByA11yState(...) is deprecated.
+    "findByA11yState(...) is deprecated and will be removed in the future.
 
     Use findByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.findAllByA11yState({ disabled: true });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
-    "findAllByA11yState(...) is deprecated.
+    "findAllByA11yState(...) is deprecated and will be removed in the future.
 
     Use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
@@ -312,42 +312,42 @@ test('*ByAccessibilityState deprecation warnings', () => {
 
   view.getByAccessibilityState({ disabled: true });
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
-    "getByAccessibilityState(...) is deprecated.
+    "getByAccessibilityState(...) is deprecated and will be removed in the future.
 
     Use getByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.getAllByAccessibilityState({ disabled: true });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
-    "getAllByAccessibilityState(...) is deprecated.
+    "getAllByAccessibilityState(...) is deprecated and will be removed in the future.
 
     Use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.queryByAccessibilityState({ disabled: true });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
-    "queryByAccessibilityState(...) is deprecated.
+    "queryByAccessibilityState(...) is deprecated and will be removed in the future.
 
     Use queryByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.queryAllByAccessibilityState({ disabled: true });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
-    "queryAllByAccessibilityState(...) is deprecated.
+    "queryAllByAccessibilityState(...) is deprecated and will be removed in the future.
 
     Use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.findByAccessibilityState({ disabled: true });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
-    "findByAccessibilityState(...) is deprecated.
+    "findByAccessibilityState(...) is deprecated and will be removed in the future.
 
     Use findByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.findAllByAccessibilityState({ disabled: true });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
-    "findAllByAccessibilityState(...) is deprecated.
+    "findAllByAccessibilityState(...) is deprecated and will be removed in the future.
 
     Use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);

--- a/src/queries/__tests__/a11yState.test.tsx
+++ b/src/queries/__tests__/a11yState.test.tsx
@@ -267,42 +267,42 @@ test('*ByA11yState deprecation warnings', () => {
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
     "getByA11yState(...) is deprecated and will be removed in the future.
 
-    Use getByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use getByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
   `);
 
   view.getAllByA11yState({ disabled: true });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
     "getAllByA11yState(...) is deprecated and will be removed in the future.
 
-    Use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
   `);
 
   view.queryByA11yState({ disabled: true });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
     "queryByA11yState(...) is deprecated and will be removed in the future.
 
-    Use queryByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use queryByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
   `);
 
   view.queryAllByA11yState({ disabled: true });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
     "queryAllByA11yState(...) is deprecated and will be removed in the future.
 
-    Use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
   `);
 
   view.findByA11yState({ disabled: true });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
     "findByA11yState(...) is deprecated and will be removed in the future.
 
-    Use findByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use findByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
   `);
 
   view.findAllByA11yState({ disabled: true });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
     "findAllByA11yState(...) is deprecated and will be removed in the future.
 
-    Use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
   `);
 });
 
@@ -314,41 +314,41 @@ test('*ByAccessibilityState deprecation warnings', () => {
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
     "getByAccessibilityState(...) is deprecated and will be removed in the future.
 
-    Use getByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use getByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
   `);
 
   view.getAllByAccessibilityState({ disabled: true });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
     "getAllByAccessibilityState(...) is deprecated and will be removed in the future.
 
-    Use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
   `);
 
   view.queryByAccessibilityState({ disabled: true });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
     "queryByAccessibilityState(...) is deprecated and will be removed in the future.
 
-    Use queryByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use queryByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
   `);
 
   view.queryAllByAccessibilityState({ disabled: true });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
     "queryAllByAccessibilityState(...) is deprecated and will be removed in the future.
 
-    Use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
   `);
 
   view.findByAccessibilityState({ disabled: true });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
     "findByAccessibilityState(...) is deprecated and will be removed in the future.
 
-    Use findByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use findByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
   `);
 
   view.findAllByAccessibilityState({ disabled: true });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
     "findAllByAccessibilityState(...) is deprecated and will be removed in the future.
 
-    Use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
   `);
 });

--- a/src/queries/__tests__/a11yState.test.tsx
+++ b/src/queries/__tests__/a11yState.test.tsx
@@ -267,48 +267,42 @@ test('*ByA11yState deprecation warnings', () => {
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
     "getByA11yState(...) is deprecated.
 
-    Please use getByRole(role, { disabled, selected, checked, busy, expanded }) query
-    or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Please use getByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.getAllByA11yState({ disabled: true });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
     "getAllByA11yState(...) is deprecated.
 
-    Please use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query
-    or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Please use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.queryByA11yState({ disabled: true });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
     "queryByA11yState(...) is deprecated.
 
-    Please use queryByRole(role, { disabled, selected, checked, busy, expanded }) query
-    or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Please use queryByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.queryAllByA11yState({ disabled: true });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
     "queryAllByA11yState(...) is deprecated.
 
-    Please use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query
-    or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Please use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.findByA11yState({ disabled: true });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
     "findByA11yState(...) is deprecated.
 
-    Please use findByRole(role, { disabled, selected, checked, busy, expanded }) query
-    or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Please use findByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.findAllByA11yState({ disabled: true });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
     "findAllByA11yState(...) is deprecated.
 
-    Please use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query
-    or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Please use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 });
 
@@ -320,47 +314,41 @@ test('*ByAccessibilityState deprecation warnings', () => {
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
     "getByAccessibilityState(...) is deprecated.
 
-    Please use getByRole(role, { disabled, selected, checked, busy, expanded }) query
-    or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Please use getByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.getAllByAccessibilityState({ disabled: true });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
     "getAllByAccessibilityState(...) is deprecated.
 
-    Please use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query
-    or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Please use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.queryByAccessibilityState({ disabled: true });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
     "queryByAccessibilityState(...) is deprecated.
 
-    Please use queryByRole(role, { disabled, selected, checked, busy, expanded }) query
-    or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Please use queryByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.queryAllByAccessibilityState({ disabled: true });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
     "queryAllByAccessibilityState(...) is deprecated.
 
-    Please use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query
-    or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Please use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.findByAccessibilityState({ disabled: true });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
     "findByAccessibilityState(...) is deprecated.
 
-    Please use findByRole(role, { disabled, selected, checked, busy, expanded }) query
-    or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Please use findByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 
   view.findAllByAccessibilityState({ disabled: true });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
     "findAllByAccessibilityState(...) is deprecated.
 
-    Please use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query
-    or expect(...).toHaveAccessibilityState(...) matcher instead."
+    Please use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead."
   `);
 });

--- a/src/queries/__tests__/a11yState.test.tsx
+++ b/src/queries/__tests__/a11yState.test.tsx
@@ -267,42 +267,42 @@ test('*ByA11yState deprecation warnings', () => {
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
     "getByA11yState(...) is deprecated and will be removed in the future.
 
-    Use getByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
+    Use getByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from "@testing-library/jest-native" package instead."
   `);
 
   view.getAllByA11yState({ disabled: true });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
     "getAllByA11yState(...) is deprecated and will be removed in the future.
 
-    Use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
+    Use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from "@testing-library/jest-native" package instead."
   `);
 
   view.queryByA11yState({ disabled: true });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
     "queryByA11yState(...) is deprecated and will be removed in the future.
 
-    Use queryByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
+    Use queryByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from "@testing-library/jest-native" package instead."
   `);
 
   view.queryAllByA11yState({ disabled: true });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
     "queryAllByA11yState(...) is deprecated and will be removed in the future.
 
-    Use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
+    Use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from "@testing-library/jest-native" package instead."
   `);
 
   view.findByA11yState({ disabled: true });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
     "findByA11yState(...) is deprecated and will be removed in the future.
 
-    Use findByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
+    Use findByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from "@testing-library/jest-native" package instead."
   `);
 
   view.findAllByA11yState({ disabled: true });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
     "findAllByA11yState(...) is deprecated and will be removed in the future.
 
-    Use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
+    Use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from "@testing-library/jest-native" package instead."
   `);
 });
 
@@ -314,41 +314,41 @@ test('*ByAccessibilityState deprecation warnings', () => {
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
     "getByAccessibilityState(...) is deprecated and will be removed in the future.
 
-    Use getByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
+    Use getByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from "@testing-library/jest-native" package instead."
   `);
 
   view.getAllByAccessibilityState({ disabled: true });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
     "getAllByAccessibilityState(...) is deprecated and will be removed in the future.
 
-    Use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
+    Use getAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from "@testing-library/jest-native" package instead."
   `);
 
   view.queryByAccessibilityState({ disabled: true });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
     "queryByAccessibilityState(...) is deprecated and will be removed in the future.
 
-    Use queryByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
+    Use queryByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from "@testing-library/jest-native" package instead."
   `);
 
   view.queryAllByAccessibilityState({ disabled: true });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
     "queryAllByAccessibilityState(...) is deprecated and will be removed in the future.
 
-    Use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
+    Use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from "@testing-library/jest-native" package instead."
   `);
 
   view.findByAccessibilityState({ disabled: true });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
     "findByAccessibilityState(...) is deprecated and will be removed in the future.
 
-    Use findByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
+    Use findByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from "@testing-library/jest-native" package instead."
   `);
 
   view.findAllByAccessibilityState({ disabled: true });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
     "findAllByAccessibilityState(...) is deprecated and will be removed in the future.
 
-    Use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead."
+    Use findAllByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from "@testing-library/jest-native" package instead."
   `);
 });

--- a/src/queries/__tests__/a11yState.test.tsx
+++ b/src/queries/__tests__/a11yState.test.tsx
@@ -1,6 +1,13 @@
+/* eslint-disable no-console */
 import * as React from 'react';
 import { View, Text, Pressable, TouchableOpacity } from 'react-native';
 import { render } from '../..';
+
+type ConsoleLogMock = jest.Mock<typeof console.log>;
+
+beforeEach(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
 
 const TEXT_LABEL = 'cool text';
 
@@ -249,5 +256,75 @@ test('byA11yState queries support hidden option', () => {
     getByA11yState({ expanded: false }, { includeHiddenElements: false })
   ).toThrowErrorMatchingInlineSnapshot(
     `"Unable to find an element with expanded state: false"`
+  );
+});
+
+test('*ByA11yState deprecation warnings', () => {
+  const mockCalls = (console.warn as ConsoleLogMock).mock.calls;
+  const view = render(<View accessibilityState={{ disabled: true }} />);
+
+  view.getByA11yState({ disabled: true });
+  expect(mockCalls[0][0]).toMatchInlineSnapshot(
+    `"getByA11yState(...) is deprecated. Please use getByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
+  );
+
+  view.getAllByA11yState({ disabled: true });
+  expect(mockCalls[1][0]).toMatchInlineSnapshot(
+    `"getAllByA11yState(...) is deprecated. Please use getAllByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
+  );
+
+  view.queryByA11yState({ disabled: true });
+  expect(mockCalls[2][0]).toMatchInlineSnapshot(
+    `"queryByA11yState(...) is deprecated. Please use queryByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
+  );
+
+  view.queryAllByA11yState({ disabled: true });
+  expect(mockCalls[3][0]).toMatchInlineSnapshot(
+    `"queryAllByA11yState(...) is deprecated. Please use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
+  );
+
+  view.findByA11yState({ disabled: true });
+  expect(mockCalls[4][0]).toMatchInlineSnapshot(
+    `"findByA11yState(...) is deprecated. Please use findByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
+  );
+
+  view.findAllByA11yState({ disabled: true });
+  expect(mockCalls[5][0]).toMatchInlineSnapshot(
+    `"findAllByA11yState(...) is deprecated. Please use findAllByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
+  );
+});
+
+test('*ByAccessibilityState deprecation warnings', () => {
+  const mockCalls = (console.warn as ConsoleLogMock).mock.calls;
+  const view = render(<View accessibilityState={{ disabled: true }} />);
+
+  view.getByAccessibilityState({ disabled: true });
+  expect(mockCalls[0][0]).toMatchInlineSnapshot(
+    `"getByAccessibilityState(...) is deprecated. Please use getByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
+  );
+
+  view.getAllByAccessibilityState({ disabled: true });
+  expect(mockCalls[1][0]).toMatchInlineSnapshot(
+    `"getAllByAccessibilityState(...) is deprecated. Please use getAllByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
+  );
+
+  view.queryByAccessibilityState({ disabled: true });
+  expect(mockCalls[2][0]).toMatchInlineSnapshot(
+    `"queryByAccessibilityState(...) is deprecated. Please use queryByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
+  );
+
+  view.queryAllByAccessibilityState({ disabled: true });
+  expect(mockCalls[3][0]).toMatchInlineSnapshot(
+    `"queryAllByAccessibilityState(...) is deprecated. Please use queryAllByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
+  );
+
+  view.findByAccessibilityState({ disabled: true });
+  expect(mockCalls[4][0]).toMatchInlineSnapshot(
+    `"findByAccessibilityState(...) is deprecated. Please use findByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
+  );
+
+  view.findAllByAccessibilityState({ disabled: true });
+  expect(mockCalls[5][0]).toMatchInlineSnapshot(
+    `"findAllByAccessibilityState(...) is deprecated. Please use findAllByRole(role, { disabled, selected, checked, busy, expanded }) instead."`
   );
 });

--- a/src/queries/__tests__/a11yValue.test.tsx
+++ b/src/queries/__tests__/a11yValue.test.tsx
@@ -1,6 +1,13 @@
+/* eslint-disable no-console */
 import * as React from 'react';
 import { View, Text, TouchableOpacity } from 'react-native';
 import { render } from '../..';
+
+type ConsoleLogMock = jest.Mock<typeof console.log>;
+
+beforeEach(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
 
 const TEXT_LABEL = 'cool text';
 
@@ -128,5 +135,75 @@ test('byA11yValue error messages', () => {
     getByA11yValue({ min: 1, max: 2, now: 3, text: /foo/i })
   ).toThrowErrorMatchingInlineSnapshot(
     `"Unable to find an element with min value: 1, max value: 2, now value: 3, text value: /foo/i"`
+  );
+});
+
+test('*ByA11yValue deprecation warnings', () => {
+  const mockCalls = (console.warn as ConsoleLogMock).mock.calls;
+  const view = render(<View accessibilityValue={{ min: 10 }} />);
+
+  view.getByA11yValue({ min: 10 });
+  expect(mockCalls[0][0]).toMatchInlineSnapshot(
+    `"getByA11yValue(...) is deprecated. Please use getByRole(role, { value: ... }) instead."`
+  );
+
+  view.getAllByA11yValue({ min: 10 });
+  expect(mockCalls[1][0]).toMatchInlineSnapshot(
+    `"getAllByA11yValue(...) is deprecated. Please use getAllByRole(role, { value: ... }) instead."`
+  );
+
+  view.queryByA11yValue({ min: 10 });
+  expect(mockCalls[2][0]).toMatchInlineSnapshot(
+    `"queryByA11yValue(...) is deprecated. Please use queryByRole(role, { value: ... }) instead."`
+  );
+
+  view.queryAllByA11yValue({ min: 10 });
+  expect(mockCalls[3][0]).toMatchInlineSnapshot(
+    `"queryAllByA11yValue(...) is deprecated. Please use queryAllByRole(role, { value: ... }) instead."`
+  );
+
+  view.findByA11yValue({ min: 10 });
+  expect(mockCalls[4][0]).toMatchInlineSnapshot(
+    `"findByA11yValue(...) is deprecated. Please use findByRole(role, { value: ... }) instead."`
+  );
+
+  view.findAllByA11yValue({ min: 10 });
+  expect(mockCalls[5][0]).toMatchInlineSnapshot(
+    `"findAllByA11yValue(...) is deprecated. Please use findAllByRole(role, { value: ... }) instead."`
+  );
+});
+
+test('*ByAccessibilityValue deprecation warnings', () => {
+  const mockCalls = (console.warn as ConsoleLogMock).mock.calls;
+  const view = render(<View accessibilityValue={{ min: 10 }} />);
+
+  view.getByAccessibilityValue({ min: 10 });
+  expect(mockCalls[0][0]).toMatchInlineSnapshot(
+    `"getByAccessibilityValue(...) is deprecated. Please use getByRole(role, { value: ... }) instead."`
+  );
+
+  view.getAllByAccessibilityValue({ min: 10 });
+  expect(mockCalls[1][0]).toMatchInlineSnapshot(
+    `"getAllByAccessibilityValue(...) is deprecated. Please use getAllByRole(role, { value: ... }) instead."`
+  );
+
+  view.queryByAccessibilityValue({ min: 10 });
+  expect(mockCalls[2][0]).toMatchInlineSnapshot(
+    `"queryByAccessibilityValue(...) is deprecated. Please use queryByRole(role, { value: ... }) instead."`
+  );
+
+  view.queryAllByAccessibilityValue({ min: 10 });
+  expect(mockCalls[3][0]).toMatchInlineSnapshot(
+    `"queryAllByAccessibilityValue(...) is deprecated. Please use queryAllByRole(role, { value: ... }) instead."`
+  );
+
+  view.findByAccessibilityValue({ min: 10 });
+  expect(mockCalls[4][0]).toMatchInlineSnapshot(
+    `"findByAccessibilityValue(...) is deprecated. Please use findByRole(role, { value: ... }) instead."`
+  );
+
+  view.findAllByAccessibilityValue({ min: 10 });
+  expect(mockCalls[5][0]).toMatchInlineSnapshot(
+    `"findAllByAccessibilityValue(...) is deprecated. Please use findAllByRole(role, { value: ... }) instead."`
   );
 });

--- a/src/queries/__tests__/a11yValue.test.tsx
+++ b/src/queries/__tests__/a11yValue.test.tsx
@@ -144,42 +144,42 @@ test('*ByA11yValue deprecation warnings', () => {
 
   view.getByA11yValue({ min: 10 });
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
-    "getByA11yValue(...) is deprecated.
+    "getByA11yValue(...) is deprecated and will be removed in the future.
 
     Use expect(...).toHaveAccessibilityValue(...) matcher or getByRole(role, { value: ... }) query instead."
   `);
 
   view.getAllByA11yValue({ min: 10 });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
-    "getAllByA11yValue(...) is deprecated.
+    "getAllByA11yValue(...) is deprecated and will be removed in the future.
 
     Use expect(...).toHaveAccessibilityValue(...) matcher or getAllByRole(role, { value: ... }) query instead."
   `);
 
   view.queryByA11yValue({ min: 10 });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
-    "queryByA11yValue(...) is deprecated.
+    "queryByA11yValue(...) is deprecated and will be removed in the future.
 
     Use expect(...).toHaveAccessibilityValue(...) matcher or queryByRole(role, { value: ... }) query instead."
   `);
 
   view.queryAllByA11yValue({ min: 10 });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
-    "queryAllByA11yValue(...) is deprecated.
+    "queryAllByA11yValue(...) is deprecated and will be removed in the future.
 
     Use expect(...).toHaveAccessibilityValue(...) matcher or queryAllByRole(role, { value: ... }) query instead."
   `);
 
   view.findByA11yValue({ min: 10 });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
-    "findByA11yValue(...) is deprecated.
+    "findByA11yValue(...) is deprecated and will be removed in the future.
 
     Use expect(...).toHaveAccessibilityValue(...) matcher or findByRole(role, { value: ... }) query instead."
   `);
 
   view.findAllByA11yValue({ min: 10 });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
-    "findAllByA11yValue(...) is deprecated.
+    "findAllByA11yValue(...) is deprecated and will be removed in the future.
 
     Use expect(...).toHaveAccessibilityValue(...) matcher or findAllByRole(role, { value: ... }) query instead."
   `);
@@ -191,42 +191,42 @@ test('*ByAccessibilityValue deprecation warnings', () => {
 
   view.getByAccessibilityValue({ min: 10 });
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
-    "getByAccessibilityValue(...) is deprecated.
+    "getByAccessibilityValue(...) is deprecated and will be removed in the future.
 
     Use expect(...).toHaveAccessibilityValue(...) matcher or getByRole(role, { value: ... }) query instead."
   `);
 
   view.getAllByAccessibilityValue({ min: 10 });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
-    "getAllByAccessibilityValue(...) is deprecated.
+    "getAllByAccessibilityValue(...) is deprecated and will be removed in the future.
 
     Use expect(...).toHaveAccessibilityValue(...) matcher or getAllByRole(role, { value: ... }) query instead."
   `);
 
   view.queryByAccessibilityValue({ min: 10 });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
-    "queryByAccessibilityValue(...) is deprecated.
+    "queryByAccessibilityValue(...) is deprecated and will be removed in the future.
 
     Use expect(...).toHaveAccessibilityValue(...) matcher or queryByRole(role, { value: ... }) query instead."
   `);
 
   view.queryAllByAccessibilityValue({ min: 10 });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
-    "queryAllByAccessibilityValue(...) is deprecated.
+    "queryAllByAccessibilityValue(...) is deprecated and will be removed in the future.
 
     Use expect(...).toHaveAccessibilityValue(...) matcher or queryAllByRole(role, { value: ... }) query instead."
   `);
 
   view.findByAccessibilityValue({ min: 10 });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
-    "findByAccessibilityValue(...) is deprecated.
+    "findByAccessibilityValue(...) is deprecated and will be removed in the future.
 
     Use expect(...).toHaveAccessibilityValue(...) matcher or findByRole(role, { value: ... }) query instead."
   `);
 
   view.findAllByAccessibilityValue({ min: 10 });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
-    "findAllByAccessibilityValue(...) is deprecated.
+    "findAllByAccessibilityValue(...) is deprecated and will be removed in the future.
 
     Use expect(...).toHaveAccessibilityValue(...) matcher or findAllByRole(role, { value: ... }) query instead."
   `);

--- a/src/queries/__tests__/a11yValue.test.tsx
+++ b/src/queries/__tests__/a11yValue.test.tsx
@@ -146,42 +146,42 @@ test('*ByA11yValue deprecation warnings', () => {
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
     "getByA11yValue(...) is deprecated.
 
-    Please use getByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher or getByRole(role, { value: ... }) query instead."
   `);
 
   view.getAllByA11yValue({ min: 10 });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
     "getAllByA11yValue(...) is deprecated.
 
-    Please use getAllByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher or getAllByRole(role, { value: ... }) query instead."
   `);
 
   view.queryByA11yValue({ min: 10 });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
     "queryByA11yValue(...) is deprecated.
 
-    Please use queryByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher or queryByRole(role, { value: ... }) query instead."
   `);
 
   view.queryAllByA11yValue({ min: 10 });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
     "queryAllByA11yValue(...) is deprecated.
 
-    Please use queryAllByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher or queryAllByRole(role, { value: ... }) query instead."
   `);
 
   view.findByA11yValue({ min: 10 });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
     "findByA11yValue(...) is deprecated.
 
-    Please use findByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher or findByRole(role, { value: ... }) query instead."
   `);
 
   view.findAllByA11yValue({ min: 10 });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
     "findAllByA11yValue(...) is deprecated.
 
-    Please use findAllByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher or findAllByRole(role, { value: ... }) query instead."
   `);
 });
 
@@ -193,41 +193,41 @@ test('*ByAccessibilityValue deprecation warnings', () => {
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
     "getByAccessibilityValue(...) is deprecated.
 
-    Please use getByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher or getByRole(role, { value: ... }) query instead."
   `);
 
   view.getAllByAccessibilityValue({ min: 10 });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
     "getAllByAccessibilityValue(...) is deprecated.
 
-    Please use getAllByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher or getAllByRole(role, { value: ... }) query instead."
   `);
 
   view.queryByAccessibilityValue({ min: 10 });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
     "queryByAccessibilityValue(...) is deprecated.
 
-    Please use queryByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher or queryByRole(role, { value: ... }) query instead."
   `);
 
   view.queryAllByAccessibilityValue({ min: 10 });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
     "queryAllByAccessibilityValue(...) is deprecated.
 
-    Please use queryAllByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher or queryAllByRole(role, { value: ... }) query instead."
   `);
 
   view.findByAccessibilityValue({ min: 10 });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
     "findByAccessibilityValue(...) is deprecated.
 
-    Please use findByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher or findByRole(role, { value: ... }) query instead."
   `);
 
   view.findAllByAccessibilityValue({ min: 10 });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
     "findAllByAccessibilityValue(...) is deprecated.
 
-    Please use findAllByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher or findAllByRole(role, { value: ... }) query instead."
   `);
 });

--- a/src/queries/__tests__/a11yValue.test.tsx
+++ b/src/queries/__tests__/a11yValue.test.tsx
@@ -146,42 +146,42 @@ test('*ByA11yValue deprecation warnings', () => {
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
     "getByA11yValue(...) is deprecated.
 
-    Please use getByRole(role, { value: ... }) instead."
+    Please use getByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
   `);
 
   view.getAllByA11yValue({ min: 10 });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
     "getAllByA11yValue(...) is deprecated.
 
-    Please use getAllByRole(role, { value: ... }) instead."
+    Please use getAllByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
   `);
 
   view.queryByA11yValue({ min: 10 });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
     "queryByA11yValue(...) is deprecated.
 
-    Please use queryByRole(role, { value: ... }) instead."
+    Please use queryByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
   `);
 
   view.queryAllByA11yValue({ min: 10 });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
     "queryAllByA11yValue(...) is deprecated.
 
-    Please use queryAllByRole(role, { value: ... }) instead."
+    Please use queryAllByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
   `);
 
   view.findByA11yValue({ min: 10 });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
     "findByA11yValue(...) is deprecated.
 
-    Please use findByRole(role, { value: ... }) instead."
+    Please use findByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
   `);
 
   view.findAllByA11yValue({ min: 10 });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
     "findAllByA11yValue(...) is deprecated.
 
-    Please use findAllByRole(role, { value: ... }) instead."
+    Please use findAllByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
   `);
 });
 
@@ -193,41 +193,41 @@ test('*ByAccessibilityValue deprecation warnings', () => {
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
     "getByAccessibilityValue(...) is deprecated.
 
-    Please use getByRole(role, { value: ... }) instead."
+    Please use getByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
   `);
 
   view.getAllByAccessibilityValue({ min: 10 });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
     "getAllByAccessibilityValue(...) is deprecated.
 
-    Please use getAllByRole(role, { value: ... }) instead."
+    Please use getAllByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
   `);
 
   view.queryByAccessibilityValue({ min: 10 });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
     "queryByAccessibilityValue(...) is deprecated.
 
-    Please use queryByRole(role, { value: ... }) instead."
+    Please use queryByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
   `);
 
   view.queryAllByAccessibilityValue({ min: 10 });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
     "queryAllByAccessibilityValue(...) is deprecated.
 
-    Please use queryAllByRole(role, { value: ... }) instead."
+    Please use queryAllByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
   `);
 
   view.findByAccessibilityValue({ min: 10 });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
     "findByAccessibilityValue(...) is deprecated.
 
-    Please use findByRole(role, { value: ... }) instead."
+    Please use findByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
   `);
 
   view.findAllByAccessibilityValue({ min: 10 });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
     "findAllByAccessibilityValue(...) is deprecated.
 
-    Please use findAllByRole(role, { value: ... }) instead."
+    Please use findAllByRole(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher instead."
   `);
 });

--- a/src/queries/__tests__/a11yValue.test.tsx
+++ b/src/queries/__tests__/a11yValue.test.tsx
@@ -143,34 +143,46 @@ test('*ByA11yValue deprecation warnings', () => {
   const view = render(<View accessibilityValue={{ min: 10 }} />);
 
   view.getByA11yValue({ min: 10 });
-  expect(mockCalls[0][0]).toMatchInlineSnapshot(
-    `"getByA11yValue(...) is deprecated. Please use getByRole(role, { value: ... }) instead."`
-  );
+  expect(mockCalls[0][0]).toMatchInlineSnapshot(`
+    "getByA11yValue(...) is deprecated.
+
+    Please use getByRole(role, { value: ... }) instead."
+  `);
 
   view.getAllByA11yValue({ min: 10 });
-  expect(mockCalls[1][0]).toMatchInlineSnapshot(
-    `"getAllByA11yValue(...) is deprecated. Please use getAllByRole(role, { value: ... }) instead."`
-  );
+  expect(mockCalls[1][0]).toMatchInlineSnapshot(`
+    "getAllByA11yValue(...) is deprecated.
+
+    Please use getAllByRole(role, { value: ... }) instead."
+  `);
 
   view.queryByA11yValue({ min: 10 });
-  expect(mockCalls[2][0]).toMatchInlineSnapshot(
-    `"queryByA11yValue(...) is deprecated. Please use queryByRole(role, { value: ... }) instead."`
-  );
+  expect(mockCalls[2][0]).toMatchInlineSnapshot(`
+    "queryByA11yValue(...) is deprecated.
+
+    Please use queryByRole(role, { value: ... }) instead."
+  `);
 
   view.queryAllByA11yValue({ min: 10 });
-  expect(mockCalls[3][0]).toMatchInlineSnapshot(
-    `"queryAllByA11yValue(...) is deprecated. Please use queryAllByRole(role, { value: ... }) instead."`
-  );
+  expect(mockCalls[3][0]).toMatchInlineSnapshot(`
+    "queryAllByA11yValue(...) is deprecated.
+
+    Please use queryAllByRole(role, { value: ... }) instead."
+  `);
 
   view.findByA11yValue({ min: 10 });
-  expect(mockCalls[4][0]).toMatchInlineSnapshot(
-    `"findByA11yValue(...) is deprecated. Please use findByRole(role, { value: ... }) instead."`
-  );
+  expect(mockCalls[4][0]).toMatchInlineSnapshot(`
+    "findByA11yValue(...) is deprecated.
+
+    Please use findByRole(role, { value: ... }) instead."
+  `);
 
   view.findAllByA11yValue({ min: 10 });
-  expect(mockCalls[5][0]).toMatchInlineSnapshot(
-    `"findAllByA11yValue(...) is deprecated. Please use findAllByRole(role, { value: ... }) instead."`
-  );
+  expect(mockCalls[5][0]).toMatchInlineSnapshot(`
+    "findAllByA11yValue(...) is deprecated.
+
+    Please use findAllByRole(role, { value: ... }) instead."
+  `);
 });
 
 test('*ByAccessibilityValue deprecation warnings', () => {
@@ -178,32 +190,44 @@ test('*ByAccessibilityValue deprecation warnings', () => {
   const view = render(<View accessibilityValue={{ min: 10 }} />);
 
   view.getByAccessibilityValue({ min: 10 });
-  expect(mockCalls[0][0]).toMatchInlineSnapshot(
-    `"getByAccessibilityValue(...) is deprecated. Please use getByRole(role, { value: ... }) instead."`
-  );
+  expect(mockCalls[0][0]).toMatchInlineSnapshot(`
+    "getByAccessibilityValue(...) is deprecated.
+
+    Please use getByRole(role, { value: ... }) instead."
+  `);
 
   view.getAllByAccessibilityValue({ min: 10 });
-  expect(mockCalls[1][0]).toMatchInlineSnapshot(
-    `"getAllByAccessibilityValue(...) is deprecated. Please use getAllByRole(role, { value: ... }) instead."`
-  );
+  expect(mockCalls[1][0]).toMatchInlineSnapshot(`
+    "getAllByAccessibilityValue(...) is deprecated.
+
+    Please use getAllByRole(role, { value: ... }) instead."
+  `);
 
   view.queryByAccessibilityValue({ min: 10 });
-  expect(mockCalls[2][0]).toMatchInlineSnapshot(
-    `"queryByAccessibilityValue(...) is deprecated. Please use queryByRole(role, { value: ... }) instead."`
-  );
+  expect(mockCalls[2][0]).toMatchInlineSnapshot(`
+    "queryByAccessibilityValue(...) is deprecated.
+
+    Please use queryByRole(role, { value: ... }) instead."
+  `);
 
   view.queryAllByAccessibilityValue({ min: 10 });
-  expect(mockCalls[3][0]).toMatchInlineSnapshot(
-    `"queryAllByAccessibilityValue(...) is deprecated. Please use queryAllByRole(role, { value: ... }) instead."`
-  );
+  expect(mockCalls[3][0]).toMatchInlineSnapshot(`
+    "queryAllByAccessibilityValue(...) is deprecated.
+
+    Please use queryAllByRole(role, { value: ... }) instead."
+  `);
 
   view.findByAccessibilityValue({ min: 10 });
-  expect(mockCalls[4][0]).toMatchInlineSnapshot(
-    `"findByAccessibilityValue(...) is deprecated. Please use findByRole(role, { value: ... }) instead."`
-  );
+  expect(mockCalls[4][0]).toMatchInlineSnapshot(`
+    "findByAccessibilityValue(...) is deprecated.
+
+    Please use findByRole(role, { value: ... }) instead."
+  `);
 
   view.findAllByAccessibilityValue({ min: 10 });
-  expect(mockCalls[5][0]).toMatchInlineSnapshot(
-    `"findAllByAccessibilityValue(...) is deprecated. Please use findAllByRole(role, { value: ... }) instead."`
-  );
+  expect(mockCalls[5][0]).toMatchInlineSnapshot(`
+    "findAllByAccessibilityValue(...) is deprecated.
+
+    Please use findAllByRole(role, { value: ... }) instead."
+  `);
 });

--- a/src/queries/__tests__/a11yValue.test.tsx
+++ b/src/queries/__tests__/a11yValue.test.tsx
@@ -146,42 +146,42 @@ test('*ByA11yValue deprecation warnings', () => {
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
     "getByA11yValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or getByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from "@testing-library/jest-native" package or getByRole(role, { value: ... }) query instead."
   `);
 
   view.getAllByA11yValue({ min: 10 });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
     "getAllByA11yValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or getAllByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from "@testing-library/jest-native" package or getAllByRole(role, { value: ... }) query instead."
   `);
 
   view.queryByA11yValue({ min: 10 });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
     "queryByA11yValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or queryByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from "@testing-library/jest-native" package or queryByRole(role, { value: ... }) query instead."
   `);
 
   view.queryAllByA11yValue({ min: 10 });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
     "queryAllByA11yValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or queryAllByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from "@testing-library/jest-native" package or queryAllByRole(role, { value: ... }) query instead."
   `);
 
   view.findByA11yValue({ min: 10 });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
     "findByA11yValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or findByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from "@testing-library/jest-native" package or findByRole(role, { value: ... }) query instead."
   `);
 
   view.findAllByA11yValue({ min: 10 });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
     "findAllByA11yValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or findAllByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from "@testing-library/jest-native" package or findAllByRole(role, { value: ... }) query instead."
   `);
 });
 
@@ -193,41 +193,41 @@ test('*ByAccessibilityValue deprecation warnings', () => {
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
     "getByAccessibilityValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or getByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from "@testing-library/jest-native" package or getByRole(role, { value: ... }) query instead."
   `);
 
   view.getAllByAccessibilityValue({ min: 10 });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
     "getAllByAccessibilityValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or getAllByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from "@testing-library/jest-native" package or getAllByRole(role, { value: ... }) query instead."
   `);
 
   view.queryByAccessibilityValue({ min: 10 });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
     "queryByAccessibilityValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or queryByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from "@testing-library/jest-native" package or queryByRole(role, { value: ... }) query instead."
   `);
 
   view.queryAllByAccessibilityValue({ min: 10 });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
     "queryAllByAccessibilityValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or queryAllByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from "@testing-library/jest-native" package or queryAllByRole(role, { value: ... }) query instead."
   `);
 
   view.findByAccessibilityValue({ min: 10 });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
     "findByAccessibilityValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or findByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from "@testing-library/jest-native" package or findByRole(role, { value: ... }) query instead."
   `);
 
   view.findAllByAccessibilityValue({ min: 10 });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
     "findAllByAccessibilityValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or findAllByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from "@testing-library/jest-native" package or findAllByRole(role, { value: ... }) query instead."
   `);
 });

--- a/src/queries/__tests__/a11yValue.test.tsx
+++ b/src/queries/__tests__/a11yValue.test.tsx
@@ -146,42 +146,42 @@ test('*ByA11yValue deprecation warnings', () => {
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
     "getByA11yValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher or getByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or getByRole(role, { value: ... }) query instead."
   `);
 
   view.getAllByA11yValue({ min: 10 });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
     "getAllByA11yValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher or getAllByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or getAllByRole(role, { value: ... }) query instead."
   `);
 
   view.queryByA11yValue({ min: 10 });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
     "queryByA11yValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher or queryByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or queryByRole(role, { value: ... }) query instead."
   `);
 
   view.queryAllByA11yValue({ min: 10 });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
     "queryAllByA11yValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher or queryAllByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or queryAllByRole(role, { value: ... }) query instead."
   `);
 
   view.findByA11yValue({ min: 10 });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
     "findByA11yValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher or findByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or findByRole(role, { value: ... }) query instead."
   `);
 
   view.findAllByA11yValue({ min: 10 });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
     "findAllByA11yValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher or findAllByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or findAllByRole(role, { value: ... }) query instead."
   `);
 });
 
@@ -193,41 +193,41 @@ test('*ByAccessibilityValue deprecation warnings', () => {
   expect(mockCalls[0][0]).toMatchInlineSnapshot(`
     "getByAccessibilityValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher or getByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or getByRole(role, { value: ... }) query instead."
   `);
 
   view.getAllByAccessibilityValue({ min: 10 });
   expect(mockCalls[1][0]).toMatchInlineSnapshot(`
     "getAllByAccessibilityValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher or getAllByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or getAllByRole(role, { value: ... }) query instead."
   `);
 
   view.queryByAccessibilityValue({ min: 10 });
   expect(mockCalls[2][0]).toMatchInlineSnapshot(`
     "queryByAccessibilityValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher or queryByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or queryByRole(role, { value: ... }) query instead."
   `);
 
   view.queryAllByAccessibilityValue({ min: 10 });
   expect(mockCalls[3][0]).toMatchInlineSnapshot(`
     "queryAllByAccessibilityValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher or queryAllByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or queryAllByRole(role, { value: ... }) query instead."
   `);
 
   view.findByAccessibilityValue({ min: 10 });
   expect(mockCalls[4][0]).toMatchInlineSnapshot(`
     "findByAccessibilityValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher or findByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or findByRole(role, { value: ... }) query instead."
   `);
 
   view.findAllByAccessibilityValue({ min: 10 });
   expect(mockCalls[5][0]).toMatchInlineSnapshot(`
     "findAllByAccessibilityValue(...) is deprecated and will be removed in the future.
 
-    Use expect(...).toHaveAccessibilityValue(...) matcher or findAllByRole(role, { value: ... }) query instead."
+    Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or findAllByRole(role, { value: ... }) query instead."
   `);
 });

--- a/src/queries/a11yState.ts
+++ b/src/queries/a11yState.ts
@@ -1,6 +1,7 @@
 import type { ReactTestInstance } from 'react-test-renderer';
 import { AccessibilityState } from 'react-native';
 import { accessibilityStateKeys } from '../helpers/accessiblity';
+import { deprecateAllQueries } from '../helpers/deprecation';
 import { findAll } from '../helpers/findAll';
 import { matchAccessibilityState } from '../helpers/matchers/accessibilityState';
 import { makeQueries } from './makeQueries';
@@ -92,18 +93,30 @@ export const bindByA11yStateQueries = (
   const findAllByA11yState = findAllBy(instance);
 
   return {
-    getByA11yState,
-    getAllByA11yState,
-    queryByA11yState,
-    queryAllByA11yState,
-    findByA11yState,
-    findAllByA11yState,
+    ...deprecateAllQueries(
+      {
+        getByA11yState,
+        getAllByA11yState,
+        queryByA11yState,
+        queryAllByA11yState,
+        findByA11yState,
+        findAllByA11yState,
+      },
+      'A11yState',
+      'Role(role, { disabled, selected, checked, busy, expanded })'
+    ),
 
-    getByAccessibilityState: getByA11yState,
-    getAllByAccessibilityState: getAllByA11yState,
-    queryByAccessibilityState: queryByA11yState,
-    queryAllByAccessibilityState: queryAllByA11yState,
-    findByAccessibilityState: findByA11yState,
-    findAllByAccessibilityState: findAllByA11yState,
+    ...deprecateAllQueries(
+      {
+        getByAccessibilityState: getByA11yState,
+        getAllByAccessibilityState: getAllByA11yState,
+        queryByAccessibilityState: queryByA11yState,
+        queryAllByAccessibilityState: queryAllByA11yState,
+        findByAccessibilityState: findByA11yState,
+        findAllByAccessibilityState: findAllByA11yState,
+      },
+      'AccessibilityState',
+      'Role(role, { disabled, selected, checked, busy, expanded })'
+    ),
   };
 };

--- a/src/queries/a11yState.ts
+++ b/src/queries/a11yState.ts
@@ -101,13 +101,6 @@ export const bindByA11yStateQueries = (
         queryAllByA11yState,
         findByA11yState,
         findAllByA11yState,
-      },
-      'A11yState',
-      'Role(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher'
-    ),
-
-    ...deprecateAllQueries(
-      {
         getByAccessibilityState: getByA11yState,
         getAllByAccessibilityState: getAllByA11yState,
         queryByAccessibilityState: queryByA11yState,
@@ -115,8 +108,7 @@ export const bindByA11yStateQueries = (
         findByAccessibilityState: findByA11yState,
         findAllByAccessibilityState: findAllByA11yState,
       },
-      'AccessibilityState',
-      'Role(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher'
+      'Use {queryPrefix}ByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead.'
     ),
   };
 };

--- a/src/queries/a11yState.ts
+++ b/src/queries/a11yState.ts
@@ -108,7 +108,7 @@ export const bindByA11yStateQueries = (
         findByAccessibilityState: findByA11yState,
         findAllByAccessibilityState: findAllByA11yState,
       },
-      'Use {queryPrefix}ByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead.'
+      'Use {queryPrefix}ByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from "@testing-library/jest-native" package instead.'
     ),
   };
 };

--- a/src/queries/a11yState.ts
+++ b/src/queries/a11yState.ts
@@ -103,7 +103,7 @@ export const bindByA11yStateQueries = (
         findAllByA11yState,
       },
       'A11yState',
-      'Role(role, { disabled, selected, checked, busy, expanded }) query\nor expect(...).toHaveAccessibilityState(...) matcher'
+      'Role(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher'
     ),
 
     ...deprecateAllQueries(
@@ -116,7 +116,7 @@ export const bindByA11yStateQueries = (
         findAllByAccessibilityState: findAllByA11yState,
       },
       'AccessibilityState',
-      'Role(role, { disabled, selected, checked, busy, expanded }) query\nor expect(...).toHaveAccessibilityState(...) matcher'
+      'Role(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher'
     ),
   };
 };

--- a/src/queries/a11yState.ts
+++ b/src/queries/a11yState.ts
@@ -103,7 +103,7 @@ export const bindByA11yStateQueries = (
         findAllByA11yState,
       },
       'A11yState',
-      'Role(role, { disabled, selected, checked, busy, expanded })'
+      'Role(role, { disabled, selected, checked, busy, expanded }) query\nor expect(...).toHaveAccessibilityState(...) matcher'
     ),
 
     ...deprecateAllQueries(
@@ -116,7 +116,7 @@ export const bindByA11yStateQueries = (
         findAllByAccessibilityState: findAllByA11yState,
       },
       'AccessibilityState',
-      'Role(role, { disabled, selected, checked, busy, expanded })'
+      'Role(role, { disabled, selected, checked, busy, expanded }) query\nor expect(...).toHaveAccessibilityState(...) matcher'
     ),
   };
 };

--- a/src/queries/a11yState.ts
+++ b/src/queries/a11yState.ts
@@ -108,7 +108,7 @@ export const bindByA11yStateQueries = (
         findByAccessibilityState: findByA11yState,
         findAllByAccessibilityState: findAllByA11yState,
       },
-      'Use {queryPrefix}ByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead.'
+      'Use {queryPrefix}ByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher from @testing-library/jest-nativ package instead.'
     ),
   };
 };

--- a/src/queries/a11yState.ts
+++ b/src/queries/a11yState.ts
@@ -1,7 +1,7 @@
 import type { ReactTestInstance } from 'react-test-renderer';
 import { AccessibilityState } from 'react-native';
 import { accessibilityStateKeys } from '../helpers/accessiblity';
-import { deprecateAllQueries } from '../helpers/deprecation';
+import { deprecateQueries } from '../helpers/deprecation';
 import { findAll } from '../helpers/findAll';
 import { matchAccessibilityState } from '../helpers/matchers/accessibilityState';
 import { makeQueries } from './makeQueries';
@@ -93,7 +93,7 @@ export const bindByA11yStateQueries = (
   const findAllByA11yState = findAllBy(instance);
 
   return {
-    ...deprecateAllQueries(
+    ...deprecateQueries(
       {
         getByA11yState,
         getAllByA11yState,

--- a/src/queries/a11yValue.ts
+++ b/src/queries/a11yValue.ts
@@ -120,7 +120,7 @@ export const bindByA11yValueQueries = (
         findAllByA11yValue,
       },
       'A11yValue',
-      'Role(role, { value: ... })'
+      'Role(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher'
     ),
 
     ...deprecateAllQueries(
@@ -133,7 +133,7 @@ export const bindByA11yValueQueries = (
         findAllByAccessibilityValue: findAllByA11yValue,
       },
       'AccessibilityValue',
-      'Role(role, { value: ... })'
+      'Role(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher'
     ),
   };
 };

--- a/src/queries/a11yValue.ts
+++ b/src/queries/a11yValue.ts
@@ -125,7 +125,7 @@ export const bindByA11yValueQueries = (
         findByAccessibilityValue: findByA11yValue,
         findAllByAccessibilityValue: findAllByA11yValue,
       },
-      'Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or {queryPrefix}ByRole(role, { value: ... }) query instead.'
+      'Use expect(...).toHaveAccessibilityValue(...) matcher from "@testing-library/jest-native" package or {queryPrefix}ByRole(role, { value: ... }) query instead.'
     ),
   };
 };

--- a/src/queries/a11yValue.ts
+++ b/src/queries/a11yValue.ts
@@ -125,7 +125,7 @@ export const bindByA11yValueQueries = (
         findByAccessibilityValue: findByA11yValue,
         findAllByAccessibilityValue: findAllByA11yValue,
       },
-      'Use expect(...).toHaveAccessibilityValue(...) matcher or {queryPrefix}ByRole(role, { value: ... }) query instead.'
+      'Use expect(...).toHaveAccessibilityValue(...) matcher from @testing-library/jest-native package or {queryPrefix}ByRole(role, { value: ... }) query instead.'
     ),
   };
 };

--- a/src/queries/a11yValue.ts
+++ b/src/queries/a11yValue.ts
@@ -1,6 +1,6 @@
 import type { ReactTestInstance } from 'react-test-renderer';
 import { accessiblityValueKeys } from '../helpers/accessiblity';
-import { deprecateAllQueries } from '../helpers/deprecation';
+import { deprecateQueries } from '../helpers/deprecation';
 import { findAll } from '../helpers/findAll';
 import {
   AccessibilityValueMatcher,
@@ -110,7 +110,7 @@ export const bindByA11yValueQueries = (
   const findAllByA11yValue = findAllBy(instance);
 
   return {
-    ...deprecateAllQueries(
+    ...deprecateQueries(
       {
         getByA11yValue,
         getAllByA11yValue,

--- a/src/queries/a11yValue.ts
+++ b/src/queries/a11yValue.ts
@@ -118,13 +118,6 @@ export const bindByA11yValueQueries = (
         queryAllByA11yValue,
         findByA11yValue,
         findAllByA11yValue,
-      },
-      'A11yValue',
-      'Role(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher'
-    ),
-
-    ...deprecateAllQueries(
-      {
         getByAccessibilityValue: getByA11yValue,
         getAllByAccessibilityValue: getAllByA11yValue,
         queryByAccessibilityValue: queryByA11yValue,
@@ -132,8 +125,7 @@ export const bindByA11yValueQueries = (
         findByAccessibilityValue: findByA11yValue,
         findAllByAccessibilityValue: findAllByA11yValue,
       },
-      'AccessibilityValue',
-      'Role(role, { value: ... }) query or expect(...).toHaveAccessibilityValue(...) matcher'
+      'Use expect(...).toHaveAccessibilityValue(...) matcher or {queryPrefix}ByRole(role, { value: ... }) query instead.'
     ),
   };
 };

--- a/src/queries/a11yValue.ts
+++ b/src/queries/a11yValue.ts
@@ -1,5 +1,6 @@
 import type { ReactTestInstance } from 'react-test-renderer';
 import { accessiblityValueKeys } from '../helpers/accessiblity';
+import { deprecateAllQueries } from '../helpers/deprecation';
 import { findAll } from '../helpers/findAll';
 import {
   AccessibilityValueMatcher,
@@ -109,18 +110,30 @@ export const bindByA11yValueQueries = (
   const findAllByA11yValue = findAllBy(instance);
 
   return {
-    getByA11yValue,
-    getAllByA11yValue,
-    queryByA11yValue,
-    queryAllByA11yValue,
-    findByA11yValue,
-    findAllByA11yValue,
+    ...deprecateAllQueries(
+      {
+        getByA11yValue,
+        getAllByA11yValue,
+        queryByA11yValue,
+        queryAllByA11yValue,
+        findByA11yValue,
+        findAllByA11yValue,
+      },
+      'A11yValue',
+      'Role(role, { value: ... })'
+    ),
 
-    getByAccessibilityValue: getByA11yValue,
-    getAllByAccessibilityValue: getAllByA11yValue,
-    queryByAccessibilityValue: queryByA11yValue,
-    queryAllByAccessibilityValue: queryAllByA11yValue,
-    findByAccessibilityValue: findByA11yValue,
-    findAllByAccessibilityValue: findAllByA11yValue,
+    ...deprecateAllQueries(
+      {
+        getByAccessibilityValue: getByA11yValue,
+        getAllByAccessibilityValue: getAllByA11yValue,
+        queryByAccessibilityValue: queryByA11yValue,
+        queryAllByAccessibilityValue: queryAllByA11yValue,
+        findByAccessibilityValue: findByA11yValue,
+        findAllByAccessibilityValue: findAllByA11yValue,
+      },
+      'AccessibilityValue',
+      'Role(role, { value: ... })'
+    ),
   };
 };

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -30,11 +30,11 @@ title: API
     - [On a `ScrollView`](#on-a-scrollview)
     - [On a `FlatList`](#on-a-flatlist)
 - [`waitFor`](#waitfor)
-    - [Using jest fake timers](#using-jest-fake-timers)
+  - [Using Jest fake timers](#using-jest-fake-timers)
 - [`waitForElementToBeRemoved`](#waitforelementtoberemoved)
 - [`within`, `getQueriesForElement`](#within-getqueriesforelement)
-- [`query` APIs](#query-apis)
-- [`queryAll` APIs](#queryall-apis)
+- [`queryBy*` APIs](#queryby-apis)
+- [`queryAll*` APIs](#queryall-apis)
 - [`act`](#act)
 - [`renderHook`](#renderhook)
   - [`callback`](#callback)
@@ -683,9 +683,9 @@ Use cases for scoped queries include:
 - queries scoped to a single item inside a FlatList containing many items
 - queries scoped to a single screen in tests involving screen transitions (e.g. with react-navigation)
 
-## `query` APIs
+## `queryBy*` APIs
 
-Each of the `getBy` APIs listed in the render section above have a complimentary `queryBy` API. The `getBy` APIs will throw errors if a proper node cannot be found. This is normally the desired effect. However, if you want to make an assertion that an element is not present in the hierarchy, then you can use the `queryBy` API instead:
+Each of the `getBy*` APIs listed in the render section above have a complimentary `queryBy*` API. The `getBy*` APIs will throw errors if a proper node cannot be found. This is normally the desired effect. However, if you want to make an assertion that an element is not present in the hierarchy, then you can use the `queryBy*` API instead:
 
 ```jsx
 import { render, screen } from '@testing-library/react-native';
@@ -695,9 +695,9 @@ const submitButton = screen.queryByText('submit');
 expect(submitButton).not.toBeOnTheScreen(); // it doesn't exist
 ```
 
-## `queryAll` APIs
+## `queryAll*` APIs
 
-Each of the query APIs have a corresponding `queryAll` version that always returns an array of matching nodes. `getAll` is the same but throws when the array has a length of 0.
+Each of the query APIs have a corresponding `queryAll*` version that always returns an array of matching nodes. `getAll*` is the same but throws when the array has a length of 0.
 
 ```jsx
 import { render } from '@testing-library/react-native';

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -685,7 +685,7 @@ Use cases for scoped queries include:
 
 ## `query` APIs
 
-Each of the get APIs listed in the render section above have a complimentary query API. The get APIs will throw errors if a proper node cannot be found. This is normally the desired effect. However, if you want to make an assertion that an element is not present in the hierarchy, then you can use the query API instead:
+Each of the `getBy` APIs listed in the render section above have a complimentary `queryBy` API. The `getBy` APIs will throw errors if a proper node cannot be found. This is normally the desired effect. However, if you want to make an assertion that an element is not present in the hierarchy, then you can use the `queryBy` API instead:
 
 ```jsx
 import { render, screen } from '@testing-library/react-native';
@@ -697,7 +697,7 @@ expect(submitButton).not.toBeOnTheScreen(); // it doesn't exist
 
 ## `queryAll` APIs
 
-Each of the query APIs have a corresponding queryAll version that always returns an Array of matching nodes. getAll is the same but throws when the array has a length of 0.
+Each of the query APIs have a corresponding `queryAll` version that always returns an array of matching nodes. `getAll` is the same but throws when the array has a length of 0.
 
 ```jsx
 import { render } from '@testing-library/react-native';

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -312,13 +312,9 @@ const element3 = screen.getByRole('button', { name: 'Hello', disabled: true });
 ### `ByA11yState`, `ByAccessibilityState` (deprecated)
 
 :::caution
-This method has been marked deprecated, as similar functionallity can be better achieved using [`*ByRole`](#byrole) query with state options (`disabled`, `selected`, etc) or by using [`toHaveAccessibilityState()`](https://github.com/testing-library/jest-native#tohaveaccessibilitystate) Jest matcher.
-:::
-
-:::caution
-This query uses a predicate that is typically too general to give meaningful results. Therefore, it's better to use one of the following options:
-* use one of [`ByRole`](#byrole) queries with relevant state options: `disabled`, `selected`, `checked`, `expanded` and `busy`
-* use [`toHaveAccessibilityState()`](https://github.com/testing-library/jest-native#tohaveaccessibilitystate) matcher to check the state of element found using some other query
+This method has been marked deprecated, as is typically too general to give meaningful results. Therefore, it's better to use one of the following options:
+* [`*ByRole`](#byrole) query with relevant state options:  `disabled`, `selected`, `checked`, `expanded` and `busy`
+* [`toHaveAccessibilityState()`](https://github.com/testing-library/jest-native#tohaveaccessibilitystate) Jest matcher to check the state of element found using some other query.
 :::
 
 > getByA11yState, getAllByA11yState, queryByA11yState, queryAllByA11yState, findByA11yState, findAllByA11yState
@@ -379,15 +375,10 @@ The difference in handling default values is made to reflect observed accessibil
 ### `ByA11Value`, `ByAccessibilityValue` (deprecated)
 
 :::caution
-This method has been marked deprecated, as similar functionallity can be better achieved using [`*ByRole`](#byrole) query with `value` option or by using [`toHaveAccessibilityValue()`](https://github.com/testing-library/jest-native#tohaveaccessibilityvalue) Jest matcher.
+This method has been marked deprecated, as is typically too general to give meaningful results. Therefore, it's better to use one of the following options:
+* [`toHaveAccessibilityValue()`](https://github.com/testing-library/jest-native#tohaveaccessibilityvalue) Jest matcher to check the state of element found using some other query.
+* [`*ByRole`](#byrole) query with `value` option
 :::
-
-:::caution
-This query uses a predicate that is typically too general to give meaningful results. Therefore, it's better to use one of the following options:
-* use one of [`ByRole`](#byrole) queries with `value` option
-* use [`toHaveAccessibilityValue()`](https://github.com/testing-library/jest-native#tohaveaccessibilityvalue) matcher to check the state of element found using some other query
-:::
-
 
 > getByA11yValue, getAllByA11yValue, queryByA11yValue, queryAllByA11yValue, findByA11yValue, findAllByA11yValue
 > getByAccessibilityValue, getAllByAccessibilityValue, queryByAccessibilityValue, queryAllByAccessibilityValue, findByAccessibilityValue, findAllByAccessibilityValue

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -312,9 +312,9 @@ const element3 = screen.getByRole('button', { name: 'Hello', disabled: true });
 ### `ByA11yState`, `ByAccessibilityState` (deprecated)
 
 :::caution
-This method has been marked deprecated, as is typically too general to give meaningful results. Therefore, it's better to use one of the following options:
+This method has been marked deprecated, as is typically too general to give meaningful results. Therefore, it's better to use one of following options:
 * [`*ByRole`](#byrole) query with relevant state options:  `disabled`, `selected`, `checked`, `expanded` and `busy`
-* [`toHaveAccessibilityState()`](https://github.com/testing-library/jest-native#tohaveaccessibilitystate) Jest matcher to check the state of element found using some other query.
+* [`toHaveAccessibilityState()`](https://github.com/testing-library/jest-native#tohaveaccessibilitystate) Jest matcher to check the state of element found using some other query
 :::
 
 > getByA11yState, getAllByA11yState, queryByA11yState, queryAllByA11yState, findByA11yState, findAllByA11yState
@@ -375,8 +375,8 @@ The difference in handling default values is made to reflect observed accessibil
 ### `ByA11Value`, `ByAccessibilityValue` (deprecated)
 
 :::caution
-This method has been marked deprecated, as is typically too general to give meaningful results. Therefore, it's better to use one of the following options:
-* [`toHaveAccessibilityValue()`](https://github.com/testing-library/jest-native#tohaveaccessibilityvalue) Jest matcher to check the state of element found using some other query.
+This method has been marked deprecated, as is typically too general to give meaningful results. Therefore, it's better to use one of following options:
+* [`toHaveAccessibilityValue()`](https://github.com/testing-library/jest-native#tohaveaccessibilityvalue) Jest matcher to check the state of element found using some other query
 * [`*ByRole`](#byrole) query with `value` option
 :::
 

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -312,7 +312,7 @@ const element3 = screen.getByRole('button', { name: 'Hello', disabled: true });
 ### `ByA11yState`, `ByAccessibilityState` (deprecated)
 
 :::caution
-This method has been marked deprecated, as is typically too general to give meaningful results. Therefore, it's better to use one of following options:
+This query has been marked deprecated, as is typically too general to give meaningful results. Therefore, it's better to use one of following options:
 * [`*ByRole`](#byrole) query with relevant state options:  `disabled`, `selected`, `checked`, `expanded` and `busy`
 * [`toHaveAccessibilityState()`](https://github.com/testing-library/jest-native#tohaveaccessibilitystate) Jest matcher to check the state of element found using some other query
 :::
@@ -375,7 +375,7 @@ The difference in handling default values is made to reflect observed accessibil
 ### `ByA11Value`, `ByAccessibilityValue` (deprecated)
 
 :::caution
-This method has been marked deprecated, as is typically too general to give meaningful results. Therefore, it's better to use one of following options:
+This query has been marked deprecated, as is typically too general to give meaningful results. Therefore, it's better to use one of following options:
 * [`toHaveAccessibilityValue()`](https://github.com/testing-library/jest-native#tohaveaccessibilityvalue) Jest matcher to check the state of element found using some other query
 * [`*ByRole`](#byrole) query with `value` option
 :::
@@ -551,7 +551,7 @@ The interface is the same as for other queries, but we won't provide full names 
 Returns a `ReactTestInstance` with matching a React component type.
 
 :::caution
-This method has been marked unsafe, since it requires knowledge about implementation details of the component. Use responsibly.
+This query has been marked unsafe, since it requires knowledge about implementation details of the component. Use responsibly.
 :::
 
 ### `UNSAFE_ByProps`
@@ -561,7 +561,7 @@ This method has been marked unsafe, since it requires knowledge about implementa
 Returns a `ReactTestInstance` with matching props object.
 
 :::caution
-This method has been marked unsafe, since it requires knowledge about implementation details of the component. Use responsibly.
+This query has been marked unsafe, since it requires knowledge about implementation details of the component. Use responsibly.
 :::
 
 </details>

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -22,10 +22,10 @@ title: Queries
   - [`ByHintText`, `ByA11yHint`, `ByAccessibilityHint`](#byhinttext-bya11yhint-byaccessibilityhint)
   - [`ByRole`](#byrole)
     - [Options](#options-1)
-  - [`ByA11yState`, `ByAccessibilityState`](#bya11ystate-byaccessibilitystate)
+  - [`ByA11yState`, `ByAccessibilityState` (deprecated)](#bya11ystate-byaccessibilitystate-deprecated)
     - [Default state for: `disabled`, `selected`, and `busy` keys](#default-state-for-disabled-selected-and-busy-keys)
     - [Default state for: `checked` and `expanded` keys](#default-state-for-checked-and-expanded-keys)
-  - [`ByA11Value`, `ByAccessibilityValue`](#bya11value-byaccessibilityvalue)
+  - [`ByA11Value`, `ByAccessibilityValue` (deprecated)](#bya11value-byaccessibilityvalue-deprecated)
 - [Common options](#common-options)
   - [`includeHiddenElements` option](#includehiddenelements-option)
 - [TextMatch](#textmatch)
@@ -309,7 +309,11 @@ const element3 = screen.getByRole('button', { name: 'Hello', disabled: true });
 
 `value`: Filter elements by their accessibility, available value entries include numeric `min`, `max` & `now`, as well as string or regex `text` key. See React Native [accessibilityValue](https://reactnative.dev/docs/accessibility#accessibilityvalue) docs to learn more about this prop.
 
-### `ByA11yState`, `ByAccessibilityState`
+### `ByA11yState`, `ByAccessibilityState` (deprecated)
+
+:::caution
+This method has been marked deprecated, as similar functionallity can be better achieved using [`*ByRole`](#byrole) query with state options (`disabled`, `selected`, etc) or by using [`toHaveAccessibilityState()`](https://github.com/testing-library/jest-native#tohaveaccessibilitystate) Jest matcher.
+:::
 
 :::caution
 This query uses a predicate that is typically too general to give meaningful results. Therefore, it's better to use one of the following options:
@@ -372,7 +376,11 @@ but will not match elements with following props:
 The difference in handling default values is made to reflect observed accessibility behaviour on iOS and Android platforms.
 :::
 
-### `ByA11Value`, `ByAccessibilityValue`
+### `ByA11Value`, `ByAccessibilityValue` (deprecated)
+
+:::caution
+This method has been marked deprecated, as similar functionallity can be better achieved using [`*ByRole`](#byrole) query with `value` option or by using [`toHaveAccessibilityValue()`](https://github.com/testing-library/jest-native#tohaveaccessibilityvalue) Jest matcher.
+:::
 
 :::caution
 This query uses a predicate that is typically too general to give meaningful results. Therefore, it's better to use one of the following options:


### PR DESCRIPTION
### Summary

Make `*ByA11yState` and `*ByA11yValue` queries deprecated, redirecting user to use `*ByRole` queries or `toHaveAcessbibilityState/Value()` matchers.

When doing any of the mentioned queries, user will received following warning to console:

```
getByA11yValue(...) is deprecated and will be removed in the future.
      
Use expect(...).toHaveAccessibilityValue(...) matcher o rgetByRole(role, { value: ... }) query instead.
```

```
getByAccessibilityState(...) is deprecated and will be removed in the future.
 
Use getByRole(role, { disabled, selected, checked, busy, expanded }) query or expect(...).toHaveAccessibilityState(...) matcher instead.
```

Resolves #1208

### Test plan

Add tests for deprecation messages warnings.