### PR TITLE
feat: config option to allow breaking changes

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,10 +1,16 @@
-import { getConfig, configure, resetToDefaults } from '../config';
+import {
+  getConfig,
+  configure,
+  resetToDefaults,
+  configureInternal,
+} from '../config';
 
 beforeEach(() => {
   resetToDefaults();
 });
 
 test('getConfig() returns existing configuration', () => {
+  expect(getConfig().allowBreakingChanges).toEqual(false);
   expect(getConfig().asyncUtilTimeout).toEqual(1000);
   expect(getConfig().defaultIncludeHiddenElements).toEqual(true);
 });
@@ -31,6 +37,16 @@ test('resetToDefaults() resets config to defaults', () => {
   resetToDefaults();
   expect(getConfig().asyncUtilTimeout).toEqual(1000);
   expect(getConfig().defaultIncludeHiddenElements).toEqual(true);
+});
+
+test('resetToDefaults() resets internal config to defaults', () => {
+  configureInternal({
+    allowBreakingChanges: true,
+  });
+  expect(getConfig().allowBreakingChanges).toEqual(true);
+
+  resetToDefaults();
+  expect(getConfig().allowBreakingChanges).toEqual(false);
 });
 
 test('configure handles alias option defaultHidden', () => {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
 });
 
 test('getConfig() returns existing configuration', () => {
-  expect(getConfig().allowBreakingChanges).toEqual(false);
+  expect(getConfig().useBreakingChanges).toEqual(false);
   expect(getConfig().asyncUtilTimeout).toEqual(1000);
   expect(getConfig().defaultIncludeHiddenElements).toEqual(true);
 });
@@ -22,7 +22,7 @@ test('configure() overrides existing config values', () => {
     asyncUtilTimeout: 5000,
     defaultDebugOptions: { message: 'debug message' },
     defaultIncludeHiddenElements: true,
-    allowBreakingChanges: false,
+    useBreakingChanges: false,
   });
 });
 
@@ -41,12 +41,12 @@ test('resetToDefaults() resets config to defaults', () => {
 
 test('resetToDefaults() resets internal config to defaults', () => {
   configureInternal({
-    allowBreakingChanges: true,
+    useBreakingChanges: true,
   });
-  expect(getConfig().allowBreakingChanges).toEqual(true);
+  expect(getConfig().useBreakingChanges).toEqual(true);
 
   resetToDefaults();
-  expect(getConfig().allowBreakingChanges).toEqual(false);
+  expect(getConfig().useBreakingChanges).toEqual(false);
 });
 
 test('configure handles alias option defaultHidden', () => {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -16,6 +16,7 @@ test('configure() overrides existing config values', () => {
     asyncUtilTimeout: 5000,
     defaultDebugOptions: { message: 'debug message' },
     defaultIncludeHiddenElements: true,
+    allowBreakingChanges: false,
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,12 +20,12 @@ export type ConfigAliasOptions = {
 };
 
 export type InternalConfig = Config & {
-  /** Whether to allow RNTL to use latest and greatest improvements even if they are breaking changes. */
-  allowBreakingChanges: boolean;
+  /** Whether to use breaking changes intended for next major version release. */
+  useBreakingChanges: boolean;
 };
 
 const defaultConfig: InternalConfig = {
-  allowBreakingChanges: false,
+  useBreakingChanges: false,
   asyncUtilTimeout: 1000,
   defaultIncludeHiddenElements: true,
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,9 @@ export type Config = {
 
   /** Default options for `debug` helper. */
   defaultDebugOptions?: Partial<DebugOptions>;
+
+  /** Whether to allow RNTL to use latest and greatest improvements even if they are breaking changes. */
+  allowBreakingChanges: boolean;
 };
 
 export type ConfigAliasOptions = {
@@ -19,6 +22,7 @@ export type ConfigAliasOptions = {
 const defaultConfig: Config = {
   asyncUtilTimeout: 1000,
   defaultIncludeHiddenElements: true,
+  allowBreakingChanges: false,
 };
 
 let config = { ...defaultConfig };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,8 @@
 import { DebugOptions } from './helpers/debugDeep';
 
+/**
+ * Global configuration options for React Native Testing Library.
+ */
 export type Config = {
   /** Default timeout, in ms, for `waitFor` and `findBy*` queries. */
   asyncUtilTimeout: number;
@@ -9,9 +12,6 @@ export type Config = {
 
   /** Default options for `debug` helper. */
   defaultDebugOptions?: Partial<DebugOptions>;
-
-  /** Whether to allow RNTL to use latest and greatest improvements even if they are breaking changes. */
-  allowBreakingChanges: boolean;
 };
 
 export type ConfigAliasOptions = {
@@ -19,14 +19,22 @@ export type ConfigAliasOptions = {
   defaultHidden: boolean;
 };
 
-const defaultConfig: Config = {
+export type InternalConfig = Config & {
+  /** Whether to allow RNTL to use latest and greatest improvements even if they are breaking changes. */
+  allowBreakingChanges: boolean;
+};
+
+const defaultConfig: InternalConfig = {
+  allowBreakingChanges: false,
   asyncUtilTimeout: 1000,
   defaultIncludeHiddenElements: true,
-  allowBreakingChanges: false,
 };
 
 let config = { ...defaultConfig };
 
+/**
+ * Configure global options for React Native Testing Library.
+ */
 export function configure(options: Partial<Config & ConfigAliasOptions>) {
   const { defaultHidden, ...restOptions } = options;
 
@@ -39,6 +47,13 @@ export function configure(options: Partial<Config & ConfigAliasOptions>) {
     ...config,
     ...restOptions,
     defaultIncludeHiddenElements,
+  };
+}
+
+export function configureInternal(option: Partial<InternalConfig>) {
+  config = {
+    ...config,
+    ...option,
   };
 }
 

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -52,7 +52,6 @@ title: API
     - [`asyncUtilTimeout` option](#asyncutiltimeout-option)
     - [`defaultIncludeHiddenElements` option](#defaultincludehiddenelements-option)
     - [`defaultDebugOptions` option](#defaultdebugoptions-option)
-    - [`allowBreakingChanges` option](#allowbreakingchanges-option)
   - [`resetToDefaults()`](#resettodefaults)
   - [Environment variables](#environment-variables)
     - [`RNTL_SKIP_AUTO_CLEANUP`](#rntl_skip_auto_cleanup)
@@ -783,7 +782,6 @@ type Config = {
   asyncUtilTimeout: number;
   defaultHidden: boolean;
   defaultDebugOptions: Partial<DebugOptions>;
-  allowBreakingChanges: boolean;
 };
 
 function configure(options: Partial<Config>) {}
@@ -805,9 +803,6 @@ This option is also available as `defaultHidden` alias for compatibility with [R
 
 Default [debug options](#debug) to be used when calling `debug()`. These default options will be overridden by the ones you specify directly when calling `debug()`.
 
-#### `allowBreakingChanges` option
-
-By default RNTL is using SemVer practices that require a major version update in case of any breaking changes. If you set this option to `true` you will be allowed to use latest RNTL API that might contain breaking changes. These breaking changes are planned to become default in the next major release. APIs that would be affected by this option will have that documented.
 ### `resetToDefaults()`
 
 ```ts

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -52,6 +52,7 @@ title: API
     - [`asyncUtilTimeout` option](#asyncutiltimeout-option)
     - [`defaultIncludeHiddenElements` option](#defaultincludehiddenelements-option)
     - [`defaultDebugOptions` option](#defaultdebugoptions-option)
+    - [`allowBreakingChanges` option](#allowbreakingchanges-option)
   - [`resetToDefaults()`](#resettodefaults)
   - [Environment variables](#environment-variables)
     - [`RNTL_SKIP_AUTO_CLEANUP`](#rntl_skip_auto_cleanup)
@@ -782,6 +783,7 @@ type Config = {
   asyncUtilTimeout: number;
   defaultHidden: boolean;
   defaultDebugOptions: Partial<DebugOptions>;
+  allowBreakingChanges: boolean;
 };
 
 function configure(options: Partial<Config>) {}
@@ -803,6 +805,9 @@ This option is also available as `defaultHidden` alias for compatibility with [R
 
 Default [debug options](#debug) to be used when calling `debug()`. These default options will be overridden by the ones you specify directly when calling `debug()`.
 
+#### `allowBreakingChanges` option
+
+By default RNTL is using SemVer practices that require a major version update in case of any breaking changes. If you set this option to `true` you will be allowed to use latest RNTL API that might contain breaking changes. These breaking changes are planned to become default in the next major release. APIs that would be affected by this option will have that documented.
 ### `resetToDefaults()`
 
 ```ts


### PR DESCRIPTION
### Summary

New config option `allowBreakingChanges` that when set to `true` would allow us to introduce breaking changes without need for major release. It has to be opt-in, so that if not set the library works in non-breaking way.

The goal here is to be able to move forward with code changes that introduce breaking changes like #1234 #1180 without blocking other non-breaking developments. When the major release happens we would promote changes enabled by `allowBreakingChanges` optiopn and make the the default. 

I've also have alternative names for the option:
* `useCuttingEdge: true`
* `useLatestApis: true`
* `useVersionNext: true`
* `moveFastAndBreakThings: true`

Pls treat this PR as RFC/discussion I've submitted it as PR because it was low-effort to do it in this way. @pierrezimmermannbam @AugustinLF @MattAgn @thymikee wdyt?

### Test plan

No new changes, as the option is not yet used anywhere.