### PR TITLE
byRole queries return only accessibility elements

### DIFF
--- a/src/__tests__/host-component-names.test.tsx
+++ b/src/__tests__/host-component-names.test.tsx
@@ -2,8 +2,13 @@ import { View } from 'react-native';
 import TestRenderer from 'react-test-renderer';
 import { configureInternal, getConfig } from '../config';
 import { getHostComponentNames } from '../helpers/host-component-names';
+import * as within from '../within';
 
 const mockCreate = jest.spyOn(TestRenderer, 'create') as jest.Mock;
+const mockGetQueriesForElements = jest.spyOn(
+  within,
+  'getQueriesForElement'
+) as jest.Mock;
 
 describe('getHostComponentNames', () => {
   test('updates internal config with host component names when they are not defined', () => {
@@ -39,6 +44,24 @@ describe('getHostComponentNames', () => {
       "Trying to detect host component names triggered the following error:
 
       Unable to find an element with testID: text
+
+      There seems to be an issue with your configuration that prevents React Native Testing Library from working correctly.
+      Please check if you are using compatible versions of React Native and React Native Testing Library.
+      "
+    `);
+  });
+
+  test('throw an error when autodetection fails due to getByTestId returning non-host component', () => {
+    mockGetQueriesForElements.mockReturnValue({
+      getByTestId: () => {
+        return { type: View };
+      },
+    });
+
+    expect(() => getHostComponentNames()).toThrowErrorMatchingInlineSnapshot(`
+      "Trying to detect host component names triggered the following error:
+
+      getByTestId returned non-host component
 
       There seems to be an issue with your configuration that prevents React Native Testing Library from working correctly.
       Please check if you are using compatible versions of React Native and React Native Testing Library.

--- a/src/helpers/__tests__/accessiblity.test.tsx
+++ b/src/helpers/__tests__/accessiblity.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, TextInput, Pressable } from 'react-native';
+import { View, Text, TextInput, Pressable, Switch } from 'react-native';
 import { render, isHiddenFromAccessibility, isInaccessible } from '../..';
 import { isAccessibilityElement } from '../accessiblity';
 
@@ -199,6 +199,11 @@ describe('isAccessibilityElement', () => {
       const element = render(<Pressable testID="pressable" />).getByTestId(
         'pressable'
       );
+      expect(isAccessibilityElement(element)).toEqual(true);
+    });
+
+    test('returns true for Switch component', () => {
+      const element = render(<Switch testID="switch" />).getByTestId('switch');
       expect(isAccessibilityElement(element)).toEqual(true);
     });
 

--- a/src/helpers/__tests__/accessiblity.test.tsx
+++ b/src/helpers/__tests__/accessiblity.test.tsx
@@ -2,174 +2,180 @@ import React from 'react';
 import { View, Text, TextInput } from 'react-native';
 import { render, isHiddenFromAccessibility, isInaccessible } from '../..';
 
-test('returns false for accessible elements', () => {
-  expect(
-    isHiddenFromAccessibility(
-      render(<View testID="subject" />).getByTestId('subject')
-    )
-  ).toBe(false);
+describe('isHiddenFromAccessibility', () => {
+  test('returns false for accessible elements', () => {
+    expect(
+      isHiddenFromAccessibility(
+        render(<View testID="subject" />).getByTestId('subject')
+      )
+    ).toBe(false);
 
-  expect(
-    isHiddenFromAccessibility(
-      render(<Text testID="subject">Hello</Text>).getByTestId('subject')
-    )
-  ).toBe(false);
+    expect(
+      isHiddenFromAccessibility(
+        render(<Text testID="subject">Hello</Text>).getByTestId('subject')
+      )
+    ).toBe(false);
 
-  expect(
-    isHiddenFromAccessibility(
-      render(<TextInput testID="subject" />).getByTestId('subject')
-    )
-  ).toBe(false);
-});
+    expect(
+      isHiddenFromAccessibility(
+        render(<TextInput testID="subject" />).getByTestId('subject')
+      )
+    ).toBe(false);
+  });
 
-test('returns true for null elements', () => {
-  expect(isHiddenFromAccessibility(null)).toBe(true);
-});
+  test('returns true for null elements', () => {
+    expect(isHiddenFromAccessibility(null)).toBe(true);
+  });
 
-test('detects elements with accessibilityElementsHidden prop', () => {
-  const view = render(<View testID="subject" accessibilityElementsHidden />);
-  expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
-});
+  test('detects elements with accessibilityElementsHidden prop', () => {
+    const view = render(<View testID="subject" accessibilityElementsHidden />);
+    expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
+  });
 
-test('detects nested elements with accessibilityElementsHidden prop', () => {
-  const view = render(
-    <View accessibilityElementsHidden>
-      <View testID="subject" />
-    </View>
-  );
-  expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
-});
-
-test('detects deeply nested elements with accessibilityElementsHidden prop', () => {
-  const view = render(
-    <View accessibilityElementsHidden>
-      <View>
-        <View>
-          <View testID="subject" />
-        </View>
-      </View>
-    </View>
-  );
-  expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
-});
-
-test('detects elements with importantForAccessibility="no-hide-descendants" prop', () => {
-  const view = render(
-    <View testID="subject" importantForAccessibility="no-hide-descendants" />
-  );
-  expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
-});
-
-test('detects nested elements with importantForAccessibility="no-hide-descendants" prop', () => {
-  const view = render(
-    <View importantForAccessibility="no-hide-descendants">
-      <View testID="subject" />
-    </View>
-  );
-  expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
-});
-
-test('detects elements with display=none', () => {
-  const view = render(<View testID="subject" style={{ display: 'none' }} />);
-  expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
-});
-
-test('detects nested elements with display=none', () => {
-  const view = render(
-    <View style={{ display: 'none' }}>
-      <View testID="subject" />
-    </View>
-  );
-  expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
-});
-
-test('detects deeply nested elements with display=none', () => {
-  const view = render(
-    <View style={{ display: 'none' }}>
-      <View>
-        <View>
-          <View testID="subject" />
-        </View>
-      </View>
-    </View>
-  );
-  expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
-});
-
-test('detects elements with display=none with complex style', () => {
-  const view = render(
-    <View
-      testID="subject"
-      style={[{ display: 'flex' }, [{ display: 'flex' }], { display: 'none' }]}
-    />
-  );
-  expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
-});
-
-test('is not trigged by opacity = 0', () => {
-  const view = render(<View testID="subject" style={{ opacity: 0 }} />);
-  expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(false);
-});
-
-test('detects siblings of element with accessibilityViewIsModal prop', () => {
-  const view = render(
-    <View>
-      <View accessibilityViewIsModal />
-      <View testID="subject" />
-    </View>
-  );
-  expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
-});
-
-test('detects deeply nested siblings of element with accessibilityViewIsModal prop', () => {
-  const view = render(
-    <View>
-      <View accessibilityViewIsModal />
-      <View>
-        <View>
-          <View testID="subject" />
-        </View>
-      </View>
-    </View>
-  );
-  expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
-});
-
-test('is not triggered for element with accessibilityViewIsModal prop', () => {
-  const view = render(
-    <View>
-      <View accessibilityViewIsModal testID="subject" />
-    </View>
-  );
-  expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(false);
-});
-
-test('is not triggered for child of element with accessibilityViewIsModal prop', () => {
-  const view = render(
-    <View>
-      <View accessibilityViewIsModal>
+  test('detects nested elements with accessibilityElementsHidden prop', () => {
+    const view = render(
+      <View accessibilityElementsHidden>
         <View testID="subject" />
       </View>
-    </View>
-  );
-  expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(false);
-});
+    );
+    expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
+  });
 
-test('is not triggered for descendent of element with accessibilityViewIsModal prop', () => {
-  const view = render(
-    <View>
-      <View accessibilityViewIsModal>
+  test('detects deeply nested elements with accessibilityElementsHidden prop', () => {
+    const view = render(
+      <View accessibilityElementsHidden>
         <View>
           <View>
             <View testID="subject" />
           </View>
         </View>
       </View>
-    </View>
-  );
-  expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(false);
-});
+    );
+    expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
+  });
 
-test('has isInaccessible alias', () => {
-  expect(isInaccessible).toBe(isHiddenFromAccessibility);
+  test('detects elements with importantForAccessibility="no-hide-descendants" prop', () => {
+    const view = render(
+      <View testID="subject" importantForAccessibility="no-hide-descendants" />
+    );
+    expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
+  });
+
+  test('detects nested elements with importantForAccessibility="no-hide-descendants" prop', () => {
+    const view = render(
+      <View importantForAccessibility="no-hide-descendants">
+        <View testID="subject" />
+      </View>
+    );
+    expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
+  });
+
+  test('detects elements with display=none', () => {
+    const view = render(<View testID="subject" style={{ display: 'none' }} />);
+    expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
+  });
+
+  test('detects nested elements with display=none', () => {
+    const view = render(
+      <View style={{ display: 'none' }}>
+        <View testID="subject" />
+      </View>
+    );
+    expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
+  });
+
+  test('detects deeply nested elements with display=none', () => {
+    const view = render(
+      <View style={{ display: 'none' }}>
+        <View>
+          <View>
+            <View testID="subject" />
+          </View>
+        </View>
+      </View>
+    );
+    expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
+  });
+
+  test('detects elements with display=none with complex style', () => {
+    const view = render(
+      <View
+        testID="subject"
+        style={[
+          { display: 'flex' },
+          [{ display: 'flex' }],
+          { display: 'none' },
+        ]}
+      />
+    );
+    expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
+  });
+
+  test('is not trigged by opacity = 0', () => {
+    const view = render(<View testID="subject" style={{ opacity: 0 }} />);
+    expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(false);
+  });
+
+  test('detects siblings of element with accessibilityViewIsModal prop', () => {
+    const view = render(
+      <View>
+        <View accessibilityViewIsModal />
+        <View testID="subject" />
+      </View>
+    );
+    expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
+  });
+
+  test('detects deeply nested siblings of element with accessibilityViewIsModal prop', () => {
+    const view = render(
+      <View>
+        <View accessibilityViewIsModal />
+        <View>
+          <View>
+            <View testID="subject" />
+          </View>
+        </View>
+      </View>
+    );
+    expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(true);
+  });
+
+  test('is not triggered for element with accessibilityViewIsModal prop', () => {
+    const view = render(
+      <View>
+        <View accessibilityViewIsModal testID="subject" />
+      </View>
+    );
+    expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(false);
+  });
+
+  test('is not triggered for child of element with accessibilityViewIsModal prop', () => {
+    const view = render(
+      <View>
+        <View accessibilityViewIsModal>
+          <View testID="subject" />
+        </View>
+      </View>
+    );
+    expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(false);
+  });
+
+  test('is not triggered for descendent of element with accessibilityViewIsModal prop', () => {
+    const view = render(
+      <View>
+        <View accessibilityViewIsModal>
+          <View>
+            <View>
+              <View testID="subject" />
+            </View>
+          </View>
+        </View>
+      </View>
+    );
+    expect(isHiddenFromAccessibility(view.getByTestId('subject'))).toBe(false);
+  });
+
+  test('has isInaccessible alias', () => {
+    expect(isInaccessible).toBe(isHiddenFromAccessibility);
+  });
 });

--- a/src/helpers/__tests__/accessiblity.test.tsx
+++ b/src/helpers/__tests__/accessiblity.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { View, Text, TextInput } from 'react-native';
+import { View, Text, TextInput, Pressable } from 'react-native';
 import { render, isHiddenFromAccessibility, isInaccessible } from '../..';
+import { isAccessibilityElement } from '../accessiblity';
 
 describe('isHiddenFromAccessibility', () => {
   test('returns false for accessible elements', () => {
@@ -177,5 +178,55 @@ describe('isHiddenFromAccessibility', () => {
 
   test('has isInaccessible alias', () => {
     expect(isInaccessible).toBe(isHiddenFromAccessibility);
+  });
+});
+
+describe('isAccessibilityElement', () => {
+  describe('when accessible prop is not defined', () => {
+    test('returns true for Text component', () => {
+      const element = render(<Text testID="text">Hey</Text>).getByTestId(
+        'text'
+      );
+      expect(isAccessibilityElement(element)).toEqual(true);
+    });
+
+    test('returns true for TextInput component', () => {
+      const element = render(<TextInput testID="input" />).getByTestId('input');
+      expect(isAccessibilityElement(element)).toEqual(true);
+    });
+
+    test('returns true for Pressable component', () => {
+      const element = render(<Pressable testID="pressable" />).getByTestId(
+        'pressable'
+      );
+      expect(isAccessibilityElement(element)).toEqual(true);
+    });
+
+    test('returns false for View component', () => {
+      const element = render(<View testID="element" />).getByTestId('element');
+      expect(isAccessibilityElement(element)).toEqual(false);
+    });
+  });
+
+  describe('when accessible prop is defined', () => {
+    test('returns false when accessible prop is set to false', () => {
+      const element = render(
+        <TextInput accessible={false} testID="input">
+          Hey
+        </TextInput>
+      ).getByTestId('input');
+      expect(isAccessibilityElement(element)).toEqual(false);
+    });
+
+    test('returns true when accessible prop is set to true', () => {
+      const element = render(
+        <View accessible={true} testID="view" />
+      ).getByTestId('view');
+      expect(isAccessibilityElement(element)).toEqual(true);
+    });
+  });
+
+  test('returns false when given null', () => {
+    expect(isAccessibilityElement(null)).toEqual(false);
   });
 });

--- a/src/helpers/__tests__/accessiblity.test.tsx
+++ b/src/helpers/__tests__/accessiblity.test.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { View, Text, TextInput, Pressable, Switch } from 'react-native';
+import {
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  Switch,
+  TouchableOpacity,
+} from 'react-native';
 import { render, isHiddenFromAccessibility, isInaccessible } from '../..';
 import { isAccessibilityElement } from '../accessiblity';
 
@@ -182,53 +189,86 @@ describe('isHiddenFromAccessibility', () => {
 });
 
 describe('isAccessibilityElement', () => {
-  describe('when accessible prop is not defined', () => {
-    test('returns true for Text component', () => {
-      const element = render(<Text testID="text">Hey</Text>).getByTestId(
-        'text'
-      );
-      expect(isAccessibilityElement(element)).toEqual(true);
-    });
-
-    test('returns true for TextInput component', () => {
-      const element = render(<TextInput testID="input" />).getByTestId('input');
-      expect(isAccessibilityElement(element)).toEqual(true);
-    });
-
-    test('returns true for Pressable component', () => {
-      const element = render(<Pressable testID="pressable" />).getByTestId(
-        'pressable'
-      );
-      expect(isAccessibilityElement(element)).toEqual(true);
-    });
-
-    test('returns true for Switch component', () => {
-      const element = render(<Switch testID="switch" />).getByTestId('switch');
-      expect(isAccessibilityElement(element)).toEqual(true);
-    });
-
-    test('returns false for View component', () => {
-      const element = render(<View testID="element" />).getByTestId('element');
-      expect(isAccessibilityElement(element)).toEqual(false);
-    });
+  test('matches View component properly', () => {
+    const { getByTestId } = render(
+      <View>
+        <View testID="default" />
+        <View testID="true" accessible />
+        <View testID="false" accessible={false} />
+      </View>
+    );
+    expect(isAccessibilityElement(getByTestId('default'))).toBeFalsy();
+    expect(isAccessibilityElement(getByTestId('true'))).toBeTruthy();
+    expect(isAccessibilityElement(getByTestId('false'))).toBeFalsy();
   });
 
-  describe('when accessible prop is defined', () => {
-    test('returns false when accessible prop is set to false', () => {
-      const element = render(
-        <TextInput accessible={false} testID="input">
-          Hey
-        </TextInput>
-      ).getByTestId('input');
-      expect(isAccessibilityElement(element)).toEqual(false);
-    });
+  test('matches TextInput component properly', () => {
+    const { getByTestId } = render(
+      <View>
+        <TextInput testID="default" />
+        <TextInput testID="true" accessible />
+        <TextInput testID="false" accessible={false} />
+      </View>
+    );
+    expect(isAccessibilityElement(getByTestId('default'))).toBeTruthy();
+    expect(isAccessibilityElement(getByTestId('true'))).toBeTruthy();
+    expect(isAccessibilityElement(getByTestId('false'))).toBeFalsy();
+  });
 
-    test('returns true when accessible prop is set to true', () => {
-      const element = render(
-        <View accessible={true} testID="view" />
-      ).getByTestId('view');
-      expect(isAccessibilityElement(element)).toEqual(true);
-    });
+  test('matches Text component properly', () => {
+    const { getByTestId } = render(
+      <View>
+        <Text testID="default">Default</Text>
+        <Text testID="true" accessible>
+          True
+        </Text>
+        <Text testID="false" accessible={false}>
+          False
+        </Text>
+      </View>
+    );
+    expect(isAccessibilityElement(getByTestId('default'))).toBeTruthy();
+    expect(isAccessibilityElement(getByTestId('true'))).toBeTruthy();
+    expect(isAccessibilityElement(getByTestId('false'))).toBeFalsy();
+  });
+
+  test('matches Switch component properly', () => {
+    const { getByTestId } = render(
+      <View>
+        <Switch testID="default" />
+        <Switch testID="true" accessible />
+        <Switch testID="false" accessible={false} />
+      </View>
+    );
+    expect(isAccessibilityElement(getByTestId('default'))).toBeTruthy();
+    expect(isAccessibilityElement(getByTestId('true'))).toBeTruthy();
+    expect(isAccessibilityElement(getByTestId('false'))).toBeFalsy();
+  });
+
+  test('matches Pressable component properly', () => {
+    const { getByTestId } = render(
+      <View>
+        <Pressable testID="default" />
+        <Pressable testID="true" accessible />
+        <Pressable testID="false" accessible={false} />
+      </View>
+    );
+    expect(isAccessibilityElement(getByTestId('default'))).toBeTruthy();
+    expect(isAccessibilityElement(getByTestId('true'))).toBeTruthy();
+    expect(isAccessibilityElement(getByTestId('false'))).toBeFalsy();
+  });
+
+  test('matches TouchableOpacity component properly', () => {
+    const { getByTestId } = render(
+      <View>
+        <TouchableOpacity testID="default" />
+        <TouchableOpacity testID="true" accessible />
+        <TouchableOpacity testID="false" accessible={false} />
+      </View>
+    );
+    expect(isAccessibilityElement(getByTestId('default'))).toBeTruthy();
+    expect(isAccessibilityElement(getByTestId('true'))).toBeTruthy();
+    expect(isAccessibilityElement(getByTestId('false'))).toBeFalsy();
   });
 
   test('returns false when given null', () => {

--- a/src/helpers/accessiblity.ts
+++ b/src/helpers/accessiblity.ts
@@ -2,9 +2,11 @@ import {
   AccessibilityState,
   AccessibilityValue,
   StyleSheet,
+  Text,
+  TextInput,
 } from 'react-native';
 import { ReactTestInstance } from 'react-test-renderer';
-import { getHostSiblings } from './component-tree';
+import { getHostSiblings, isHostElementForType } from './component-tree';
 
 type IsInaccessibleOptions = {
   cache?: WeakMap<ReactTestInstance, boolean>;
@@ -80,4 +82,21 @@ function isSubtreeInaccessible(element: ReactTestInstance): boolean {
   }
 
   return false;
+}
+
+export function isAccessibilityElement(
+  element: ReactTestInstance | null
+): boolean {
+  if (element == null) {
+    return false;
+  }
+
+  if (element.props.accessible !== undefined) {
+    return element.props.accessible;
+  }
+
+  return (
+    isHostElementForType(element, Text) ||
+    isHostElementForType(element, TextInput)
+  );
 }

--- a/src/helpers/accessiblity.ts
+++ b/src/helpers/accessiblity.ts
@@ -2,6 +2,7 @@ import {
   AccessibilityState,
   AccessibilityValue,
   StyleSheet,
+  Switch,
   Text,
   TextInput,
 } from 'react-native';
@@ -97,6 +98,7 @@ export function isAccessibilityElement(
 
   return (
     isHostElementForType(element, Text) ||
-    isHostElementForType(element, TextInput)
+    isHostElementForType(element, TextInput) ||
+    isHostElementForType(element, Switch)
   );
 }

--- a/src/helpers/host-component-names.tsx
+++ b/src/helpers/host-component-names.tsx
@@ -29,7 +29,7 @@ export function getHostComponentNames(): HostComponentNames {
       typeof textHostName !== 'string' ||
       typeof textInputHostName !== 'string'
     ) {
-      throw new Error(defaultErrorMessage);
+      throw new Error('getByTestId returned non-host component');
     }
 
     const hostComponentNames = {

--- a/src/queries/__tests__/role-value.test.tsx
+++ b/src/queries/__tests__/role-value.test.tsx
@@ -6,6 +6,7 @@ describe('accessibility value', () => {
   test('matches using all value props', () => {
     const { getByRole, queryByRole } = render(
       <View
+        accessible
         accessibilityRole="adjustable"
         accessibilityValue={{ min: 0, max: 100, now: 50, text: '50%' }}
       />
@@ -41,6 +42,7 @@ describe('accessibility value', () => {
   test('matches using single value', () => {
     const { getByRole, queryByRole } = render(
       <View
+        accessible
         accessibilityRole="adjustable"
         accessibilityValue={{ min: 10, max: 20, now: 12, text: 'Hello' }}
       />

--- a/src/queries/__tests__/role.breaking.test.tsx
+++ b/src/queries/__tests__/role.breaking.test.tsx
@@ -8,6 +8,11 @@ import {
   Button as RNButton,
 } from 'react-native';
 import { render } from '../..';
+import { configureInternal } from '../../config';
+
+beforeEach(() => {
+  configureInternal({ useBreakingChanges: true });
+});
 
 const TEXT_LABEL = 'cool text';
 
@@ -734,11 +739,11 @@ test('byRole queries support hidden option', () => {
   );
 });
 
-test('does not take accessible prop into account', () => {
-  const { getByRole } = render(
+test('takes accessible prop into account', () => {
+  const { queryByRole } = render(
     <Pressable accessibilityRole="button" accessible={false}>
       <Text>Action</Text>
     </Pressable>
   );
-  expect(getByRole('button', { name: 'Action' })).toBeTruthy();
+  expect(queryByRole('button', { name: 'Action' })).toBeFalsy();
 });

--- a/src/queries/__tests__/role.breaking.test.tsx
+++ b/src/queries/__tests__/role.breaking.test.tsx
@@ -740,7 +740,7 @@ test('byRole queries support hidden option', () => {
 });
 
 describe('matches only accessible elements', () => {
-  test('takes explicit accessible prop into account', () => {
+  test('ignores elements with accessible={false}', () => {
     const { queryByRole } = render(
       <Pressable accessibilityRole="button" accessible={false}>
         <Text>Action</Text>
@@ -749,7 +749,7 @@ describe('matches only accessible elements', () => {
     expect(queryByRole('button', { name: 'Action' })).toBeFalsy();
   });
 
-  test('takes implicit accessible value into account', () => {
+  test('ignores elements with accessible={undefined} and that are implicitely not accessible', () => {
     const { queryByRole } = render(
       <View accessibilityRole="menu">
         <Text>Action</Text>

--- a/src/queries/__tests__/role.breaking.test.tsx
+++ b/src/queries/__tests__/role.breaking.test.tsx
@@ -739,11 +739,22 @@ test('byRole queries support hidden option', () => {
   );
 });
 
-test('takes accessible prop into account', () => {
-  const { queryByRole } = render(
-    <Pressable accessibilityRole="button" accessible={false}>
-      <Text>Action</Text>
-    </Pressable>
-  );
-  expect(queryByRole('button', { name: 'Action' })).toBeFalsy();
+describe('matches only accessible elements', () => {
+  test('takes explicit accessible prop into account', () => {
+    const { queryByRole } = render(
+      <Pressable accessibilityRole="button" accessible={false}>
+        <Text>Action</Text>
+      </Pressable>
+    );
+    expect(queryByRole('button', { name: 'Action' })).toBeFalsy();
+  });
+
+  test('takes implicit accessible value into account', () => {
+    const { queryByRole } = render(
+      <View accessibilityRole="menu">
+        <Text>Action</Text>
+      </View>
+    );
+    expect(queryByRole('menu', { name: 'Action' })).toBeFalsy();
+  });
 });

--- a/src/queries/__tests__/role.breaking.test.tsx
+++ b/src/queries/__tests__/role.breaking.test.tsx
@@ -740,6 +740,15 @@ test('byRole queries support hidden option', () => {
 });
 
 describe('matches only accessible elements', () => {
+  test('matches elements with accessible={true}', () => {
+    const { queryByRole } = render(
+      <View accessibilityRole="menu" accessible={true}>
+        <Text>Action</Text>
+      </View>
+    );
+    expect(queryByRole('menu', { name: 'Action' })).toBeTruthy();
+  });
+
   test('ignores elements with accessible={false}', () => {
     const { queryByRole } = render(
       <Pressable accessibilityRole="button" accessible={false}>

--- a/src/queries/__tests__/role.test.tsx
+++ b/src/queries/__tests__/role.test.tsx
@@ -733,3 +733,12 @@ test('byRole queries support hidden option', () => {
     `"Unable to find an element with role: "button""`
   );
 });
+
+test('takes accessible prop into account', () => {
+  const { queryByRole } = render(
+    <Pressable accessibilityRole="button" accessible={false}>
+      <Text>Action</Text>
+    </Pressable>
+  );
+  expect(queryByRole('button', { name: 'Action' })).toBeFalsy();
+});

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -63,7 +63,7 @@ const queryAllByRole = (
     return findAll(
       instance,
       (node) =>
-        // run the cheapest checks first, and early exit too avoid unneeded computations
+        // run the cheapest checks first, and early exit to avoid unneeded computations
         typeof node.type === 'string' &&
         matchStringProp(node.props.accessibilityRole, role) &&
         matchAccessibleStateIfNeeded(node, options) &&

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -3,6 +3,7 @@ import type { ReactTestInstance } from 'react-test-renderer';
 import {
   accessibilityStateKeys,
   accessiblityValueKeys,
+  isAccessibilityElement,
 } from '../helpers/accessiblity';
 import { findAll } from '../helpers/findAll';
 import { matchAccessibilityState } from '../helpers/matchers/accessibilityState';
@@ -65,6 +66,7 @@ const queryAllByRole = (
       (node) =>
         // run the cheapest checks first, and early exit to avoid unneeded computations
         typeof node.type === 'string' &&
+        isAccessibilityElement(node) &&
         matchStringProp(node.props.accessibilityRole, role) &&
         matchAccessibleStateIfNeeded(node, options) &&
         matchAccessibilityValueIfNeeded(node, options?.value) &&

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -14,6 +14,7 @@ import {
 import { matchStringProp } from '../helpers/matchers/matchStringProp';
 import type { TextMatch } from '../matches';
 import { getQueriesForElement } from '../within';
+import { getConfig } from '../config';
 import { makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
@@ -61,12 +62,15 @@ const queryAllByRole = (
   instance: ReactTestInstance
 ): ((role: TextMatch, options?: ByRoleOptions) => Array<ReactTestInstance>) =>
   function queryAllByRoleFn(role, options) {
+    const shouldMatchOnlyAccessibilityElements = (node: ReactTestInstance) =>
+      !getConfig().useBreakingChanges || isAccessibilityElement(node);
+
     return findAll(
       instance,
       (node) =>
         // run the cheapest checks first, and early exit to avoid unneeded computations
         typeof node.type === 'string' &&
-        isAccessibilityElement(node) &&
+        shouldMatchOnlyAccessibilityElements(node) &&
         matchStringProp(node.props.accessibilityRole, role) &&
         matchAccessibleStateIfNeeded(node, options) &&
         matchAccessibilityValueIfNeeded(node, options?.value) &&

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -62,15 +62,15 @@ const queryAllByRole = (
   instance: ReactTestInstance
 ): ((role: TextMatch, options?: ByRoleOptions) => Array<ReactTestInstance>) =>
   function queryAllByRoleFn(role, options) {
-    const shouldMatchOnlyAccessibilityElements = (node: ReactTestInstance) =>
-      !getConfig().useBreakingChanges || isAccessibilityElement(node);
+    const shouldMatchOnlyAccessibilityElements = getConfig().useBreakingChanges;
 
     return findAll(
       instance,
       (node) =>
         // run the cheapest checks first, and early exit to avoid unneeded computations
         typeof node.type === 'string' &&
-        shouldMatchOnlyAccessibilityElements(node) &&
+        (!shouldMatchOnlyAccessibilityElements ||
+          isAccessibilityElement(node)) &&
         matchStringProp(node.props.accessibilityRole, role) &&
         matchAccessibleStateIfNeeded(node, options) &&
         matchAccessibilityValueIfNeeded(node, options?.value) &&


### PR DESCRIPTION
### Summary

Solves #1180. It makes byRole queries return only implicit or explicit accessibility elements. Explicit accessibility elements are those with `accessibility` prop set to true. Implicit accessibility elements are `Text`, `TextInput`, `Pressable` and `Switch` (tested with VoiceOver for `Switch` to check it was indeed accessible even without setting the accessible prop and I checked through a snapshot, behing the scene, Switch resolves to a host component RCTSwitch).

### Test plan
- [x] Unit tests for `isAccessibilityElement` helper
- [x] One test to check that byRole only returns accessibility elements 

