### PR TITLE
refactor: remove stale tests

### DIFF
--- a/src/__tests__/fireEvent.test.tsx
+++ b/src/__tests__/fireEvent.test.tsx
@@ -217,25 +217,6 @@ test('should not fire on disabled Pressable', () => {
 });
 
 test('should not fire on non-editable TextInput', () => {
-  const placeholder = 'Test placeholder';
-  const onChangeTextMock = jest.fn();
-  const NEW_TEXT = 'New text';
-
-  const { getByPlaceholderText } = render(
-    <View>
-      <TextInput
-        editable={false}
-        placeholder={placeholder}
-        onChangeText={onChangeTextMock}
-      />
-    </View>
-  );
-
-  fireEvent.changeText(getByPlaceholderText(placeholder), NEW_TEXT);
-  expect(onChangeTextMock).not.toHaveBeenCalled();
-});
-
-test('should not fire on non-editable host TextInput', () => {
   const testID = 'my-text-input';
   const onChangeTextMock = jest.fn();
   const NEW_TEXT = 'New text';
@@ -245,7 +226,6 @@ test('should not fire on non-editable host TextInput', () => {
       editable={false}
       testID={testID}
       onChangeText={onChangeTextMock}
-      placeholder="placeholder"
     />
   );
 

--- a/src/__tests__/react-native-api.test.tsx
+++ b/src/__tests__/react-native-api.test.tsx
@@ -10,8 +10,6 @@ import { getHostSelf } from '../helpers/component-tree';
 
 test('React Native API assumption: <View> renders single host element', () => {
   const view = render(<View testID="test" />);
-  const hostView = view.getByTestId('test');
-  expect(getHostSelf(hostView)).toBe(hostView);
 
   expect(view.toJSON()).toMatchInlineSnapshot(`
     <View
@@ -22,9 +20,7 @@ test('React Native API assumption: <View> renders single host element', () => {
 
 test('React Native API assumption: <Text> renders single host element', () => {
   const view = render(<Text testID="test">Hello</Text>);
-  const compositeView = view.getByText('Hello');
-  const hostView = view.getByTestId('test');
-  expect(getHostSelf(compositeView)).toBe(hostView);
+  expect(view.getByText('Hello')).toBe(view.getByTestId('test'));
 
   expect(view.toJSON()).toMatchInlineSnapshot(`
     <Text
@@ -45,11 +41,9 @@ test('React Native API assumption: nested <Text> renders single host element', (
       </Text>
     </Text>
   );
-  expect(getHostSelf(view.getByText(/Hello/))).toBe(view.getByTestId('test'));
-  expect(getHostSelf(view.getByText('Before'))).toBe(
-    view.getByTestId('before')
-  );
-  expect(getHostSelf(view.getByText('Deeply nested'))).toBe(
+  expect(view.getByText(/Hello/)).toBe(view.getByTestId('test'));
+  expect(view.getByText('Before')).toBe(view.getByTestId('before'));
+  expect(view.getByText('Deeply nested')).toBe(
     view.getByTestId('deeplyNested')
   );
 
@@ -85,9 +79,9 @@ test('React Native API assumption: <TextInput> renders single host element', () 
       placeholder="Placeholder"
     />
   );
-  const compositeView = view.getByPlaceholderText('Placeholder');
-  const hostView = view.getByTestId('test');
-  expect(getHostSelf(compositeView)).toBe(hostView);
+  expect(view.getByPlaceholderText('Placeholder')).toBe(
+    view.getByTestId('test')
+  );
 
   expect(view.toJSON()).toMatchInlineSnapshot(`
     <TextInput

--- a/src/__tests__/within.test.tsx
+++ b/src/__tests__/within.test.tsx
@@ -94,11 +94,3 @@ test('within() exposes a11y queries', async () => {
 test('getQueriesForElement is alias to within', () => {
   expect(getQueriesForElement).toBe(within);
 });
-
-test('within allows searching for text within a composite component', () => {
-  const view = render(<Text testID="subject">Hello</Text>);
-  // view.getByTestId('subject') returns a host component, contrary to text queries returning a composite component
-  // we want to be sure that this doesn't interfere with the way text is searched
-  const hostTextQueries = within(view.getByTestId('subject'));
-  expect(hostTextQueries.getByText('Hello')).toBeTruthy();
-});

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -12,9 +12,8 @@ const isTextInput = (element?: ReactTestInstance) => {
     return false;
   }
 
-  // We have to test if the element type is either the TextInput component
-  // (which would if it is a composite component) or the string
-  // TextInput (which would be true if it is a host component)
+  // We have to test if the element type is either the `TextInput` component
+  // (for composite component) or the string "TextInput" (for host component)
   // All queries return host components but since fireEvent bubbles up
   // it would trigger the parent prop without the composite component check
   return (

--- a/src/helpers/__tests__/component-tree.test.tsx
+++ b/src/helpers/__tests__/component-tree.test.tsx
@@ -142,17 +142,13 @@ describe('getHostSelf()', () => {
       </View>
     );
 
-    const compositeText = view.getByText('Text');
+    const compositeText = view.UNSAFE_getByType(Text);
     const hostText = view.getByTestId('text');
     expect(getHostSelf(compositeText)).toEqual(hostText);
 
-    const compositeTextInputByValue = view.getByDisplayValue('TextInputValue');
-    const compositeTextInputByPlaceholder = view.getByPlaceholderText(
-      'TextInputPlaceholder'
-    );
+    const compositeTextInput = view.UNSAFE_getByType(TextInput);
     const hostTextInput = view.getByTestId('textInput');
-    expect(getHostSelf(compositeTextInputByValue)).toEqual(hostTextInput);
-    expect(getHostSelf(compositeTextInputByPlaceholder)).toEqual(hostTextInput);
+    expect(getHostSelf(compositeTextInput)).toEqual(hostTextInput);
   });
 
   it('throws on non-single host children elements for custom composite components', () => {


### PR DESCRIPTION
### Summary

Remove or refactor tests that relied on some queries (`*ByText`, `*ByPlaceholder`, `*ByDisplayValue`) returning composite components. Currently are safe queries return host components.

### Test plan

N/A