### PR TITLE
fix: disable container deprecation warning (main)

### DIFF
--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -229,13 +229,6 @@ test('returns composite UNSAFE_root', () => {
 test('returns container', () => {
   const { container } = render(<View testID="inner" />);
 
-  const mockCalls = (console.warn as any as ConsoleLogMock).mock.calls;
-  expect(mockCalls[0][0]).toMatchInlineSnapshot(`
-    "'container' property is deprecated and has been renamed to 'UNSAFE_root'.
-
-    Consider using 'root' property which returns root host element."
-  `);
-
   expect(container).toBeDefined();
   // `View` composite component is returned. This behavior will break if we
   // start returning only host components.
@@ -263,4 +256,12 @@ test('returns wrapper component as container', () => {
 test('RenderAPI type', () => {
   render(<Banana />) as RenderAPI;
   expect(true).toBeTruthy();
+});
+
+test('returned output can be spread using rest operator', () => {
+  // Next line should not throw
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { rerender, ...rest } = render(<View testID="inner" />);
+  expect(rest).toBeTruthy();
+  expect(console.warn).not.toHaveBeenCalled();
 });

--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -3,8 +3,6 @@ import * as React from 'react';
 import { View, Text, TextInput, Pressable, SafeAreaView } from 'react-native';
 import { render, fireEvent, RenderAPI } from '..';
 
-type ConsoleLogMock = jest.Mock<typeof console.log>;
-
 beforeEach(() => {
   jest.spyOn(console, 'warn').mockImplementation(() => {});
 });

--- a/src/helpers/__tests__/getTextContent.test.tsx
+++ b/src/helpers/__tests__/getTextContent.test.tsx
@@ -5,7 +5,7 @@ import { getTextContent } from '../getTextContent';
 
 test('getTextContent with simple content', () => {
   const view = render(<Text>Hello world</Text>);
-  expect(getTextContent(view.container)).toBe('Hello world');
+  expect(getTextContent(view.root)).toBe('Hello world');
 });
 
 test('getTextContent with null element', () => {
@@ -18,7 +18,7 @@ test('getTextContent with single nested content', () => {
       <Text>Hello world</Text>
     </Text>
   );
-  expect(getTextContent(view.container)).toBe('Hello world');
+  expect(getTextContent(view.root)).toBe('Hello world');
 });
 
 test('getTextContent with multiple nested content', () => {
@@ -27,7 +27,7 @@ test('getTextContent with multiple nested content', () => {
       <Text>Hello</Text> <Text>world</Text>
     </Text>
   );
-  expect(getTextContent(view.container)).toBe('Hello world');
+  expect(getTextContent(view.root)).toBe('Hello world');
 });
 
 test('getTextContent with multiple number content', () => {
@@ -36,7 +36,7 @@ test('getTextContent with multiple number content', () => {
       <Text>Hello</Text> <Text>world</Text> <Text>{100}</Text>
     </Text>
   );
-  expect(getTextContent(view.container)).toBe('Hello world 100');
+  expect(getTextContent(view.root)).toBe('Hello world 100');
 });
 
 test('getTextContent with multiple boolean content', () => {
@@ -45,5 +45,5 @@ test('getTextContent with multiple boolean content', () => {
       <Text>Hello{false}</Text> <Text>{true}world</Text>
     </Text>
   );
-  expect(getTextContent(view.container)).toBe('Hello world');
+  expect(getTextContent(view.root)).toBe('Hello world');
 });

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -113,11 +113,6 @@ function buildRenderResult(
     UNSAFE_root: instance,
     get container() {
       if (!getConfig().useBreakingChanges) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          "'container' property is deprecated and has been renamed to 'UNSAFE_root'.\n\n" +
-            "Consider using 'root' property which returns root host element."
-        );
         return instance;
       }
 


### PR DESCRIPTION
### Summary

Resolves #1350 on `main`

```ts
const { something, ...rest } = render(...)
```
Above code, frequently used for building custom render functions, triggers `container` console warning, as rest operator causes `container` property to be read and hence the error logged. To avoid this unnecessary and not actionable noise for the users I disabled the console warning.

### Test plan

All checks should pass.
