### PR TITLE
fix: "Edit this Page" link in docs results in 404

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -95,7 +95,7 @@ const siteConfig = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // Please change this to your repo.
-          editUrl: `${repoUrl}/blob/main`,
+          editUrl: `${repoUrl}/blob/main/website`,
           sidebarCollapsible: false,
         },
         blog: {


### PR DESCRIPTION

### Summary

The documentation contains a link at the bottom of each page: "Edit this page". The link was resulting in a 404 because Docusaurus was not configured with the proper path.

* Before (404): https://github.com/callstack/react-native-testing-library/blob/main/docs/FAQ.md (as seen from [this page](https://callstack.github.io/react-native-testing-library/docs/faq))
* After: https://github.com/callstack/react-native-testing-library/blob/main/website/docs/FAQ.md

### Test plan

I built the documentation, per the readme, and verified the link now works.