### PR TITLE
Fixing disabled TextInput keyPress  event in fireEvent

### DIFF
--- a/src/__tests__/fireEvent.test.tsx
+++ b/src/__tests__/fireEvent.test.tsx
@@ -274,6 +274,52 @@ test('should not fire on non-editable TextInput with nested Text', () => {
   expect(onChangeTextMock).not.toHaveBeenCalled();
 });
 
+test('Should fire keyPress on non-editable TextInput', () => {
+  const placeholder = 'Test placeholder';
+  const onKeyPressMock = jest.fn();
+  const KEY_PRESS_EVENT = {
+    nativeEvent: {
+      key:'1',
+    }
+  };
+
+  const { getByPlaceholderText } = render(
+    <View>
+      <TextInput
+        editable={false}
+        placeholder={placeholder}
+        onKeyPress={onKeyPressMock}
+      />
+    </View>
+  );
+
+  fireEvent(getByPlaceholderText(placeholder), 'keyPress', KEY_PRESS_EVENT);
+  expect(onKeyPressMock).toHaveBeenCalled();
+});
+
+test('Should fire keyPress on editable TextInput', () => {
+  const placeholder = 'Test placeholder';
+  const onKeyPressMock = jest.fn();
+  const KEY_PRESS_EVENT = {
+    nativeEvent: {
+      key:'1',
+    }
+  };
+
+  const { getByPlaceholderText } = render(
+    <View>
+      <TextInput
+        editable={true}
+        placeholder={placeholder}
+        onKeyPress={onKeyPressMock}
+      />
+    </View>
+  );
+
+  fireEvent(getByPlaceholderText(placeholder), 'keyPress', KEY_PRESS_EVENT);
+  expect(onKeyPressMock).toHaveBeenCalled();
+});
+
 test('should not fire on none pointerEvents View', () => {
   const handlePress = jest.fn();
 

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -55,7 +55,8 @@ const isEventEnabled = (
   touchResponder?: ReactTestInstance,
   eventName?: string
 ) => {
-  if (isTextInput(element)) return element?.props.editable !== false;
+  const isTextInputChangeTextEvent = isTextInput(element) && eventName === 'changeText'
+  if (isTextInputChangeTextEvent) return element?.props.editable !== false;
   if (!isPointerEventEnabled(element) && isTouchEvent(eventName)) return false;
 
   const touchStart = touchResponder?.props.onStartShouldSetResponder?.();


### PR DESCRIPTION
### Summary

When trying to use `fireEvent(element, 'keyPress', event)` for a TextInput element that has been set to the disabled state the firing of the event ignored if the element was a TextInput that had been disabled. This check makes sense for onChangeText events, but it doesn't make sense for onKeyPress events because the developer might choose to do direct handling of the input state through key presses while disabling the default change text behavior of the input.

### Test plan

Added 2 new test cases for TextInput keyPress events: 
1. Text input is editable
2. TextInput is disabled
