### PR TITLE
fix: force cast await to proper type

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "jest": ">=28.0.0",
-    "react": ">=16.0.0",
+    "react": ">=16.8.0",
     "react-native": ">=0.59",
     "react-test-renderer": ">=16.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "jest": ">=28.0.0",
     "react": ">=16.0.0",
     "react-native": ">=0.59",
-    "react-test-renderer": ">=16.0.0"
+    "react-test-renderer": ">=16.8.0"
   },
   "peerDependenciesMeta": {
     "jest": {

--- a/src/__tests__/act.test.tsx
+++ b/src/__tests__/act.test.tsx
@@ -56,7 +56,7 @@ test('should act even if there is no act in react-test-renderer', () => {
 
 test('should be able to not await act', async () => {
   const result = act(() => {});
-  expect(result).toBe(undefined);
+  expect(result).toHaveProperty('then');
 });
 
 test('should be able to await act', async () => {

--- a/src/__tests__/act.test.tsx
+++ b/src/__tests__/act.test.tsx
@@ -43,7 +43,7 @@ test('fireEvent should trigger useState', () => {
 });
 
 test('should act even if there is no act in react-test-renderer', () => {
-  // @ts-ignore
+  // @ts-expect-error
   ReactTestRenderer.act = undefined;
   const callback = jest.fn();
 
@@ -52,4 +52,14 @@ test('should act even if there is no act in react-test-renderer', () => {
   });
 
   expect(callback).toHaveBeenCalled();
+});
+
+test('should be able to not await act', async () => {
+  const result = act(() => {});
+  expect(result).toBe(undefined);
+});
+
+test('should be able to await act', async () => {
+  const result = await act(async () => {});
+  expect(result).toBe(undefined);
 });

--- a/src/__tests__/act.test.tsx
+++ b/src/__tests__/act.test.tsx
@@ -42,18 +42,6 @@ test('fireEvent should trigger useState', () => {
   expect(counter.props.children).toEqual('Total count: 1');
 });
 
-test('should act even if there is no act in react-test-renderer', () => {
-  // @ts-expect-error
-  ReactTestRenderer.act = undefined;
-  const callback = jest.fn();
-
-  act(() => {
-    callback();
-  });
-
-  expect(callback).toHaveBeenCalled();
-});
-
 test('should be able to not await act', async () => {
   const result = act(() => {});
   expect(result).toHaveProperty('then');

--- a/src/__tests__/act.test.tsx
+++ b/src/__tests__/act.test.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Text } from 'react-native';
-import ReactTestRenderer from 'react-test-renderer';
 import act from '../act';
 import render from '../render';
 import fireEvent from '../fireEvent';

--- a/src/act.ts
+++ b/src/act.ts
@@ -75,24 +75,13 @@ function withGlobalActEnvironment(actImplementation: ReactAct) {
   };
 }
 
-type MockAct = (callback: () => void) => void;
-type Act = typeof reactTestRendererAct extends undefined ? MockAct : ReactAct;
-
-const actMock = (callback: () => void) => {
-  callback();
-};
-
 const getAct = () => {
-  if (!reactTestRendererAct) {
-    return actMock;
-  }
-
   return checkReactVersionAtLeast(18, 0)
     ? withGlobalActEnvironment(reactTestRendererAct)
     : reactTestRendererAct;
 };
 
-const act = getAct() as Act;
+const act = getAct() as ReactAct;
 
 export default act;
 export {

--- a/src/act.ts
+++ b/src/act.ts
@@ -3,9 +3,7 @@
 import { act as reactTestRendererAct } from 'react-test-renderer';
 import { checkReactVersionAtLeast } from './react-versions';
 
-const actMock = (callback: () => void) => {
-  callback();
-};
+type ReactAct = typeof reactTestRendererAct;
 
 // See https://github.com/reactwg/react-18/discussions/102 for more context on global.IS_REACT_ACT_ENVIRONMENT
 declare global {
@@ -20,10 +18,8 @@ function getIsReactActEnvironment() {
   return globalThis.IS_REACT_ACT_ENVIRONMENT;
 }
 
-type Act = typeof reactTestRendererAct;
-
-function withGlobalActEnvironment(actImplementation: Act) {
-  return (callback: Parameters<Act>[0]) => {
+function withGlobalActEnvironment(actImplementation: ReactAct) {
+  return (callback: Parameters<ReactAct>[0]) => {
     const previousActEnvironment = getIsReactActEnvironment();
     setIsReactActEnvironment(true);
 
@@ -44,6 +40,7 @@ function withGlobalActEnvironment(actImplementation: Act) {
         }
         return result;
       });
+
       if (callbackNeedsToBeAwaited) {
         const thenable = actResult;
         return {
@@ -77,6 +74,14 @@ function withGlobalActEnvironment(actImplementation: Act) {
     }
   };
 }
+
+type MockAct = (callback: () => void) => void;
+type Act = typeof reactTestRendererAct extends undefined ? MockAct : ReactAct;
+
+const actMock = (callback: () => void) => {
+  callback();
+};
+
 const getAct = () => {
   if (!reactTestRendererAct) {
     return actMock;
@@ -86,7 +91,8 @@ const getAct = () => {
     ? withGlobalActEnvironment(reactTestRendererAct)
     : reactTestRendererAct;
 };
-const act = getAct();
+
+const act = getAct() as Act;
 
 export default act;
 export {

--- a/src/act.ts
+++ b/src/act.ts
@@ -75,13 +75,9 @@ function withGlobalActEnvironment(actImplementation: ReactAct) {
   };
 }
 
-const getAct = () => {
-  return checkReactVersionAtLeast(18, 0)
-    ? withGlobalActEnvironment(reactTestRendererAct)
-    : reactTestRendererAct;
-};
-
-const act = getAct() as ReactAct;
+const act: ReactAct = checkReactVersionAtLeast(18, 0)
+  ? (withGlobalActEnvironment(reactTestRendererAct) as ReactAct)
+  : reactTestRendererAct;
 
 export default act;
 export {


### PR DESCRIPTION
### Summary

Resolve typing issues with `act` by allowing to invoke both `act()` and `await act()`. React `act` has uses function overloading which is hard to work with, so I've resorted to casting.

Dropping support for mock `act` and increasing peer dep req to [React 16.8](https://github.com/facebook/react/releases/tag/v16.8.0) (earliest version to expose act in Test Renderer). I think we can avoid calling this a breaking change, as we already specified minimal RN version of 0.59, which uses React 16.8.3 ([see here](https://docs.google.com/presentation/d/1Z8mNkRw5CJ93qSQqESrcXbgia1dA8V1olnpKT0lsygk/edit#slide=id.gdc26277501_0_39))

Resolves #1276 
Resolves #1207

### Test plan

Typecheck runs fine.