### PR TITLE
fix: typing of `act`

### DIFF
--- a/src/act.ts
+++ b/src/act.ts
@@ -86,7 +86,7 @@ const getAct = () => {
     ? withGlobalActEnvironment(reactTestRendererAct)
     : reactTestRendererAct;
 };
-const act = getAct();
+const act = getAct() as Act;
 
 export default act;
 export {


### PR DESCRIPTION
### Summary

- cast customized act function back to react-test-renderer type
- flow types can be ignored since they already use `Thenable`

Fixes #1207 