### PR TITLE
Fix broken link in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ The core team works directly on GitHub and all work is public.
 
 ### Development workflow
 
-> **Working on your first pull request?** You can learn how from this _free_ series: [How to Contribute to an Open Source Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github).
+> **Working on your first pull request?** You can learn how from this _free_ series: [How to Contribute to an Open Source Project on GitHub](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github).
 
 1. Fork the repo and create your branch from `main` (a guide on [how to fork a repository](https://help.github.com/articles/fork-a-repo/)).
 2. Run `yarn` to setup the development environment.


### PR DESCRIPTION
This just fixes a broken link in the contributing guide.

Before: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
After: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github