### PR TITLE
refactor(breaking): rename `container` to `UNSAFE_root`; introduce `root` host element

### DIFF
--- a/src/__tests__/__snapshots__/render.breaking.test.tsx.snap
+++ b/src/__tests__/__snapshots__/render.breaking.test.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`toJSON 1`] = `
+<View
+  accessibilityState={
+    {
+      "busy": undefined,
+      "checked": undefined,
+      "disabled": undefined,
+      "expanded": undefined,
+      "selected": undefined,
+    }
+  }
+  accessibilityValue={
+    {
+      "max": undefined,
+      "min": undefined,
+      "now": undefined,
+      "text": undefined,
+    }
+  }
+  accessible={true}
+  collapsable={false}
+  focusable={true}
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+>
+  <Text>
+    press me
+  </Text>
+</View>
+`;

--- a/src/__tests__/__snapshots__/render.breaking.test.tsx.snap
+++ b/src/__tests__/__snapshots__/render.breaking.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`toJSON 1`] = `
+exports[`toJSON renders host output 1`] = `
 <View
   accessibilityState={
     {

--- a/src/__tests__/__snapshots__/render.test.tsx.snap
+++ b/src/__tests__/__snapshots__/render.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`toJSON 1`] = `
+exports[`toJSON renders host output 1`] = `
 <View
   accessibilityState={
     {

--- a/src/__tests__/render.breaking.test.tsx
+++ b/src/__tests__/render.breaking.test.tsx
@@ -219,7 +219,7 @@ test('returns host root', () => {
   expect(root.props.testID).toBe('inner');
 });
 
-test('returns UNSAFE_root', () => {
+test('returns composite UNSAFE_root', () => {
   const { UNSAFE_root } = render(<View testID="inner" />);
 
   expect(UNSAFE_root).toBeDefined();

--- a/src/__tests__/render.breaking.test.tsx
+++ b/src/__tests__/render.breaking.test.tsx
@@ -1,10 +1,10 @@
+/** This is a copy of regular tests with `useBreakingChanges` flag turned on. */
+
 /* eslint-disable no-console */
 import * as React from 'react';
 import { View, Text, TextInput, Pressable } from 'react-native';
 import { render, screen, fireEvent, RenderAPI } from '..';
 import { configureInternal } from '../config';
-
-type ConsoleLogMock = jest.Mock<typeof console.log>;
 
 beforeEach(() => {
   configureInternal({ useBreakingChanges: true });
@@ -155,9 +155,8 @@ test('unmount should handle cleanup functions', () => {
   expect(cleanup).toHaveBeenCalledTimes(1);
 });
 
-test('toJSON', () => {
+test('toJSON renders host output', () => {
   const { toJSON } = render(<MyButton>press me</MyButton>);
-
   expect(toJSON()).toMatchSnapshot();
 });
 
@@ -228,21 +227,12 @@ test('returns composite UNSAFE_root', () => {
 });
 
 test('container displays deprecation', () => {
-  jest.spyOn(console, 'warn').mockImplementation(() => {});
-  const mockCalls = (console.warn as ConsoleLogMock).mock.calls;
   const view = render(<View testID="inner" />);
 
   expect(() => view.container).toThrowErrorMatchingInlineSnapshot(
     `"'container' property has been renamed to 'UNSAFE_root'"`
   );
-  expect(mockCalls[0][0]).toMatchInlineSnapshot(
-    `"'container' property has been renamed to 'UNSAFE_root'"`
-  );
-
   expect(() => screen.container).toThrowErrorMatchingInlineSnapshot(
-    `"'container' property has been renamed to 'UNSAFE_root'"`
-  );
-  expect(mockCalls[1][0]).toMatchInlineSnapshot(
     `"'container' property has been renamed to 'UNSAFE_root'"`
   );
 });

--- a/src/__tests__/render.breaking.test.tsx
+++ b/src/__tests__/render.breaking.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import * as React from 'react';
-import { View, Text, TextInput, Pressable, SafeAreaView } from 'react-native';
+import { View, Text, TextInput, Pressable } from 'react-native';
 import { render, screen, fireEvent, RenderAPI } from '..';
 import { configureInternal } from '../config';
 

--- a/src/__tests__/render.breaking.test.tsx
+++ b/src/__tests__/render.breaking.test.tsx
@@ -229,12 +229,16 @@ test('returns composite UNSAFE_root', () => {
 test('container displays deprecation', () => {
   const view = render(<View testID="inner" />);
 
-  expect(() => view.container).toThrowErrorMatchingInlineSnapshot(
-    `"'container' property has been renamed to 'UNSAFE_root'"`
-  );
-  expect(() => screen.container).toThrowErrorMatchingInlineSnapshot(
-    `"'container' property has been renamed to 'UNSAFE_root'"`
-  );
+  expect(() => view.container).toThrowErrorMatchingInlineSnapshot(`
+    "'container' property has been renamed to 'UNSAFE_root'.
+
+    Consider using 'root' property which returns root host element."
+  `);
+  expect(() => screen.container).toThrowErrorMatchingInlineSnapshot(`
+    "'container' property has been renamed to 'UNSAFE_root'.
+
+    Consider using 'root' property which returns root host element."
+  `);
 });
 
 test('RenderAPI type', () => {

--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -212,7 +212,7 @@ test('returns host root', () => {
   expect(root.props.testID).toBe('inner');
 });
 
-test('returns UNSAFE_root', () => {
+test('returns composite UNSAFE_root', () => {
   const { UNSAFE_root } = render(<View testID="inner" />);
 
   expect(UNSAFE_root).toBeDefined();

--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -3,6 +3,12 @@ import * as React from 'react';
 import { View, Text, TextInput, Pressable, SafeAreaView } from 'react-native';
 import { render, fireEvent, RenderAPI } from '..';
 
+type ConsoleLogMock = jest.Mock<typeof console.log>;
+
+beforeEach(() => {
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
 const PLACEHOLDER_FRESHNESS = 'Add custom freshness';
 const PLACEHOLDER_CHEF = 'Who inspected freshness?';
 const INPUT_FRESHNESS = 'Custom Freshie';
@@ -222,6 +228,13 @@ test('returns composite UNSAFE_root', () => {
 
 test('returns container', () => {
   const { container } = render(<View testID="inner" />);
+
+  const mockCalls = (console.warn as any as ConsoleLogMock).mock.calls;
+  expect(mockCalls[0][0]).toMatchInlineSnapshot(`
+    "'container' property is deprecated and has been renamed to 'UNSAFE_root'.
+
+    Consider using 'root' property which returns root host element."
+  `);
 
   expect(container).toBeDefined();
   // `View` composite component is returned. This behavior will break if we

--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -148,7 +148,7 @@ test('unmount should handle cleanup functions', () => {
   expect(cleanup).toHaveBeenCalledTimes(1);
 });
 
-test('toJSON', () => {
+test('toJSON renders host output', () => {
   const { toJSON } = render(<MyButton>press me</MyButton>);
 
   expect(toJSON()).toMatchSnapshot();

--- a/src/__tests__/screen.test.tsx
+++ b/src/__tests__/screen.test.tsx
@@ -52,6 +52,10 @@ test('screen works with nested re-mounting rerender', () => {
 });
 
 test('screen throws without render', () => {
+  expect(() => screen.root).toThrow('`render` method has not been called');
+  expect(() => screen.UNSAFE_root).toThrow(
+    '`render` method has not been called'
+  );
   expect(() => screen.container).toThrow('`render` method has not been called');
   expect(() => screen.debug()).toThrow('`render` method has not been called');
   expect(() => screen.debug.shallow()).toThrow(

--- a/src/queries/__tests__/displayValue.breaking.test.tsx
+++ b/src/queries/__tests__/displayValue.breaking.test.tsx
@@ -1,3 +1,5 @@
+/** This is a copy of regular tests with `useBreakingChanges` flag turned on. */
+
 import * as React from 'react';
 import { View, TextInput } from 'react-native';
 

--- a/src/queries/__tests__/placeholderText.breaking.test.tsx
+++ b/src/queries/__tests__/placeholderText.breaking.test.tsx
@@ -1,4 +1,4 @@
-/** This is a copy of regular test with `useBreakingChanges` flag turned on. */
+/** This is a copy of regular tests with `useBreakingChanges` flag turned on. */
 
 import * as React from 'react';
 import { View, TextInput } from 'react-native';

--- a/src/queries/__tests__/placeholderText.breaking.test.tsx
+++ b/src/queries/__tests__/placeholderText.breaking.test.tsx
@@ -1,3 +1,5 @@
+/** This is a copy of regular test with `useBreakingChanges` flag turned on. */
+
 import * as React from 'react';
 import { View, TextInput } from 'react-native';
 import { render } from '../..';

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -10,6 +10,7 @@ import { getQueriesForElement } from './within';
 import { setRenderResult, screen } from './screen';
 import { validateStringsRenderedWithinText } from './helpers/stringValidation';
 import { getConfig } from './config';
+import { getHostChildren } from './helpers/component-tree';
 import { configureHostComponentNamesIfNeeded } from './helpers/host-component-names';
 
 export type RenderOptions = {
@@ -103,10 +104,22 @@ function buildRenderResult(
     ...getQueriesForElement(instance),
     update,
     unmount,
-    container: instance,
     rerender: update, // alias for `update`
     toJSON: renderer.toJSON,
     debug: debug(instance, renderer),
+    get root() {
+      return getHostChildren(instance)[0];
+    },
+    UNSAFE_root: instance,
+    get container() {
+      if (!getConfig().useBreakingChanges) {
+        return instance;
+      }
+
+      // eslint-disable-next-line no-console
+      console.warn(`'container' property has been renamed to 'UNSAFE_root'`);
+      throw new Error("'container' property has been renamed to 'UNSAFE_root'");
+    },
   };
 
   setRenderResult(result);

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -113,10 +113,18 @@ function buildRenderResult(
     UNSAFE_root: instance,
     get container() {
       if (!getConfig().useBreakingChanges) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          "'container' property is deprecated and has been renamed to 'UNSAFE_root'.\n\n" +
+            "Consider using 'root' property which returns root host element."
+        );
         return instance;
       }
 
-      throw new Error("'container' property has been renamed to 'UNSAFE_root'");
+      throw new Error(
+        "'container' property has been renamed to 'UNSAFE_root'.\n\n" +
+          "Consider using 'root' property which returns root host element."
+      );
     },
   };
 

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -116,8 +116,6 @@ function buildRenderResult(
         return instance;
       }
 
-      // eslint-disable-next-line no-console
-      console.warn(`'container' property has been renamed to 'UNSAFE_root'`);
       throw new Error("'container' property has been renamed to 'UNSAFE_root'");
     },
   };

--- a/src/screen.ts
+++ b/src/screen.ts
@@ -16,6 +16,12 @@ const defaultScreen: RenderResult = {
   get container(): ReactTestInstance {
     throw new Error(SCREEN_ERROR);
   },
+  get root(): ReactTestInstance {
+    throw new Error(SCREEN_ERROR);
+  },
+  get UNSAFE_root(): ReactTestInstance {
+    throw new Error(SCREEN_ERROR);
+  },
   debug: notImplementedDebug,
   update: notImplemented,
   unmount: notImplemented,

--- a/typings/index.flow.js
+++ b/typings/index.flow.js
@@ -436,6 +436,8 @@ declare module '@testing-library/react-native' {
     unmount(nextElement?: React.Element<any>): void;
     toJSON(): ReactTestRendererJSON[] | ReactTestRendererJSON | null;
     debug: Debug;
+    root: ReactTestInstance;
+    UNSAFE_root: ReactTestInstance;
     container: ReactTestInstance;
   }
 

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -19,7 +19,8 @@ title: API
     - [`mapProps` option](#mapprops-option)
     - [`debug.shallow`](#debugshallow)
   - [`toJSON`](#tojson)
-  - [`container`](#container)
+  - [`root`](#root)
+  - [`UNSAFE_root`](#unsafe_root)
 - [`screen`](#screen)
 - [`cleanup`](#cleanup)
 - [`fireEvent`](#fireevent)
@@ -251,13 +252,31 @@ toJSON(): ReactTestRendererJSON | null
 
 Get the rendered component JSON representation, e.g. for snapshot testing.
 
-### `container`
+### `root`
 
 ```ts
-container: ReactTestInstance;
+root: ReactTestInstance;
 ```
 
-A reference to the rendered root element.
+Returns the rendered root host element.
+
+This API is primarily useful in component tests, as it allows you to access root host view without using `ByTestId` queries or similar methods.
+
+### `UNSAFE_root`
+
+```ts
+UNSAFE_root: ReactTestInstance;
+```
+
+Returns the rendered root element.
+
+::caution
+This API typically will return a composite view which goes against recommended testing practices. This API is primarily available for legacy test suits that rely on such testing.
+::
+
+::note
+Previously this API has been named `container` for compatibility with React Testing Library. However, despite the same name, the actual behavior has been signficantly different, hence the name change to `UNSAFE_root`.
+::
 
 ## `screen`
 

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -258,7 +258,7 @@ Get the rendered component JSON representation, e.g. for snapshot testing.
 root: ReactTestInstance;
 ```
 
-Returns the rendered root host element.
+Returns the rendered root [host element](testing-env#host-and-composite-components).
 
 This API is primarily useful in component tests, as it allows you to access root host view without using `ByTestId` queries or similar methods.
 
@@ -268,14 +268,14 @@ This API is primarily useful in component tests, as it allows you to access root
 UNSAFE_root: ReactTestInstance;
 ```
 
-Returns the rendered root element.
+Returns the rendered [composite root element](testing-env#host-and-composite-components).
 
 ::caution
 This API typically will return a composite view which goes against recommended testing practices. This API is primarily available for legacy test suits that rely on such testing.
 ::
 
 ::note
-Previously this API has been named `container` for compatibility with React Testing Library. However, despite the same name, the actual behavior has been signficantly different, hence the name change to `UNSAFE_root`.
+This API has been previously named `container` for compatibility with [React Testing Library](https://testing-library.com/docs/react-testing-library/api#container-1). However, despite the same name, the actual behavior has been signficantly different, hence the name change to `UNSAFE_root`.
 ::
 
 ## `screen`

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -271,7 +271,7 @@ UNSAFE_root: ReactTestInstance;
 Returns the rendered [composite root element](testing-env#host-and-composite-components).
 
 :::caution
-This API typically will return a composite view which goes against recommended testing practices. This API is primarily available for legacy test suits that rely on such testing.
+This API typically will return a composite view which goes against recommended testing practices. This API is primarily available for legacy test suites that rely on such testing.
 :::
 
 :::note

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -260,7 +260,7 @@ root: ReactTestInstance;
 
 Returns the rendered root [host element](testing-env#host-and-composite-components).
 
-This API is primarily useful in component tests, as it allows you to access root host view without using `ByTestId` queries or similar methods.
+This API is primarily useful in component tests, as it allows you to access root host view without using `*ByTestId` queries or similar methods.
 
 ### `UNSAFE_root`
 
@@ -270,13 +270,13 @@ UNSAFE_root: ReactTestInstance;
 
 Returns the rendered [composite root element](testing-env#host-and-composite-components).
 
-::caution
+:::caution
 This API typically will return a composite view which goes against recommended testing practices. This API is primarily available for legacy test suits that rely on such testing.
-::
+:::
 
-::note
+:::note
 This API has been previously named `container` for compatibility with [React Testing Library](https://testing-library.com/docs/react-testing-library/api#container-1). However, despite the same name, the actual behavior has been signficantly different, hence the name change to `UNSAFE_root`.
-::
+:::
 
 ## `screen`
 

--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -39,7 +39,7 @@ title: Queries
 
 ## Variants
 
-> `getBy` queries are shown by default in the [query documentation](#queries)
+> `getBy*` queries are shown by default in the [query documentation](#queries)
 > below.
 
 ### getBy
@@ -60,22 +60,22 @@ title: Queries
 
 ### findBy
 
-`findBy` queries return a promise which resolves when a matching element is found. The promise is rejected if no elements match or if more than one match is found after a default timeout of 1000 ms. If you need to find more than one element, then use `findAllBy`.
+`findBy*` queries return a promise which resolves when a matching element is found. The promise is rejected if no elements match or if more than one match is found after a default timeout of 1000 ms. If you need to find more than one element, then use `findAllBy*`.
 
 ### findAllBy
 
-`findAllBy` queries return a promise which resolves to an array of matching elements. The promise is rejected if no elements match after a default timeout of 1000 ms.
+`findAllBy*` queries return a promise which resolves to an array of matching elements. The promise is rejected if no elements match after a default timeout of 1000 ms.
 
 :::info
-`findBy` and `findAllBy` queries accept optional `waitForOptions` object argument which can contain `timeout`, `interval` and `onTimeout` properies which have the same meaning as respective options for [`waitFor`](api#waitfor) function.
+`findBy*` and `findAllBy*` queries accept optional `waitForOptions` object argument which can contain `timeout`, `interval` and `onTimeout` properies which have the same meaning as respective options for [`waitFor`](api#waitfor) function.
 :::
 
 :::info
-In cases when your `findBy` and `findAllBy` queries throw when not able to find matching elements it is useful to pass `onTimeout: () => { screen.debug(); }` callback using `waitForOptions` parameter.
+In cases when your `findBy*` and `findAllBy*` queries throw when not able to find matching elements it is useful to pass `onTimeout: () => { screen.debug(); }` callback using `waitForOptions` parameter.
 :::
 
 :::info
-In order to properly use `findBy` and `findAllBy` queries you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.61 (which comes with React >=16.9.0).
+In order to properly use `findBy*` and `findAllBy*` queries you need at least React >=16.9.0 (featuring async `act`) or React Native >=0.61 (which comes with React >=16.9.0).
 :::
 
 ## Queries


### PR DESCRIPTION
### Summary

This PR contains breaking changes behind `useBreakingChanges` feature flag.

Resolves #1296 

1. Rename `container` to `UNSAFE_root`
2. Display deprecation messages for `container` (behind `useBreakingChanges` )
3. Expose `root` API that returns root host element.

### Test plan

All tests pass.