### PR TITLE
chore: switch Codecov PR comment to default behavior

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,6 +4,6 @@ coverage:
   range: 70...100
 
 comment:
-  behavior: new
+  behavior: default
   require_changes: false
   require_base: no


### PR DESCRIPTION
### Summary

It's super annoying to get dozens of meaningless codecov notifications in my inbox every day, because of the current behavior. Switching to default to "update, if exists. Otherwise post new"

Ref: https://docs.codecov.com/docs/pull-request-comments#behavior

### Test plan

Codecov updates instead of recreating the comment
