### PR TITLE
fix: add prop to render to skip configureHostComponentNamesIfNeeded

### DIFF
--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import * as React from 'react';
 import { View, Text, TextInput, Pressable } from 'react-native';
+import { getConfig, resetToDefaults } from '../config';
 import { render, screen, fireEvent, RenderAPI } from '..';
 
 const PLACEHOLDER_FRESHNESS = 'Add custom freshness';
@@ -242,6 +243,14 @@ test('RenderAPI type', () => {
 test('returned output can be spread using rest operator', () => {
   // Next line should not throw
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { rerender, ...rest } = render(<View testID="inner" />);
+  const { rerender, ...rest } = render(<View testID="test" />);
   expect(rest).toBeTruthy();
+});
+
+test('render calls detects host component names', () => {
+  resetToDefaults();
+  expect(getConfig().hostComponentNames).toBeUndefined();
+
+  render(<View testID="test" />);
+  expect(getConfig().hostComponentNames).not.toBeUndefined();
 });

--- a/src/__tests__/renderHook.test.tsx
+++ b/src/__tests__/renderHook.test.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react';
+import TestRenderer from 'react-test-renderer';
 import { renderHook } from '../pure';
 
 test('gives comitted result', () => {
@@ -93,4 +94,21 @@ test('props type is inferred correctly when initial props is explicitly undefine
   rerender(6);
 
   expect(result.current).toBe(6);
+});
+
+/**
+ * This test makes sure that calling renderHook does
+ * not try to detect host component names in any form.
+ * But since there are numerous methods that could trigger that
+ * we check the count of renders using React Test Renderers.
+ */
+test('does render only once', () => {
+  jest.spyOn(TestRenderer, 'create');
+
+  renderHook(() => {
+    const [state, setState] = React.useState(1);
+    return [state, setState];
+  });
+
+  expect(TestRenderer.create).toHaveBeenCalledTimes(1);
 });

--- a/src/helpers/accessiblity.ts
+++ b/src/helpers/accessiblity.ts
@@ -6,6 +6,7 @@ import {
 import { ReactTestInstance } from 'react-test-renderer';
 import { getConfig } from '../config';
 import { getHostSiblings } from './component-tree';
+import { getHostComponentNames } from './host-component-names';
 
 type IsInaccessibleOptions = {
   cache?: WeakMap<ReactTestInstance, boolean>;
@@ -99,8 +100,7 @@ export function isAccessibilityElement(
     return element.props.accessible;
   }
 
-  const hostComponentNames = getConfig().hostComponentNames;
-
+  const hostComponentNames = getHostComponentNames();
   return (
     element?.type === hostComponentNames?.text ||
     element?.type === hostComponentNames?.textInput ||

--- a/src/helpers/accessiblity.ts
+++ b/src/helpers/accessiblity.ts
@@ -4,7 +4,6 @@ import {
   StyleSheet,
 } from 'react-native';
 import { ReactTestInstance } from 'react-test-renderer';
-import { getConfig } from '../config';
 import { getHostSiblings } from './component-tree';
 import { getHostComponentNames } from './host-component-names';
 

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -13,12 +13,11 @@ import { renderWithAct } from './render-act';
 import { setRenderResult, screen } from './screen';
 import { getQueriesForElement } from './within';
 
-export type RenderOptions = {
+export interface RenderOptions {
   wrapper?: React.ComponentType<any>;
   createNodeMock?: (element: React.ReactElement) => any;
   unstable_validateStringsRenderedWithinText?: boolean;
-  skipHostComponentNamesConfiguration?: boolean;
-};
+}
 
 export type RenderResult = ReturnType<typeof render>;
 
@@ -28,14 +27,28 @@ export type RenderResult = ReturnType<typeof render>;
  */
 export default function render<T>(
   component: React.ReactElement<T>,
+  options: RenderOptions = {}
+) {
+  return renderInternal(component, {
+    ...options,
+    detectHostComponentNames: true,
+  });
+}
+
+export interface RenderInternalOptions extends RenderOptions {
+  detectHostComponentNames?: boolean;
+}
+
+export function renderInternal<T>(
+  component: React.ReactElement<T>,
   {
     wrapper: Wrapper,
     createNodeMock,
     unstable_validateStringsRenderedWithinText,
-    skipHostComponentNamesConfiguration = false,
-  }: RenderOptions = {}
+    detectHostComponentNames = false,
+  }: RenderInternalOptions = {}
 ) {
-  if (skipHostComponentNamesConfiguration === false) {
+  if (detectHostComponentNames) {
     configureHostComponentNamesIfNeeded();
   }
 

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -17,6 +17,7 @@ export type RenderOptions = {
   wrapper?: React.ComponentType<any>;
   createNodeMock?: (element: React.ReactElement) => any;
   unstable_validateStringsRenderedWithinText?: boolean;
+  skipHostComponentNamesConfiguration?: boolean;
 };
 
 export type RenderResult = ReturnType<typeof render>;
@@ -31,9 +32,12 @@ export default function render<T>(
     wrapper: Wrapper,
     createNodeMock,
     unstable_validateStringsRenderedWithinText,
+    skipHostComponentNamesConfiguration = false,
   }: RenderOptions = {}
 ) {
-  configureHostComponentNamesIfNeeded();
+  if (skipHostComponentNamesConfiguration === false) {
+    configureHostComponentNamesIfNeeded();
+  }
 
   if (unstable_validateStringsRenderedWithinText) {
     return renderWithStringValidation(component, {

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -22,17 +22,14 @@ export interface RenderOptions {
 export type RenderResult = ReturnType<typeof render>;
 
 /**
- * Renders test component deeply using react-test-renderer and exposes helpers
+ * Renders test component deeply using React Test Renderer and exposes helpers
  * to assert on the output.
  */
 export default function render<T>(
   component: React.ReactElement<T>,
   options: RenderOptions = {}
 ) {
-  return renderInternal(component, {
-    ...options,
-    detectHostComponentNames: true,
-  });
+  return renderInternal(component, options);
 }
 
 export interface RenderInternalOptions extends RenderOptions {
@@ -45,7 +42,7 @@ export function renderInternal<T>(
     wrapper: Wrapper,
     createNodeMock,
     unstable_validateStringsRenderedWithinText,
-    detectHostComponentNames = false,
+    detectHostComponentNames = true,
   }: RenderInternalOptions = {}
 ) {
   if (detectHostComponentNames) {

--- a/src/renderHook.tsx
+++ b/src/renderHook.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { ComponentType } from 'react';
-import render from './render';
+import { renderInternal } from './render';
 
 export type RenderHookResult<Result, Props> = {
   rerender: (props: Props) => void;
@@ -36,10 +36,13 @@ export function renderHook<Result, Props>(
     return null;
   }
 
-  const { rerender: baseRerender, unmount } = render(
+  const { rerender: baseRerender, unmount } = renderInternal(
     // @ts-expect-error since option can be undefined, initialProps can be undefined when it should'nt
     <TestComponent renderCallbackProps={initialProps} />,
-    { wrapper, skipHostComponentNamesConfiguration: true }
+    {
+      wrapper,
+      detectHostComponentNames: false,
+    }
   );
 
   function rerender(rerenderCallbackProps: Props) {

--- a/src/renderHook.tsx
+++ b/src/renderHook.tsx
@@ -39,7 +39,7 @@ export function renderHook<Result, Props>(
   const { rerender: baseRerender, unmount } = render(
     // @ts-expect-error since option can be undefined, initialProps can be undefined when it should'nt
     <TestComponent renderCallbackProps={initialProps} />,
-    { wrapper }
+    { wrapper, skipHostComponentNamesConfiguration: true }
   );
 
   function rerender(rerenderCallbackProps: Props) {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
https://github.com/callstack/react-native-testing-library/issues/1423

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
This change can be tested by running the renderHook.test.tsx tests after clearing the jest cache. Before my change, the first test takes 445 ms and after my change it takes 5 ms. 


Before: 
``` ~/Code/react-native-testing-library   main  yarn jest ./src/__tests__/renderHook.test.tsx
yarn run v1.22.19
$ ~/Code/react-native-testing-library/node_modules/.bin/jest ./src/__tests__/renderHook.test.tsx
 PASS  src/__tests__/renderHook.test.tsx
  ✓ gives comitted result (445 ms)
  ✓ allows rerendering (1 ms)
  ✓ allows wrapper components (2 ms)

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        1.273 s
Ran all test suites matching /.\/src\/__tests__\/renderHook.test.tsx/i.
✨  Done in 2.19s.
```

After: 
```~/Code/react-native-testing-library   fix/renderHook-skip-component-names-config  yarn jest ./src/__tests__/renderHook.test.tsx 
yarn run v1.22.19
$ ~/Code/react-native-testing-library/node_modules/.bin/jest ./src/__tests__/renderHook.test.tsx
 PASS  src/__tests__/renderHook.test.tsx
  ✓ gives comitted result (5 ms)
  ✓ allows rerendering (1 ms)
  ✓ allows wrapper components

Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        0.819 s
Ran all test suites matching /.\/src\/__tests__\/renderHook.test.tsx/i.
✨  Done in 1.74s.
```