### PR TITLE
chore: remove stale babel deps

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -12,4 +12,10 @@ module.exports = {
       },
     ],
   ],
+  env: {
+    test: {
+      // https://github.com/react-native-community/upgrade-support/issues/152
+      plugins: ['@babel/plugin-transform-flow-strip-types'],
+    },
+  },
 };

--- a/babel.config.js
+++ b/babel.config.js
@@ -12,11 +12,4 @@ module.exports = {
       },
     ],
   ],
-  plugins: ['@babel/plugin-proposal-class-properties'],
-  env: {
-    test: {
-      // https://github.com/react-native-community/upgrade-support/issues/152
-      plugins: ['@babel/plugin-transform-flow-strip-types'],
-    },
-  },
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@babel/core": "^7.20.2",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/preset-env": "^7.20.2",
-    "@babel/preset-flow": "^7.18.6",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.18.6",
     "@callstack/eslint-config": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "devDependencies": {
     "@babel/cli": "^7.19.3",
     "@babel/core": "^7.20.2",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.18.6",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@babel/cli": "^7.19.3",
     "@babel/core": "^7.20.2",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
-    "@babel/plugin-transform-flow-strip-types": "^7.19.0",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-flow": "^7.18.6",
     "@babel/preset-react": "^7.18.6",

--- a/src/__tests__/__snapshots__/render-debug.test.tsx.snap
+++ b/src/__tests__/__snapshots__/render-debug.test.tsx.snap
@@ -393,7 +393,7 @@ exports[`debug: shallow 1`] = `
     value=""
   />
   <MyButton
-    onPress={[Function anonymous]}
+    onPress={[Function changeFresh]}
     type="primary"
   >
     Change freshness!
@@ -445,7 +445,7 @@ exports[`debug: shallow with message 1`] = `
     value=""
   />
   <MyButton
-    onPress={[Function anonymous]}
+    onPress={[Function changeFresh]}
     type="primary"
   >
     Change freshness!

--- a/yarn.lock
+++ b/yarn.lock
@@ -1004,7 +1004,7 @@
     core-js-compat "^3.25.1"
     semver "^6.3.0"
 
-"@babel/preset-flow@^7.13.13", "@babel/preset-flow@^7.18.6":
+"@babel/preset-flow@^7.13.13":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.18.6.tgz#83f7602ba566e72a9918beefafef8ef16d2810cb"
   integrity sha512-E7BDhL64W6OUqpuyHnSroLnqyRTcG6ZdOBl1OKI/QK/HJfplqK/S3sq1Cckx7oTodJ5yOXyfw7rEADJ6UjoQDQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -679,7 +679,7 @@
     "@babel/helper-builder-binary-assignment-operator-visitor" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-transform-flow-strip-types@^7.0.0", "@babel/plugin-transform-flow-strip-types@^7.18.6", "@babel/plugin-transform-flow-strip-types@^7.19.0":
+"@babel/plugin-transform-flow-strip-types@^7.0.0", "@babel/plugin-transform-flow-strip-types@^7.18.6":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.21.0.tgz#6aeca0adcb81dc627c8986e770bfaa4d9812aff5"
   integrity sha512-FlFA2Mj87a6sDkW4gfGrQQqwY/dLlBAyJa2dJEZ+FHXUVHBflO2wyKvg+OOEzXfrKYIa4HWl0mgmbCzt0cMb7w==


### PR DESCRIPTION
### Summary

Remove explicit dev deps on babel packages:
* "@babel/plugin-proposal-class-properties": "^7.18.6",
* "@babel/plugin-transform-flow-strip-types": "^7.19.0",
* "@babel/preset-flow": "^7.18.6",

### Test plan

All checks should pass.
