### PR TITLE
Fix a11y typo

### DIFF
--- a/website/docs/Queries.md
+++ b/website/docs/Queries.md
@@ -22,7 +22,7 @@ title: Queries
   - [`ByHintText`, `ByA11yHint`, `ByAccessibilityHint`](#byhinttext-bya11yhint-byaccessibilityhint)
   - [`ByRole`](#byrole)
   - [`ByA11yState`, `ByAccessibilityState`](#bya11ystate-byaccessibilitystate)
-  - [`ByA11Value`, `ByAccessibilityValue`](#bya11value-byaccessibilityvalue)
+  - [`ByA11yValue`, `ByAccessibilityValue`](#bya11yvalue-byaccessibilityvalue)
 - [TextMatch](#textmatch)
   - [Examples](#examples)
   - [Precision](#precision)
@@ -207,7 +207,7 @@ render(<Component />);
 const element = screen.getByA11yState({ disabled: true });
 ```
 
-### `ByA11Value`, `ByAccessibilityValue`
+### `ByA11yValue`, `ByAccessibilityValue`
 
 > getByA11yValue, getAllByA11yValue, queryByA11yValue, queryAllByA11yValue, findByA11yValue, findAllByA11yValue
 > getByAccessibilityValue, getAllByAccessibilityValue, queryByAccessibilityValue, queryAllByAccessibilityValue, findByAccessibilityValue, findAllByAccessibilityValue


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes a typo in the docs in the name of `ByA11yValue` queries

### Test plan

Run the docs and confirm clicking the "`ByA11yValue`, `ByAccesibilityValue`" link correctly takes you to the section.
