### PR TITLE
fix:  support `onXxx` event name for TextInput event checks

### DIFF
--- a/src/__tests__/fireEvent-textInput.test.tsx
+++ b/src/__tests__/fireEvent-textInput.test.tsx
@@ -62,13 +62,17 @@ test('should fire only non-touch-related events on non-editable TextInput with n
 
   const subject = view.getByText('Nested Text');
   fireEvent(subject, 'focus');
+  fireEvent(subject, 'onFocus');
   fireEvent.changeText(subject, 'Text');
   fireEvent(subject, 'submitEditing', { nativeEvent: { text: 'Text' } });
+  fireEvent(subject, 'onSubmitEditing', { nativeEvent: { text: 'Text' } });
   fireEvent(subject, 'layout', layoutEvent);
+  fireEvent(subject, 'onLayout', layoutEvent);
 
   expect(onFocus).not.toHaveBeenCalled();
   expect(onChangeText).not.toHaveBeenCalled();
   expect(onSubmitEditing).not.toHaveBeenCalled();
+  expect(onLayout).toHaveBeenCalledTimes(2);
   expect(onLayout).toHaveBeenCalledWith(layoutEvent);
 });
 

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -40,20 +40,29 @@ function isPointerEventEnabled(
   return isPointerEventEnabled(parent, true);
 }
 
-// Due to accepting both `press` and `onPress` for event names, we need to
-// cover both forms.
-const touchEventNames = ['press', 'onPress'];
+/**
+ * List of events affected by `pointerEvents` prop.
+ *
+ * Note: `fireEvent` is accepting both `press` and `onPress` for event names,
+ * so we need cover both forms.
+ */
+const eventsAffectedByPointerEventsProp = new Set(['press', 'onPress']);
 
-function isTouchEvent(eventName: string) {
-  return touchEventNames.includes(eventName);
-}
-
-// Experimentally checked which events are called on non-editable TextInput
-const textInputEventsIgnoringEditableProp = [
+/**
+ * List of `TextInput` events not affected by `editable` prop.
+ *
+ * Note: `fireEvent` is accepting both `press` and `onPress` for event names,
+ * so we need cover both forms.
+ */
+const textInputEventsIgnoringEditableProp = new Set([
   'contentSizeChange',
+  'onContentSizeChange',
   'layout',
+  'layout',
+  'onLayout',
   'scroll',
-];
+  'onScroll',
+]);
 
 function isEventEnabled(
   element: ReactTestInstance,
@@ -63,11 +72,14 @@ function isEventEnabled(
   if (isHostTextInput(nearestTouchResponder)) {
     return (
       nearestTouchResponder?.props.editable !== false ||
-      textInputEventsIgnoringEditableProp.includes(eventName)
+      textInputEventsIgnoringEditableProp.has(eventName)
     );
   }
 
-  if (isTouchEvent(eventName) && !isPointerEventEnabled(element)) {
+  if (
+    eventsAffectedByPointerEventsProp.has(eventName) &&
+    !isPointerEventEnabled(element)
+  ) {
     return false;
   }
 

--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -58,7 +58,6 @@ const textInputEventsIgnoringEditableProp = new Set([
   'contentSizeChange',
   'onContentSizeChange',
   'layout',
-  'layout',
   'onLayout',
   'scroll',
   'onScroll',


### PR DESCRIPTION
### Summary

This fixed an edge case when user would use `onLayout` event handler name instead of `layout` event name with `fireEvent` and that would skip the `editable` prop check.

Additionally, refactored event array checks to use `Set` type.

### Test plan

Added test code to detect the fixed scenario.