### PR TITLE
fix: get host component names on render (modified)

### DIFF
--- a/src/__tests__/host-component-names.test.tsx
+++ b/src/__tests__/host-component-names.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { View } from 'react-native';
 import TestRenderer from 'react-test-renderer';
 import { configureInternal, getConfig } from '../config';

--- a/src/__tests__/host-component-names.test.tsx
+++ b/src/__tests__/host-component-names.test.tsx
@@ -1,8 +1,10 @@
+import React from 'react';
 import { View } from 'react-native';
 import TestRenderer from 'react-test-renderer';
 import { configureInternal, getConfig } from '../config';
 import { getHostComponentNames } from '../helpers/host-component-names';
 import * as within from '../within';
+import { act, render } from '..';
 
 const mockCreate = jest.spyOn(TestRenderer, 'create') as jest.Mock;
 const mockGetQueriesForElements = jest.spyOn(
@@ -33,6 +35,15 @@ describe('getHostComponentNames', () => {
       text: 'banana',
       textInput: 'banana',
     });
+  });
+
+  test('does not throw when wrapped in act after render has been called', () => {
+    render(<View />);
+    expect(() =>
+      act(() => {
+        getHostComponentNames();
+      })
+    ).not.toThrow();
   });
 
   test('throw an error when autodetection fails', () => {

--- a/src/__tests__/host-component-names.test.tsx
+++ b/src/__tests__/host-component-names.test.tsx
@@ -27,13 +27,16 @@ describe('getHostComponentNames', () => {
     });
   });
 
-  test('throws when names are missing in the internal config', () => {
-    expect(() => getHostComponentNames()).toThrowErrorMatchingInlineSnapshot(`
-      "Missing host component names.
+  test('detects host component names if not present in internal config', () => {
+    expect(getConfig().hostComponentNames).toBeUndefined();
 
-      There seems to be an issue with your configuration that prevents React Native Testing Library from working correctly.
-      Please check if you are using compatible versions of React Native and React Native Testing Library."
-    `);
+    const hostComponentNames = getHostComponentNames();
+
+    expect(hostComponentNames).toEqual({
+      text: 'Text',
+      textInput: 'TextInput',
+    });
+    expect(getConfig().hostComponentNames).toBe(hostComponentNames);
   });
 
   // Repro test for case when user indirectly triggers `getHostComponentNames` calls from

--- a/src/__tests__/host-component-names.test.tsx
+++ b/src/__tests__/host-component-names.test.tsx
@@ -36,6 +36,10 @@ describe('getHostComponentNames', () => {
     `);
   });
 
+  // Repro test for case when user indirectly triggers `getHostComponentNames` calls from
+  // explicit `act` wrapper.
+  // See: https://github.com/callstack/react-native-testing-library/issues/1302
+  // and https://github.com/callstack/react-native-testing-library/issues/1305
   test('does not throw when wrapped in act after render has been called', () => {
     render(<View />);
     expect(() =>

--- a/src/helpers/host-component-names.tsx
+++ b/src/helpers/host-component-names.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Text, TextInput, View } from 'react-native';
 import TestRenderer from 'react-test-renderer';
+import type { ReactTestRenderer } from 'react-test-renderer';
 import { configureInternal, getConfig, HostComponentNames } from '../config';
 import { getQueriesForElement } from '../within';
-
 const defaultErrorMessage = `There seems to be an issue with your configuration that prevents React Native Testing Library from working correctly.
 Please check if you are using compatible versions of React Native and React Native Testing Library.`;
 
@@ -12,14 +12,16 @@ export function getHostComponentNames(): HostComponentNames {
   if (configHostComponentNames) {
     return configHostComponentNames;
   }
+  let renderer: ReactTestRenderer;
 
   try {
-    const renderer = TestRenderer.create(
+    renderer = TestRenderer.create(
       <View>
         <Text testID="text">Hello</Text>
         <TextInput testID="textInput" />
       </View>
     );
+
     const { getByTestId } = getQueriesForElement(renderer.root);
     const textHostName = getByTestId('text').type;
     const textInputHostName = getByTestId('textInput').type;

--- a/src/helpers/host-component-names.tsx
+++ b/src/helpers/host-component-names.tsx
@@ -3,16 +3,18 @@ import { Text, TextInput, View } from 'react-native';
 import TestRenderer from 'react-test-renderer';
 import { configureInternal, getConfig, HostComponentNames } from '../config';
 import { getQueriesForElement } from '../within';
-const defaultErrorMessage = `There seems to be an issue with your configuration that prevents React Native Testing Library from working correctly.
+
+const userConfigErrorMessage = `There seems to be an issue with your configuration that prevents React Native Testing Library from working correctly.
 Please check if you are using compatible versions of React Native and React Native Testing Library.`;
 
 export function getHostComponentNames(): HostComponentNames {
-  const configHostComponentNames = getConfig().hostComponentNames;
-  if (!configHostComponentNames) {
-    throw new Error(`Missing host component names.\n\n${defaultErrorMessage}`);
+  let hostComponentNames = getConfig().hostComponentNames;
+  if (!hostComponentNames) {
+    hostComponentNames = detectHostComponentNames();
+    configureInternal({ hostComponentNames });
   }
 
-  return configHostComponentNames;
+  return hostComponentNames;
 }
 
 export function configureHostComponentNamesIfNeeded() {
@@ -57,7 +59,7 @@ function detectHostComponentNames(): HostComponentNames {
         : null;
 
     throw new Error(
-      `Trying to detect host component names triggered the following error:\n\n${errorMessage}\n\n${defaultErrorMessage}`
+      `Trying to detect host component names triggered the following error:\n\n${errorMessage}\n\n${userConfigErrorMessage}`
     );
   }
 }

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -10,7 +10,7 @@ import { getQueriesForElement } from './within';
 import { setRenderResult, screen } from './screen';
 import { validateStringsRenderedWithinText } from './helpers/stringValidation';
 import { getConfig } from './config';
-import { getHostComponentNames } from './helpers/host-component-names';
+import { configureHostComponentNamesIfNeeded } from './helpers/host-component-names';
 
 export type RenderOptions = {
   wrapper?: React.ComponentType<any>;
@@ -36,14 +36,14 @@ export default function render<T>(
     unstable_validateStringsRenderedWithinText,
   }: RenderOptions = {}
 ) {
+  configureHostComponentNamesIfNeeded();
+
   if (unstable_validateStringsRenderedWithinText) {
     return renderWithStringValidation(component, {
       wrapper: Wrapper,
       createNodeMock,
     });
   }
-
-  getHostComponentNames();
 
   const wrap = (element: React.ReactElement) =>
     Wrapper ? <Wrapper>{element}</Wrapper> : element;

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -10,6 +10,7 @@ import { getQueriesForElement } from './within';
 import { setRenderResult, screen } from './screen';
 import { validateStringsRenderedWithinText } from './helpers/stringValidation';
 import { getConfig } from './config';
+import { getHostComponentNames } from './helpers/host-component-names';
 
 export type RenderOptions = {
   wrapper?: React.ComponentType<any>;
@@ -41,6 +42,8 @@ export default function render<T>(
       createNodeMock,
     });
   }
+
+  getHostComponentNames();
 
   const wrap = (element: React.ReactElement) =>
     Wrapper ? <Wrapper>{element}</Wrapper> : element;


### PR DESCRIPTION
This is based on #1304, but since that was external PR I've moved it as internal repo PR with added proposed changes:
* extract `detectHostElementNames` from `getHostComponents()`
* create `configureHostElementNamesIfNeeded` to be called in `render`
* simplify `getHostElementNames`.

Summary
Fixes https://github.com/callstack/react-native-testing-library/issues/1302 by detecting host component names in `render` to prevent running auto detection in external `act` which fails for some users.

Test plan
Added a test case where I call getHostComponentNames wrapped in act after a render and expect it does not throw