### PR TITLE
refactor: `fireEvent` cleanup

### DIFF
--- a/src/__tests__/fireEvent.test.tsx
+++ b/src/__tests__/fireEvent.test.tsx
@@ -265,6 +265,7 @@ test('should not fire inside View with pointerEvents="none"', () => {
   );
 
   fireEvent.press(screen.getByText('Trigger'));
+  fireEvent(screen.getByText('Trigger'), 'onPress');
   expect(onPress).not.toHaveBeenCalled();
 });
 
@@ -279,6 +280,7 @@ test('should not fire inside View with pointerEvents="box-only"', () => {
   );
 
   fireEvent.press(screen.getByText('Trigger'));
+  fireEvent(screen.getByText('Trigger'), 'onPress');
   expect(onPress).not.toHaveBeenCalled();
 });
 
@@ -293,7 +295,8 @@ test('should fire inside View with pointerEvents="box-none"', () => {
   );
 
   fireEvent.press(screen.getByText('Trigger'));
-  expect(onPress).toHaveBeenCalled();
+  fireEvent(screen.getByText('Trigger'), 'onPress');
+  expect(onPress).toHaveBeenCalledTimes(2);
 });
 
 test('should fire inside View with pointerEvents="auto"', () => {
@@ -307,7 +310,8 @@ test('should fire inside View with pointerEvents="auto"', () => {
   );
 
   fireEvent.press(screen.getByText('Trigger'));
-  expect(onPress).toHaveBeenCalled();
+  fireEvent(screen.getByText('Trigger'), 'onPress');
+  expect(onPress).toHaveBeenCalledTimes(2);
 });
 
 test('should not fire deeply inside View with pointerEvents="box-only"', () => {
@@ -323,6 +327,7 @@ test('should not fire deeply inside View with pointerEvents="box-only"', () => {
   );
 
   fireEvent.press(screen.getByText('Trigger'));
+  fireEvent(screen.getByText('Trigger'), 'onPress');
   expect(onPress).not.toHaveBeenCalled();
 });
 

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -93,7 +93,7 @@ const getEventHandler = (
   element: ReactTestInstance,
   eventName: string
 ): EventHandler | undefined => {
-  const eventHandlerName = toEventHandlerName(eventName);
+  const eventHandlerName = getEventHandlerName(eventName);
   if (typeof element.props[eventHandlerName] === 'function') {
     return element.props[eventHandlerName];
   }
@@ -105,19 +105,20 @@ const getEventHandler = (
   return undefined;
 };
 
-const invokeEvent = (
+const getEventHandlerName = (eventName: string) =>
+  `on${eventName.charAt(0).toUpperCase()}${eventName.slice(1)}`;
+
+const fireEvent = (
   element: ReactTestInstance,
   eventName: string,
   ...data: Array<any>
 ) => {
   const handler = findEventHandler(element, eventName);
-
   if (!handler) {
     return;
   }
 
   let returnValue;
-
   act(() => {
     returnValue = handler(...data);
   });
@@ -125,26 +126,15 @@ const invokeEvent = (
   return returnValue;
 };
 
-const toEventHandlerName = (eventName: string) =>
-  `on${eventName.charAt(0).toUpperCase()}${eventName.slice(1)}`;
+fireEvent.press = (element: ReactTestInstance, ...data: Array<any>): void =>
+  fireEvent(element, 'press', ...data);
 
-const pressHandler = (element: ReactTestInstance, ...data: Array<any>): void =>
-  invokeEvent(element, 'press', ...data);
-const changeTextHandler = (
+fireEvent.changeText = (
   element: ReactTestInstance,
   ...data: Array<any>
-): void => invokeEvent(element, 'changeText', ...data);
-const scrollHandler = (element: ReactTestInstance, ...data: Array<any>): void =>
-  invokeEvent(element, 'scroll', ...data);
+): void => fireEvent(element, 'changeText', ...data);
 
-const fireEvent = (
-  element: ReactTestInstance,
-  eventName: string,
-  ...data: Array<any>
-): void => invokeEvent(element, eventName, ...data);
-
-fireEvent.press = pressHandler;
-fireEvent.changeText = changeTextHandler;
-fireEvent.scroll = scrollHandler;
+fireEvent.scroll = (element: ReactTestInstance, ...data: Array<any>): void =>
+  fireEvent(element, 'scroll', ...data);
 
 export default fireEvent;

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -7,7 +7,7 @@ import { getHostComponentNames } from './helpers/host-component-names';
 
 type EventHandler = (...args: any) => unknown;
 
-function isTextInput(element?: ReactTestInstance) {
+function isTextInput(element: ReactTestInstance) {
   if (!element) {
     return false;
   }
@@ -22,10 +22,12 @@ function isTextInput(element?: ReactTestInstance) {
   );
 }
 
-function isTouchResponder(element?: ReactTestInstance) {
-  if (!isHostElement(element)) return false;
+function isTouchResponder(element: ReactTestInstance) {
+  if (!isHostElement(element)) {
+    return false;
+  }
 
-  return !!element?.props.onStartShouldSetResponder || isTextInput(element);
+  return !!element.props.onStartShouldSetResponder || isTextInput(element);
 }
 
 function isPointerEventEnabled(

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -8,10 +8,6 @@ import { getHostComponentNames } from './helpers/host-component-names';
 type EventHandler = (...args: any) => unknown;
 
 function isTextInput(element: ReactTestInstance) {
-  if (!element) {
-    return false;
-  }
-
   // We have to test if the element type is either the `TextInput` component
   // (for composite component) or the string "TextInput" (for host component)
   // All queries return host components but since fireEvent bubbles up

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -64,8 +64,13 @@ function isEventEnabled(
   eventName: string,
   nearestTouchResponder?: ReactTestInstance
 ) {
-  if (isTextInput(element)) return element?.props.editable !== false;
-  if (!isPointerEventEnabled(element) && isTouchEvent(eventName)) return false;
+  if (isTextInput(element)) {
+    return element.props.editable !== false;
+  }
+
+  if (isTouchEvent(eventName) && !isPointerEventEnabled(element)) {
+    return false;
+  }
 
   const touchStart = nearestTouchResponder?.props.onStartShouldSetResponder?.();
   const touchMove = nearestTouchResponder?.props.onMoveShouldSetResponder?.();

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -23,7 +23,9 @@ function isTouchResponder(element: ReactTestInstance) {
     return false;
   }
 
-  return !!element.props.onStartShouldSetResponder || isTextInput(element);
+  return (
+    Boolean(element.props.onStartShouldSetResponder) || isTextInput(element)
+  );
 }
 
 function isPointerEventEnabled(

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -55,16 +55,17 @@ function isTouchEvent(eventName?: string) {
 
 function isEventEnabled(
   element: ReactTestInstance,
-  touchResponder?: ReactTestInstance,
-  eventName?: string
+  eventName: string,
+  nearestTouchResponder?: ReactTestInstance
 ) {
   if (isTextInput(element)) return element?.props.editable !== false;
   if (!isPointerEventEnabled(element) && isTouchEvent(eventName)) return false;
 
-  const touchStart = touchResponder?.props.onStartShouldSetResponder?.();
-  const touchMove = touchResponder?.props.onMoveShouldSetResponder?.();
-
-  if (touchStart || touchMove) return true;
+  const touchStart = nearestTouchResponder?.props.onStartShouldSetResponder?.();
+  const touchMove = nearestTouchResponder?.props.onMoveShouldSetResponder?.();
+  if (touchStart || touchMove) {
+    return true;
+  }
 
   return touchStart === undefined && touchMove === undefined;
 }
@@ -79,7 +80,7 @@ function findEventHandler(
     : nearestTouchResponder;
 
   const handler = getEventHandler(element, eventName);
-  if (handler && isEventEnabled(element, touchResponder, eventName))
+  if (handler && isEventEnabled(element, eventName, touchResponder))
     return handler;
 
   if (element.parent === null || element.parent.parent === null) {
@@ -109,7 +110,7 @@ function getEventHandlerName(eventName: string) {
 function fireEvent(
   element: ReactTestInstance,
   eventName: string,
-  ...data: Array<any>
+  ...data: unknown[]
 ) {
   const handler = findEventHandler(element, eventName);
   if (!handler) {
@@ -124,15 +125,13 @@ function fireEvent(
   return returnValue;
 }
 
-fireEvent.press = (element: ReactTestInstance, ...data: Array<any>): void =>
+fireEvent.press = (element: ReactTestInstance, ...data: unknown[]) =>
   fireEvent(element, 'press', ...data);
 
-fireEvent.changeText = (
-  element: ReactTestInstance,
-  ...data: Array<any>
-): void => fireEvent(element, 'changeText', ...data);
+fireEvent.changeText = (element: ReactTestInstance, ...data: unknown[]) =>
+  fireEvent(element, 'changeText', ...data);
 
-fireEvent.scroll = (element: ReactTestInstance, ...data: Array<any>): void =>
+fireEvent.scroll = (element: ReactTestInstance, ...data: unknown[]) =>
   fireEvent(element, 'scroll', ...data);
 
 export default fireEvent;

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -72,7 +72,6 @@ const isEventEnabled = (
 const findEventHandler = (
   element: ReactTestInstance,
   eventName: string,
-  callsite?: any,
   nearestTouchResponder?: ReactTestInstance
 ): EventHandler | null => {
   const touchResponder = isTouchResponder(element)
@@ -87,7 +86,7 @@ const findEventHandler = (
     return null;
   }
 
-  return findEventHandler(element.parent, eventName, callsite, touchResponder);
+  return findEventHandler(element.parent, eventName, touchResponder);
 };
 
 const getEventHandler = (
@@ -109,10 +108,9 @@ const getEventHandler = (
 const invokeEvent = (
   element: ReactTestInstance,
   eventName: string,
-  callsite?: any,
   ...data: Array<any>
 ) => {
-  const handler = findEventHandler(element, eventName, callsite);
+  const handler = findEventHandler(element, eventName);
 
   if (!handler) {
     return;
@@ -131,19 +129,19 @@ const toEventHandlerName = (eventName: string) =>
   `on${eventName.charAt(0).toUpperCase()}${eventName.slice(1)}`;
 
 const pressHandler = (element: ReactTestInstance, ...data: Array<any>): void =>
-  invokeEvent(element, 'press', pressHandler, ...data);
+  invokeEvent(element, 'press', ...data);
 const changeTextHandler = (
   element: ReactTestInstance,
   ...data: Array<any>
-): void => invokeEvent(element, 'changeText', changeTextHandler, ...data);
+): void => invokeEvent(element, 'changeText', ...data);
 const scrollHandler = (element: ReactTestInstance, ...data: Array<any>): void =>
-  invokeEvent(element, 'scroll', scrollHandler, ...data);
+  invokeEvent(element, 'scroll', ...data);
 
 const fireEvent = (
   element: ReactTestInstance,
   eventName: string,
   ...data: Array<any>
-): void => invokeEvent(element, eventName, fireEvent, ...data);
+): void => invokeEvent(element, eventName, ...data);
 
 fireEvent.press = pressHandler;
 fireEvent.changeText = changeTextHandler;

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -49,8 +49,12 @@ function isPointerEventEnabled(
   return isPointerEventEnabled(parent, true);
 }
 
-function isTouchEvent(eventName?: string) {
-  return eventName === 'press';
+// Due to accepting both `press` and `onPress` for event names, we need to
+// cover both forms.
+const touchEventNames = ['press', 'onPress'];
+
+function isTouchEvent(eventName: string) {
+  return touchEventNames.includes(eventName);
 }
 
 function isEventEnabled(

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -7,7 +7,7 @@ import { getHostComponentNames } from './helpers/host-component-names';
 
 type EventHandler = (...args: any) => unknown;
 
-const isTextInput = (element?: ReactTestInstance) => {
+function isTextInput(element?: ReactTestInstance) {
   if (!element) {
     return false;
   }
@@ -20,18 +20,18 @@ const isTextInput = (element?: ReactTestInstance) => {
     filterNodeByType(element, TextInput) ||
     filterNodeByType(element, getHostComponentNames().textInput)
   );
-};
+}
 
-const isTouchResponder = (element?: ReactTestInstance) => {
+function isTouchResponder(element?: ReactTestInstance) {
   if (!isHostElement(element)) return false;
 
   return !!element?.props.onStartShouldSetResponder || isTextInput(element);
-};
+}
 
-const isPointerEventEnabled = (
+function isPointerEventEnabled(
   element: ReactTestInstance,
   isParent?: boolean
-): boolean => {
+): boolean {
   const pointerEvents = element.props.pointerEvents;
   if (pointerEvents === 'none') {
     return false;
@@ -47,17 +47,17 @@ const isPointerEventEnabled = (
   }
 
   return isPointerEventEnabled(parent, true);
-};
+}
 
-const isTouchEvent = (eventName?: string) => {
+function isTouchEvent(eventName?: string) {
   return eventName === 'press';
-};
+}
 
-const isEventEnabled = (
+function isEventEnabled(
   element: ReactTestInstance,
   touchResponder?: ReactTestInstance,
   eventName?: string
-) => {
+) {
   if (isTextInput(element)) return element?.props.editable !== false;
   if (!isPointerEventEnabled(element) && isTouchEvent(eventName)) return false;
 
@@ -67,13 +67,13 @@ const isEventEnabled = (
   if (touchStart || touchMove) return true;
 
   return touchStart === undefined && touchMove === undefined;
-};
+}
 
-const findEventHandler = (
+function findEventHandler(
   element: ReactTestInstance,
   eventName: string,
   nearestTouchResponder?: ReactTestInstance
-): EventHandler | null => {
+): EventHandler | null {
   const touchResponder = isTouchResponder(element)
     ? element
     : nearestTouchResponder;
@@ -87,12 +87,9 @@ const findEventHandler = (
   }
 
   return findEventHandler(element.parent, eventName, touchResponder);
-};
+}
 
-const getEventHandler = (
-  element: ReactTestInstance,
-  eventName: string
-): EventHandler | undefined => {
+function getEventHandler(element: ReactTestInstance, eventName: string) {
   const eventHandlerName = getEventHandlerName(eventName);
   if (typeof element.props[eventHandlerName] === 'function') {
     return element.props[eventHandlerName];
@@ -103,16 +100,17 @@ const getEventHandler = (
   }
 
   return undefined;
-};
+}
 
-const getEventHandlerName = (eventName: string) =>
-  `on${eventName.charAt(0).toUpperCase()}${eventName.slice(1)}`;
+function getEventHandlerName(eventName: string) {
+  return `on${eventName.charAt(0).toUpperCase()}${eventName.slice(1)}`;
+}
 
-const fireEvent = (
+function fireEvent(
   element: ReactTestInstance,
   eventName: string,
   ...data: Array<any>
-) => {
+) {
   const handler = findEventHandler(element, eventName);
   if (!handler) {
     return;
@@ -124,7 +122,7 @@ const fireEvent = (
   });
 
   return returnValue;
-};
+}
 
 fireEvent.press = (element: ReactTestInstance, ...data: Array<any>): void =>
   fireEvent(element, 'press', ...data);

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -5,7 +5,7 @@ import { getHostParent, isHostElement } from './helpers/component-tree';
 import { filterNodeByType } from './helpers/filterNodeByType';
 import { getHostComponentNames } from './helpers/host-component-names';
 
-type EventHandler = (...args: any) => unknown;
+type EventHandler = (...args: unknown[]) => unknown;
 
 function isTextInput(element: ReactTestInstance) {
   // We have to test if the element type is either the `TextInput` component

--- a/src/helpers/component-tree.ts
+++ b/src/helpers/component-tree.ts
@@ -4,7 +4,7 @@ import { ReactTestInstance } from 'react-test-renderer';
  * Checks if the given element is a host element.
  * @param element The element to check.
  */
-export function isHostElement(element?: ReactTestInstance | null) {
+export function isHostElement(element?: ReactTestInstance | null): boolean {
   return typeof element?.type === 'string';
 }
 

--- a/src/helpers/component-tree.ts
+++ b/src/helpers/component-tree.ts
@@ -4,7 +4,7 @@ import { ReactTestInstance } from 'react-test-renderer';
  * Checks if the given element is a host element.
  * @param element The element to check.
  */
-export function isHostElement(element?: ReactTestInstance | null): boolean {
+export function isHostElement(element?: ReactTestInstance | null) {
   return typeof element?.type === 'string';
 }
 


### PR DESCRIPTION
### Summary

Scope:
- [x] cleanup `fireEvent` code before further changes
  - [x] removal of unused `callsite` argument
  - [x] simplify `fireEvent` object construction by removing `invokeEvent`
- [x] fix case when passing `onPress` event name would defeat pointer events checks for `press` event despite invoking the same handler.
- [x] improve code coverage by removing dead code paths
- [x] improve code coverage by disabling checks for deprecation functions 

### Test plan

Improved existing pointer event test by using both event forms `press` and `onPress.