### PR TITLE
fix: non-editable wrapped TextInput events

### DIFF
--- a/src/__tests__/fireEvent-textInput.test.tsx
+++ b/src/__tests__/fireEvent-textInput.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { Text, TextInput, TextInputProps } from 'react-native';
+import { render, fireEvent } from '..';
+
+function WrappedTextInput(props: TextInputProps) {
+  return <TextInput {...props} />;
+}
+
+function DoubleWrappedTextInput(props: TextInputProps) {
+  return <WrappedTextInput {...props} />;
+}
+
+const layoutEvent = { nativeEvent: { layout: { width: 100, height: 100 } } };
+
+test('should fire only non-touch-related events on non-editable TextInput', () => {
+  const onFocus = jest.fn();
+  const onChangeText = jest.fn();
+  const onSubmitEditing = jest.fn();
+  const onLayout = jest.fn();
+
+  const view = render(
+    <TextInput
+      editable={false}
+      testID="subject"
+      onFocus={onFocus}
+      onChangeText={onChangeText}
+      onSubmitEditing={onSubmitEditing}
+      onLayout={onLayout}
+    />
+  );
+
+  const subject = view.getByTestId('subject');
+  fireEvent(subject, 'focus');
+  fireEvent.changeText(subject, 'Text');
+  fireEvent(subject, 'submitEditing', { nativeEvent: { text: 'Text' } });
+  fireEvent(subject, 'layout', layoutEvent);
+
+  expect(onFocus).not.toHaveBeenCalled();
+  expect(onChangeText).not.toHaveBeenCalled();
+  expect(onSubmitEditing).not.toHaveBeenCalled();
+  expect(onLayout).toHaveBeenCalledWith(layoutEvent);
+});
+
+test('should fire only non-touch-related events on non-editable TextInput with nested Text', () => {
+  const onFocus = jest.fn();
+  const onChangeText = jest.fn();
+  const onSubmitEditing = jest.fn();
+  const onLayout = jest.fn();
+
+  const view = render(
+    <TextInput
+      editable={false}
+      testID="subject"
+      onFocus={onFocus}
+      onChangeText={onChangeText}
+      onSubmitEditing={onSubmitEditing}
+      onLayout={onLayout}
+    >
+      <Text>Nested Text</Text>
+    </TextInput>
+  );
+
+  const subject = view.getByText('Nested Text');
+  fireEvent(subject, 'focus');
+  fireEvent.changeText(subject, 'Text');
+  fireEvent(subject, 'submitEditing', { nativeEvent: { text: 'Text' } });
+  fireEvent(subject, 'layout', layoutEvent);
+
+  expect(onFocus).not.toHaveBeenCalled();
+  expect(onChangeText).not.toHaveBeenCalled();
+  expect(onSubmitEditing).not.toHaveBeenCalled();
+  expect(onLayout).toHaveBeenCalledWith(layoutEvent);
+});
+
+test('should fire only non-touch-related events on non-editable wrapped TextInput', () => {
+  const onFocus = jest.fn();
+  const onChangeText = jest.fn();
+  const onSubmitEditing = jest.fn();
+  const onLayout = jest.fn();
+
+  const view = render(
+    <WrappedTextInput
+      editable={false}
+      testID="subject"
+      onFocus={onFocus}
+      onChangeText={onChangeText}
+      onSubmitEditing={onSubmitEditing}
+      onLayout={onLayout}
+    />
+  );
+
+  const subject = view.getByTestId('subject');
+  fireEvent(subject, 'focus');
+  fireEvent.changeText(subject, 'Text');
+  fireEvent(subject, 'submitEditing', { nativeEvent: { text: 'Text' } });
+  fireEvent(subject, 'layout', layoutEvent);
+
+  expect(onFocus).not.toHaveBeenCalled();
+  expect(onChangeText).not.toHaveBeenCalled();
+  expect(onSubmitEditing).not.toHaveBeenCalled();
+  expect(onLayout).toHaveBeenCalledWith(layoutEvent);
+});
+
+test('should fire only non-touch-related events on non-editable double wrapped TextInput', () => {
+  const onFocus = jest.fn();
+  const onChangeText = jest.fn();
+  const onSubmitEditing = jest.fn();
+  const onLayout = jest.fn();
+
+  const view = render(
+    <DoubleWrappedTextInput
+      editable={false}
+      testID="subject"
+      onFocus={onFocus}
+      onChangeText={onChangeText}
+      onSubmitEditing={onSubmitEditing}
+      onLayout={onLayout}
+    />
+  );
+
+  const subject = view.getByTestId('subject');
+  fireEvent(subject, 'focus');
+  fireEvent.changeText(subject, 'Text');
+  fireEvent(subject, 'submitEditing', { nativeEvent: { text: 'Text' } });
+  fireEvent(subject, 'layout', layoutEvent);
+
+  expect(onFocus).not.toHaveBeenCalled();
+  expect(onChangeText).not.toHaveBeenCalled();
+  expect(onSubmitEditing).not.toHaveBeenCalled();
+  expect(onLayout).toHaveBeenCalledWith(layoutEvent);
+});

--- a/src/__tests__/fireEvent-textInput.test.tsx
+++ b/src/__tests__/fireEvent-textInput.test.tsx
@@ -72,6 +72,22 @@ test('should fire only non-touch-related events on non-editable TextInput with n
   expect(onLayout).toHaveBeenCalledWith(layoutEvent);
 });
 
+/**
+ * Historically there were problems with custom TextInput wrappers, as they
+ * could creat a hierarchy of three or more text input views with very similar
+ * event props.
+ *
+ * Typical hierarchy would be:
+ * - User composite TextInput
+ * - UI library composite TextInput
+ * - RN composite TextInput
+ * - RN host TextInput
+ *
+ * Previous implementation of fireEvent only checked `editable` prop for
+ * RN TextInputs, both host & composite but did not check on the UI library or
+ * user composite TextInput level, hence invoking the event handlers that
+ * should be blocked by `editable={false}` prop.
+ */
 test('should fire only non-touch-related events on non-editable wrapped TextInput', () => {
   const onFocus = jest.fn();
   const onChangeText = jest.fn();
@@ -101,6 +117,9 @@ test('should fire only non-touch-related events on non-editable wrapped TextInpu
   expect(onLayout).toHaveBeenCalledWith(layoutEvent);
 });
 
+/**
+ * Ditto testing for even deeper hierarchy of TextInput wrappers.
+ */
 test('should fire only non-touch-related events on non-editable double wrapped TextInput', () => {
   const onFocus = jest.fn();
   const onChangeText = jest.fn();

--- a/src/__tests__/fireEvent-textInput.test.tsx
+++ b/src/__tests__/fireEvent-textInput.test.tsx
@@ -74,8 +74,8 @@ test('should fire only non-touch-related events on non-editable TextInput with n
 
 /**
  * Historically there were problems with custom TextInput wrappers, as they
- * could creat a hierarchy of three or more text input views with very similar
- * event props.
+ * could creat a hierarchy of three or more composite text input views with
+ * very similar event props.
  *
  * Typical hierarchy would be:
  * - User composite TextInput

--- a/src/__tests__/fireEvent.test.tsx
+++ b/src/__tests__/fireEvent.test.tsx
@@ -216,44 +216,6 @@ test('should not fire on disabled Pressable', () => {
   expect(handlePress).not.toHaveBeenCalled();
 });
 
-test('should not fire on non-editable TextInput', () => {
-  const testID = 'my-text-input';
-  const onChangeTextMock = jest.fn();
-  const NEW_TEXT = 'New text';
-
-  const { getByTestId } = render(
-    <TextInput
-      editable={false}
-      testID={testID}
-      onChangeText={onChangeTextMock}
-    />
-  );
-
-  fireEvent.changeText(getByTestId(testID), NEW_TEXT);
-  expect(onChangeTextMock).not.toHaveBeenCalled();
-});
-
-test('should not fire on non-editable TextInput with nested Text', () => {
-  const placeholder = 'Test placeholder';
-  const onChangeTextMock = jest.fn();
-  const NEW_TEXT = 'New text';
-
-  const { getByPlaceholderText } = render(
-    <View>
-      <TextInput
-        editable={false}
-        placeholder={placeholder}
-        onChangeText={onChangeTextMock}
-      >
-        <Text>Test text</Text>
-      </TextInput>
-    </View>
-  );
-
-  fireEvent.changeText(getByPlaceholderText(placeholder), NEW_TEXT);
-  expect(onChangeTextMock).not.toHaveBeenCalled();
-});
-
 test('should not fire inside View with pointerEvents="none"', () => {
   const onPress = jest.fn();
   const screen = render(

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -49,7 +49,7 @@ function isTouchEvent(eventName: string) {
 }
 
 // Experimentally checked which events are called on non-editable TextInput
-const textInputEventsNotAffectedByEditableProp = [
+const textInputEventsIgnoringEditableProp = [
   'contentSizeChange',
   'layout',
   'scroll',
@@ -63,7 +63,7 @@ function isEventEnabled(
   if (isHostTextInput(nearestTouchResponder)) {
     return (
       nearestTouchResponder?.props.editable !== false ||
-      textInputEventsNotAffectedByEditableProp.includes(eventName)
+      textInputEventsIgnoringEditableProp.includes(eventName)
     );
   }
 

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -1,22 +1,13 @@
 import { ReactTestInstance } from 'react-test-renderer';
-import { TextInput } from 'react-native';
 import act from './act';
 import { getHostParent, isHostElement } from './helpers/component-tree';
-import { filterNodeByType } from './helpers/filterNodeByType';
 import { getHostComponentNames } from './helpers/host-component-names';
 
 type EventHandler = (...args: unknown[]) => unknown;
 
-function isTextInput(element: ReactTestInstance) {
-  // We have to test if the element type is either the `TextInput` component
-  // (for composite component) or the string "TextInput" (for host component)
-  // All queries return host components but since fireEvent bubbles up
-  // it would trigger the parent prop without the composite component check.
-  return (
-    filterNodeByType(element, TextInput) ||
-    filterNodeByType(element, getHostComponentNames().textInput)
-  );
-}
+const isHostTextInput = (element?: ReactTestInstance) => {
+  return element?.type === getHostComponentNames().textInput;
+};
 
 function isTouchResponder(element: ReactTestInstance) {
   if (!isHostElement(element)) {
@@ -24,7 +15,7 @@ function isTouchResponder(element: ReactTestInstance) {
   }
 
   return (
-    Boolean(element.props.onStartShouldSetResponder) || isTextInput(element)
+    Boolean(element.props.onStartShouldSetResponder) || isHostTextInput(element)
   );
 }
 
@@ -57,13 +48,23 @@ function isTouchEvent(eventName: string) {
   return touchEventNames.includes(eventName);
 }
 
+// Experimentally checked which events are called on non-editable TextInput
+const textInputEventsNotAffectedByEditableProp = [
+  'contentSizeChange',
+  'layout',
+  'scroll',
+];
+
 function isEventEnabled(
   element: ReactTestInstance,
   eventName: string,
   nearestTouchResponder?: ReactTestInstance
 ) {
-  if (isTextInput(element)) {
-    return element.props.editable !== false;
+  if (isHostTextInput(nearestTouchResponder)) {
+    return (
+      nearestTouchResponder?.props.editable !== false ||
+      textInputEventsNotAffectedByEditableProp.includes(eventName)
+    );
   }
 
   if (isTouchEvent(eventName) && !isPointerEventEnabled(element)) {


### PR DESCRIPTION
### Summary

[Description by @mdjastrzebski]
This PR modifies the `fireEvent` handling for `TextInputs` by checking the `editable` prop status of the nearest touch responder of given element. The nearest touch responder is the nearest descendant element that is both host element as well as advertises as touch responder. One such element is `TextInput`.

The previous version of the code, checked the `editable` prop status on the element itself, which could lead to situations when `TextInput` wrappers would execute events, e.g. `changeText`, `focus`, etc on non-editable `TextInput`, because the check has been limited to host `TextInput` and wrapping it composite `TextInput` coming from RN package. Any additional `TextInput` wrapper would not have it's `editable` prop checked and would refer to host `TextInput` `editable` prop.

During experiments conducted on iOS and Android, I've discovered that most of the events are blocked by `editable={false}` prop, but some events like `layout`, `contentSizeChange`, etc are being called anyway. This PR includes special exclusion for such events.

Fixes #1384
Fixes #1261 

### Test plan
Green tests