### PR TITLE
docs: update docs on custom jest preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Then automatically add it to your jest tests by using `setupFilesAfterEnv` optio
 
 ### Custom Jest Preset
 
-> **important** if you use "modern" Fake Timers
+> **important** if you use "modern" Fake Timers and React Native < 0.71
 
 We generally advise to use the "react-native" preset when testing with this library. However, if you use ["modern" Fake Timers](https://jestjs.io/blog/2020/05/05/jest-26#new-fake-timers) (default since Jest 27), you'll need to apply our custom Jest preset or awaiting promises, like `waitFor`, will timeout.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Then automatically add it to your jest tests by using `setupFilesAfterEnv` optio
 }
 ```
 
-### Custom Jest Preset
+### Custom Jest Preset (React Native before 0.71)
 
 We generally advise to use the "react-native" preset when testing with this library.
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Then automatically add it to your jest tests by using `setupFilesAfterEnv` optio
 
 ### Custom Jest Preset
 
-> **important** if you use "modern" Fake Timers and React Native < 0.71
+We generally advise to use the "react-native" preset when testing with this library.
 
-We generally advise to use the "react-native" preset when testing with this library. However, if you use ["modern" Fake Timers](https://jestjs.io/blog/2020/05/05/jest-26#new-fake-timers) (default since Jest 27), you'll need to apply our custom Jest preset or awaiting promises, like `waitFor`, will timeout.
+However, if you use React Native version earlier than 0.71 with [modern Jest fake timers](https://jestjs.io/blog/2020/05/05/jest-26#new-fake-timers) (default since Jest 27), you'll need to apply this custom Jest preset or otherwise awaiting promises, like using `waitFor` or `findBy*`, queries will fail with timeout.
 
 This is a [known issue](https://github.com/facebook/react-native/issues/29303). It happens because React Native's Jest preset overrides native Promise. Our preset restores it to defaults, which is not a problem in most apps out there.
 

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -563,7 +563,7 @@ It is also recommended to have a [single assertion per each `waitFor`](https://k
 ### Using Jest fake timers
 
 :::caution
-When using modern fake timers (the default for `Jest` >= 27), `waitFor` won't work (it will always timeout even if `expectation()` doesn't throw) unless you use the custom [@testing-library/react-native preset](https://github.com/callstack/react-native-testing-library#custom-jest-preset). 
+When using modern fake timers (the default for `Jest` >= 27), `waitFor` won't work (it will always timeout even if `expectation()` doesn't throw) unless you use the custom [@testing-library/react-native preset](https://github.com/callstack/react-native-testing-library#custom-jest-preset) or you use a version of React Native >= 0.71. 
 :::
 
 `waitFor` checks whether Jest fake timers are enabled and adapts its behavior in such case. The following snippet is a simplified version of how it behaves when fake timers are enabled:

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -560,10 +560,10 @@ Avoiding side effects in `expectation` callback can be partially enforced with t
 
 It is also recommended to have a [single assertion per each `waitFor`](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#having-multiple-assertions-in-a-single-waitfor-callback) for more consistency and faster failing tests. If you want to make several assertions, then they should be in seperate `waitFor` calls. In many cases you won't actually need to wrap the second assertion in `waitFor` since the first one will do the waiting required for asynchronous change to happen.
 
-### Using Jest fake timers
+### Using a React Native version < 0.71 with Jest fake timers
 
 :::caution
-When using modern fake timers (the default for `Jest` >= 27), `waitFor` won't work (it will always timeout even if `expectation()` doesn't throw) unless you use the custom [@testing-library/react-native preset](https://github.com/callstack/react-native-testing-library#custom-jest-preset) or you use a version of React Native >= 0.71. 
+When using a version of React Native < 0.71 and modern fake timers (the default for `Jest` >= 27), `waitFor` won't work (it will always timeout even if `expectation()` doesn't throw) unless you use the custom [@testing-library/react-native preset](https://github.com/callstack/react-native-testing-library#custom-jest-preset). 
 :::
 
 `waitFor` checks whether Jest fake timers are enabled and adapts its behavior in such case. The following snippet is a simplified version of how it behaves when fake timers are enabled:


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Based on #1307

Updates docs to specify that jest preset is no longer required for users that have a version of react native >= 0.71.2 

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
