### PR TITLE
Flush all pending microtasks and updates before returning from waitFor

### DIFF
--- a/src/__tests__/waitFor.test.tsx
+++ b/src/__tests__/waitFor.test.tsx
@@ -281,9 +281,7 @@ test.each([
 
       // On mount, set the color to "red" in a promise microtask
       React.useEffect(() => {
-        // we want to use a Promise, as async functions are not very ergonomic as effects,
-        // and we're sure we don't need a catch handler.
-        // eslint-disable-next-line , promise/prefer-await-to-then, promise/catch-or-return
+        // eslint-disable-next-line promise/prefer-await-to-then, promise/catch-or-return
         Promise.resolve('red').then((c) => setColor(c));
       }, []);
 
@@ -302,7 +300,7 @@ test.each([
       );
     }
 
-    const onPress = jest.fn<void, [string]>();
+    const onPress = jest.fn();
     const view = render(<Apple onPress={onPress} />);
 
     // Required: this `waitFor` will succeed on first check, because the "root" view is there

--- a/src/__tests__/waitFor.test.tsx
+++ b/src/__tests__/waitFor.test.tsx
@@ -277,6 +277,9 @@ test.each([false, true])(
 
       // On mount, set the color to "red" in a promise microtask
       React.useEffect(() => {
+        // we want to use a Promise, as async functions are not very ergonomic as effects,
+        // and we're sure we don't need a catch handler.
+        // eslint-disable-next-line , promise/prefer-await-to-then, promise/catch-or-return
         Promise.resolve('red').then((c) => setColor(c));
       }, []);
 

--- a/src/flushMicroTasks.ts
+++ b/src/flushMicroTasks.ts
@@ -2,7 +2,7 @@ import { setImmediate } from './helpers/timers';
 
 type Thenable<T> = { then: (callback: () => T) => unknown };
 
-export function flushMicroTasks<T>(): Thenable<T> {
+export function flushMicroTasks(): Thenable<void> {
   return {
     // using "thenable" instead of a Promise, because otherwise it breaks when
     // using "modern" fake timers

--- a/src/waitFor.ts
+++ b/src/waitFor.ts
@@ -1,6 +1,7 @@
 /* globals jest */
 import act, { setReactActEnvironment, getIsReactActEnvironment } from './act';
 import { getConfig } from './config';
+import { flushMicroTasks } from './flushMicroTasks';
 import { ErrorWithStack, copyStackTrace } from './helpers/errors';
 import {
   setTimeout,
@@ -197,8 +198,8 @@ export default async function waitFor<T>(
 
     try {
       const result = await waitForInternal(expectation, optionsWithStackTrace);
-      // drain the microtask queue before restoring the `act` environment
-      await new Promise((resolve) => setImmediate(resolve));
+      // Flush the microtask queue before restoring the `act` environment
+      await flushMicroTasks();
       return result;
     } finally {
       setReactActEnvironment(previousActEnvironment);

--- a/src/waitFor.ts
+++ b/src/waitFor.ts
@@ -196,7 +196,10 @@ export default async function waitFor<T>(
     setReactActEnvironment(false);
 
     try {
-      return await waitForInternal(expectation, optionsWithStackTrace);
+      const result = await waitForInternal(expectation, optionsWithStackTrace);
+      // drain the microtask queue before restoring the `act` environment
+      await new Promise((resolve) => setImmediate(resolve));
+      return result;
     } finally {
       setReactActEnvironment(previousActEnvironment);
     }


### PR DESCRIPTION
It can happen that a `waitFor` call like
```js
await waitFor(() => getByText('green'));
```
successfully returns because the `"green"` text has been rendered, but after returning, the effects or state updates scheduled by the `"green"` render haven't been executed yet.

That's because `waitFor` internally leaves the `act` environment for a moment, lets a render to be performed and to schedule updates outside the `act` queue, and then returns before these updates were flushed.

I'm submitting a test that exposes this bug, using a series of cascaded effects and state updates, and also a fix.

Accidentally, @eps1lon landed almost exactly the same fix to `@testing-library/react` a month ago: https://github.com/testing-library/react-testing-library/pull/1137. But I discovered the React Native bug independently, while investigating why [our own tests are failing](https://github.com/WordPress/gutenberg/pull/46735#issuecomment-1469931650). 🙂 