### PR TITLE
fix: container enumeration

### DIFF
--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -222,12 +222,12 @@ test('returns composite UNSAFE_root', () => {
 test('container displays deprecation', () => {
   const view = render(<View testID="inner" />);
 
-  expect(() => view.container).toThrowErrorMatchingInlineSnapshot(`
+  expect(() => (view as any).container).toThrowErrorMatchingInlineSnapshot(`
     "'container' property has been renamed to 'UNSAFE_root'.
 
     Consider using 'root' property which returns root host element."
   `);
-  expect(() => screen.container).toThrowErrorMatchingInlineSnapshot(`
+  expect(() => (screen as any).container).toThrowErrorMatchingInlineSnapshot(`
     "'container' property has been renamed to 'UNSAFE_root'.
 
     Consider using 'root' property which returns root host element."

--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -238,3 +238,10 @@ test('RenderAPI type', () => {
   render(<Banana />) as RenderAPI;
   expect(true).toBeTruthy();
 });
+
+test('returned output can be spread using rest operator', () => {
+  // Next line should not throw
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { rerender, ...rest } = render(<View testID="inner" />);
+  expect(rest).toBeTruthy();
+});

--- a/src/__tests__/screen.test.tsx
+++ b/src/__tests__/screen.test.tsx
@@ -56,7 +56,6 @@ test('screen throws without render', () => {
   expect(() => screen.UNSAFE_root).toThrow(
     '`render` method has not been called'
   );
-  expect(() => screen.container).toThrow('`render` method has not been called');
   expect(() => screen.debug()).toThrow('`render` method has not been called');
   expect(() => screen.debug.shallow()).toThrow(
     '`render` method has not been called'

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -113,6 +113,8 @@ function buildRenderResult(
     UNSAFE_root: instance,
   };
 
+  // Add as non-enumerable property, so that it's safe to enumerate
+  // `render` result, e.g. using destructuring rest syntax.
   Object.defineProperty(result, 'container', {
     enumerable: false,
     get() {

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -111,13 +111,17 @@ function buildRenderResult(
       return getHostChildren(instance)[0];
     },
     UNSAFE_root: instance,
-    get container(): ReactTestInstance {
+  };
+
+  Object.defineProperty(result, 'container', {
+    enumerable: false,
+    get() {
       throw new Error(
         "'container' property has been renamed to 'UNSAFE_root'.\n\n" +
           "Consider using 'root' property which returns root host element."
       );
     },
-  };
+  });
 
   setRenderResult(result);
   return result;

--- a/src/screen.ts
+++ b/src/screen.ts
@@ -13,9 +13,6 @@ const notImplementedDebug = () => {
 notImplementedDebug.shallow = notImplemented;
 
 const defaultScreen: RenderResult = {
-  get container(): ReactTestInstance {
-    throw new Error(SCREEN_ERROR);
-  },
   get root(): ReactTestInstance {
     throw new Error(SCREEN_ERROR);
   },


### PR DESCRIPTION
### Summary

Make deprecated `container` property non enumerable to avoid triggering exception when used in e.g. object rest destructuring.

Resolves #1350.

### Test plan

Added unit test for rest destructuring.