### PR TITLE
fix: proper stack trace for findBy* and findAllBy* queries

### DIFF
--- a/src/queries/makeQueries.ts
+++ b/src/queries/makeQueries.ts
@@ -192,6 +192,10 @@ export function makeQueries<Predicate, Options>(
         ...waitForOptions
       }: WaitForOptions = {}
     ) {
+      const stackTraceError = new ErrorWithStack(
+        'STACK_TRACE_ERROR',
+        findAllFn
+      );
       const deprecatedWaitForOptions =
         extractDeprecatedWaitForOptions(queryOptions);
 
@@ -204,6 +208,7 @@ export function makeQueries<Predicate, Options>(
         {
           ...deprecatedWaitForOptions,
           ...waitForOptions,
+          stackTraceError,
           onTimeout,
         }
       );
@@ -219,6 +224,8 @@ export function makeQueries<Predicate, Options>(
         ...waitForOptions
       }: WaitForOptions = {}
     ) {
+      const stackTraceError = new ErrorWithStack('STACK_TRACE_ERROR', findFn);
+      console.log('FindByQuery', stackTraceError.stack);
       const deprecatedWaitForOptions =
         extractDeprecatedWaitForOptions(queryOptions);
 
@@ -231,6 +238,7 @@ export function makeQueries<Predicate, Options>(
         {
           ...deprecatedWaitForOptions,
           ...waitForOptions,
+          stackTraceError,
           onTimeout,
         }
       );

--- a/src/queries/makeQueries.ts
+++ b/src/queries/makeQueries.ts
@@ -225,7 +225,6 @@ export function makeQueries<Predicate, Options>(
       }: WaitForOptions = {}
     ) {
       const stackTraceError = new ErrorWithStack('STACK_TRACE_ERROR', findFn);
-      console.log('FindByQuery', stackTraceError.stack);
       const deprecatedWaitForOptions =
         extractDeprecatedWaitForOptions(queryOptions);
 


### PR DESCRIPTION
### Summary

`findBy*` and `findAllBy*` queries reported `waitFor` stack trace callsite instead of their own. This fixes it.

Before:
<img width="644" alt="image" src="https://user-images.githubusercontent.com/6368606/234819155-a1deb90c-0493-4941-8302-2330061c5717.png">
<img width="657" alt="image" src="https://user-images.githubusercontent.com/6368606/234819872-de2c6a78-bf82-412a-a580-70b176021a5f.png">

After:
<img width="644" alt="image" src="https://user-images.githubusercontent.com/6368606/234819022-7bfa00dd-b9a9-4b10-8654-bf845237ce90.png">
<img width="657" alt="image" src="https://user-images.githubusercontent.com/6368606/234820030-e688224d-a309-4263-bbe7-95b88e5b57f8.png">

### Test plan

Manually run a `findBy*` and `findAllBy*` test to view the stacktrace reported by Jest.