### PR TITLE
detectHostComponentNames: render test tree inside act to avoid timer leaks

### DIFF
--- a/src/helpers/host-component-names.tsx
+++ b/src/helpers/host-component-names.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
+import * as React from 'react';
 import { Text, TextInput, View } from 'react-native';
-import TestRenderer from 'react-test-renderer';
-import type { ReactTestRenderer } from 'react-test-renderer';
 import { configureInternal, getConfig, HostComponentNames } from '../config';
+import { renderWithAct } from '../render-act';
 import { getQueriesForElement } from '../within';
 
 const userConfigErrorMessage = `There seems to be an issue with your configuration that prevents React Native Testing Library from working correctly.
@@ -30,21 +29,12 @@ export function configureHostComponentNamesIfNeeded() {
 
 function detectHostComponentNames(): HostComponentNames {
   try {
-    const renderer = (() => {
-      let result: ReactTestRenderer;
-      TestRenderer.act(() => {
-        result = TestRenderer.create(
-          <View>
-            <Text testID="text">Hello</Text>
-            <TextInput testID="textInput" />
-          </View>
-        );
-      });
-
-      // @ts-ignore act is syncronous, so renderer will already be initialised here
-      return result;
-    })();
-
+    const renderer = renderWithAct(
+      <View>
+        <Text testID="text">Hello</Text>
+        <TextInput testID="textInput" />
+      </View>
+    );
     const { getByTestId } = getQueriesForElement(renderer.root);
     const textHostName = getByTestId('text').type;
     const textInputHostName = getByTestId('textInput').type;

--- a/src/helpers/host-component-names.tsx
+++ b/src/helpers/host-component-names.tsx
@@ -40,7 +40,8 @@ function detectHostComponentNames(): HostComponentNames {
           </View>
         );
       });
-      // @ts-ignore act is sync, so renderer is always initialised here
+
+      // @ts-ignore act is syncronous, so renderer will already be initialised here
       return result;
     })();
 

--- a/src/helpers/host-component-names.tsx
+++ b/src/helpers/host-component-names.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Text, TextInput, View } from 'react-native';
 import TestRenderer from 'react-test-renderer';
+import type { ReactTestRenderer } from 'react-test-renderer';
 import { configureInternal, getConfig, HostComponentNames } from '../config';
 import { getQueriesForElement } from '../within';
 
@@ -29,12 +30,19 @@ export function configureHostComponentNamesIfNeeded() {
 
 function detectHostComponentNames(): HostComponentNames {
   try {
-    const renderer = TestRenderer.create(
-      <View>
-        <Text testID="text">Hello</Text>
-        <TextInput testID="textInput" />
-      </View>
-    );
+    const renderer = (() => {
+      let result: ReactTestRenderer;
+      TestRenderer.act(() => {
+        result = TestRenderer.create(
+          <View>
+            <Text testID="text">Hello</Text>
+            <TextInput testID="textInput" />
+          </View>
+        );
+      });
+      // @ts-ignore act is sync, so renderer is always initialised here
+      return result;
+    })();
 
     const { getByTestId } = getQueriesForElement(renderer.root);
     const textHostName = getByTestId('text').type;

--- a/src/render-act.ts
+++ b/src/render-act.ts
@@ -14,6 +14,6 @@ export function renderWithAct(
     renderer = TestRenderer.create(component, options);
   });
 
-  // @ts-ignore act is syncronous, so renderer is already initialised here
+  // @ts-ignore act is synchronous, so renderer is already initialised here
   return renderer;
 }

--- a/src/render-act.ts
+++ b/src/render-act.ts
@@ -1,0 +1,19 @@
+import TestRenderer from 'react-test-renderer';
+import type {
+  ReactTestRenderer,
+  TestRendererOptions,
+} from 'react-test-renderer';
+
+export function renderWithAct(
+  component: React.ReactElement,
+  options?: TestRendererOptions
+): ReactTestRenderer {
+  let renderer: ReactTestRenderer;
+
+  TestRenderer.act(() => {
+    renderer = TestRenderer.create(component, options);
+  });
+
+  // @ts-ignore act is syncronous, so renderer is already initialised here
+  return renderer;
+}

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -1,26 +1,22 @@
-import TestRenderer from 'react-test-renderer';
 import type { ReactTestInstance, ReactTestRenderer } from 'react-test-renderer';
 import * as React from 'react';
 import { Profiler } from 'react';
 import act from './act';
 import { addToCleanupQueue } from './cleanup';
-import debugShallow from './helpers/debugShallow';
-import debugDeep, { DebugOptions } from './helpers/debugDeep';
-import { getQueriesForElement } from './within';
-import { setRenderResult, screen } from './screen';
-import { validateStringsRenderedWithinText } from './helpers/stringValidation';
 import { getConfig } from './config';
 import { getHostChildren } from './helpers/component-tree';
+import debugDeep, { DebugOptions } from './helpers/debugDeep';
+import debugShallow from './helpers/debugShallow';
 import { configureHostComponentNamesIfNeeded } from './helpers/host-component-names';
+import { validateStringsRenderedWithinText } from './helpers/stringValidation';
+import { renderWithAct } from './render-act';
+import { setRenderResult, screen } from './screen';
+import { getQueriesForElement } from './within';
 
 export type RenderOptions = {
   wrapper?: React.ComponentType<any>;
   createNodeMock?: (element: React.ReactElement) => any;
   unstable_validateStringsRenderedWithinText?: boolean;
-};
-
-type TestRendererOptions = {
-  createNodeMock: (element: React.ReactElement) => any;
 };
 
 export type RenderResult = ReturnType<typeof render>;
@@ -127,20 +123,6 @@ function buildRenderResult(
 
   setRenderResult(result);
   return result;
-}
-
-function renderWithAct(
-  component: React.ReactElement,
-  options?: TestRendererOptions
-): ReactTestRenderer {
-  let renderer: ReactTestRenderer;
-
-  act(() => {
-    renderer = TestRenderer.create(component, options);
-  });
-
-  // @ts-ignore act is sync, so renderer is always initialised here
-  return renderer;
 }
 
 function updateWithAct(


### PR DESCRIPTION
Fixes a bug that I discovered while working on #1366: when first calling `render` in a test suite, the `render` function calls `detectHostComponentNames`, which mounts a testing tree with a few components. This tree is rendered outside the `act` environment, and therefore schedules a `setImmediate` callback to process effects. This scheduled callback then has an unwanted interaction with my actual testing code. If there is a `waitFor` inside my test, the effects scheduled by _my_ testing code will not be processed by _my_ `setImmediate`, but by the one scheduled by `detectHostComponentNames`. That makes the precise order of events inside my test non-deterministic and unpredictable.

Look at this call stack:

<img width="453" alt="Screenshot 2023-03-17 at 11 55 24" src="https://user-images.githubusercontent.com/664258/225910104-3ab7dbc2-1622-4b67-8e24-5db17089ea29.png">

and note how it starts in my `waitFor.test.ts` test, in the `render` function, then calls `detectHostComponentNames`, schedules `setImmediate` callback, and how that `setImmediate` later processes an update scheduled by my test code (the `Apple` component).

This PR avoids that by wrapping the render with `act`. That way, all effects scheduled by the render will come into the `actQueue`, and will be flushed before returning. No leaks.

In the code, I had to do some silly IIFE magic to make TypeScript happy: it doesn't know that `act` will synchronously and reliably initialize the `result` value.