### PR TITLE
Add config example for pnpm

### DIFF
--- a/website/docs/ReactNavigation.md
+++ b/website/docs/ReactNavigation.md
@@ -140,6 +140,8 @@ module.exports = {
   setupFiles: ['./node_modules/react-native-gesture-handler/jestSetup.js'],
   transformIgnorePatterns: [
     'node_modules/(?!(jest-)?@?react-native|@react-native-community|@react-navigation)',
+    // In case you are using pnpm as package manager, use this:
+    // 'node_modules/(?!(?:.pnpm/)?((jest-)?@?react-native|@react-native-community|@react-navigation))',
   ],
 };
 ```


### PR DESCRIPTION


<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

When using `pnpm` as a package manager, `transformIgnorePatterns` should point to packages in the `.pnpm` folder. [Source](https://jestjs.io/docs/configuration#transformignorepatterns-arraystring). 

It took me some time to figure this out. I thought an example in the docs could help others who run into the same problem.


