### PR TITLE
refactor: type all queries to return host components

### DIFF
--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -7,9 +7,9 @@ import {
   ScrollViewProps,
 } from 'react-native';
 import act from './act';
-import { isPointerEventEnabled } from './helpers/pointer-events';
 import { isHostElement } from './helpers/component-tree';
 import { isHostTextInput } from './helpers/host-component-names';
+import { isPointerEventEnabled } from './helpers/pointer-events';
 
 type EventHandler = (...args: unknown[]) => unknown;
 

--- a/src/helpers/component-tree.ts
+++ b/src/helpers/component-tree.ts
@@ -1,10 +1,14 @@
 import { ReactTestInstance } from 'react-test-renderer';
 
+export type HostReactTestInstance = ReactTestInstance & { type: string };
+
 /**
  * Checks if the given element is a host element.
  * @param element The element to check.
  */
-export function isHostElement(element?: ReactTestInstance | null) {
+export function isHostElement(
+  element?: ReactTestInstance | null
+): element is HostReactTestInstance {
   return typeof element?.type === 'string';
 }
 

--- a/src/helpers/component-tree.ts
+++ b/src/helpers/component-tree.ts
@@ -1,5 +1,8 @@
 import { ReactTestInstance } from 'react-test-renderer';
 
+/**
+ * ReactTestInstance referring to host element.
+ */
 export type HostReactTestInstance = ReactTestInstance & { type: string };
 
 /**
@@ -18,7 +21,7 @@ export function isHostElement(
  */
 export function getHostParent(
   element: ReactTestInstance | null
-): ReactTestInstance | null {
+): HostReactTestInstance | null {
   if (element == null) {
     return null;
   }
@@ -41,12 +44,12 @@ export function getHostParent(
  */
 export function getHostChildren(
   element: ReactTestInstance | null
-): ReactTestInstance[] {
+): HostReactTestInstance[] {
   if (element == null) {
     return [];
   }
 
-  const hostChildren: ReactTestInstance[] = [];
+  const hostChildren: HostReactTestInstance[] = [];
 
   element.children.forEach((child) => {
     if (typeof child !== 'object') {
@@ -72,10 +75,8 @@ export function getHostChildren(
  */
 export function getHostSelves(
   element: ReactTestInstance | null
-): ReactTestInstance[] {
-  return typeof element?.type === 'string'
-    ? [element]
-    : getHostChildren(element);
+): HostReactTestInstance[] {
+  return isHostElement(element) ? [element] : getHostChildren(element);
 }
 
 /**
@@ -84,7 +85,7 @@ export function getHostSelves(
  */
 export function getHostSiblings(
   element: ReactTestInstance | null
-): ReactTestInstance[] {
+): HostReactTestInstance[] {
   const hostParent = getHostParent(element);
   const hostSelves = getHostSelves(element);
   return getHostChildren(hostParent).filter(

--- a/src/helpers/component-tree.ts
+++ b/src/helpers/component-tree.ts
@@ -3,7 +3,7 @@ import { ReactTestInstance } from 'react-test-renderer';
 /**
  * ReactTestInstance referring to host element.
  */
-export type HostReactTestInstance = ReactTestInstance & { type: string };
+export type HostTestInstance = ReactTestInstance & { type: string };
 
 /**
  * Checks if the given element is a host element.
@@ -11,7 +11,7 @@ export type HostReactTestInstance = ReactTestInstance & { type: string };
  */
 export function isHostElement(
   element?: ReactTestInstance | null
-): element is HostReactTestInstance {
+): element is HostTestInstance {
   return typeof element?.type === 'string';
 }
 
@@ -21,7 +21,7 @@ export function isHostElement(
  */
 export function getHostParent(
   element: ReactTestInstance | null
-): HostReactTestInstance | null {
+): HostTestInstance | null {
   if (element == null) {
     return null;
   }
@@ -44,12 +44,12 @@ export function getHostParent(
  */
 export function getHostChildren(
   element: ReactTestInstance | null
-): HostReactTestInstance[] {
+): HostTestInstance[] {
   if (element == null) {
     return [];
   }
 
-  const hostChildren: HostReactTestInstance[] = [];
+  const hostChildren: HostTestInstance[] = [];
 
   element.children.forEach((child) => {
     if (typeof child !== 'object') {
@@ -75,7 +75,7 @@ export function getHostChildren(
  */
 export function getHostSelves(
   element: ReactTestInstance | null
-): HostReactTestInstance[] {
+): HostTestInstance[] {
   return isHostElement(element) ? [element] : getHostChildren(element);
 }
 
@@ -85,7 +85,7 @@ export function getHostSelves(
  */
 export function getHostSiblings(
   element: ReactTestInstance | null
-): HostReactTestInstance[] {
+): HostTestInstance[] {
   const hostParent = getHostParent(element);
   const hostSelves = getHostSelves(element);
   return getHostChildren(hostParent).filter(

--- a/src/helpers/filterNodeByType.ts
+++ b/src/helpers/filterNodeByType.ts
@@ -1,7 +1,0 @@
-import type { ReactTestInstance } from 'react-test-renderer';
-import * as React from 'react';
-
-export const filterNodeByType = (
-  node: ReactTestInstance | React.ReactElement,
-  type: React.ElementType | string
-) => node.type === type;

--- a/src/helpers/findAll.ts
+++ b/src/helpers/findAll.ts
@@ -19,7 +19,7 @@ export function findAll(
   root: ReactTestInstance,
   predicate: (element: ReactTestInstance) => boolean,
   options?: FindAllOptions
-): Array<HostReactTestInstance> {
+): HostReactTestInstance[] {
   const results = findAllInternal(root, predicate, options);
 
   const includeHiddenElements =
@@ -43,7 +43,7 @@ function findAllInternal(
   root: ReactTestInstance,
   predicate: (element: ReactTestInstance) => boolean,
   options?: FindAllOptions
-): Array<HostReactTestInstance> {
+): HostReactTestInstance[] {
   const results: HostReactTestInstance[] = [];
 
   // Match descendants first but do not add them to results yet.

--- a/src/helpers/findAll.ts
+++ b/src/helpers/findAll.ts
@@ -1,8 +1,7 @@
 import { ReactTestInstance } from 'react-test-renderer';
 import { getConfig } from '../config';
 import { isHiddenFromAccessibility } from './accessiblity';
-import { isHostElement } from './component-tree';
-import type { HostReactTestInstance } from './component-tree';
+import { HostReactTestInstance, isHostElement } from './component-tree';
 
 interface FindAllOptions {
   /** Match elements hidden from accessibility */

--- a/src/helpers/findAll.ts
+++ b/src/helpers/findAll.ts
@@ -1,6 +1,8 @@
 import { ReactTestInstance } from 'react-test-renderer';
 import { getConfig } from '../config';
 import { isHiddenFromAccessibility } from './accessiblity';
+import { isHostElement } from './component-tree';
+import type { HostReactTestInstance } from './component-tree';
 
 interface FindAllOptions {
   /** Match elements hidden from accessibility */
@@ -17,7 +19,7 @@ export function findAll(
   root: ReactTestInstance,
   predicate: (element: ReactTestInstance) => boolean,
   options?: FindAllOptions
-) {
+): Array<HostReactTestInstance> {
   const results = findAllInternal(root, predicate, options);
 
   const includeHiddenElements =
@@ -41,11 +43,11 @@ function findAllInternal(
   root: ReactTestInstance,
   predicate: (element: ReactTestInstance) => boolean,
   options?: FindAllOptions
-): Array<ReactTestInstance> {
-  const results: ReactTestInstance[] = [];
+): Array<HostReactTestInstance> {
+  const results: HostReactTestInstance[] = [];
 
   // Match descendants first but do not add them to results yet.
-  const matchingDescendants: ReactTestInstance[] = [];
+  const matchingDescendants: HostReactTestInstance[] = [];
   root.children.forEach((child) => {
     if (typeof child === 'string') {
       return;
@@ -54,9 +56,10 @@ function findAllInternal(
   });
 
   if (
+    isHostElement(root) &&
+    predicate(root) &&
     // When matchDeepestOnly = true: add current element only if no descendants match
-    (!options?.matchDeepestOnly || matchingDescendants.length === 0) &&
-    predicate(root)
+    (!options?.matchDeepestOnly || matchingDescendants.length === 0)
   ) {
     results.push(root);
   }

--- a/src/helpers/findAll.ts
+++ b/src/helpers/findAll.ts
@@ -56,10 +56,10 @@ function findAllInternal(
   });
 
   if (
-    isHostElement(root) &&
-    predicate(root) &&
     // When matchDeepestOnly = true: add current element only if no descendants match
-    (!options?.matchDeepestOnly || matchingDescendants.length === 0)
+    (!options?.matchDeepestOnly || matchingDescendants.length === 0) &&
+    isHostElement(root) &&
+    predicate(root)
   ) {
     results.push(root);
   }

--- a/src/helpers/findAll.ts
+++ b/src/helpers/findAll.ts
@@ -1,7 +1,7 @@
 import { ReactTestInstance } from 'react-test-renderer';
 import { getConfig } from '../config';
 import { isHiddenFromAccessibility } from './accessiblity';
-import { HostReactTestInstance, isHostElement } from './component-tree';
+import { HostTestInstance, isHostElement } from './component-tree';
 
 interface FindAllOptions {
   /** Match elements hidden from accessibility */
@@ -18,7 +18,7 @@ export function findAll(
   root: ReactTestInstance,
   predicate: (element: ReactTestInstance) => boolean,
   options?: FindAllOptions
-): HostReactTestInstance[] {
+): HostTestInstance[] {
   const results = findAllInternal(root, predicate, options);
 
   const includeHiddenElements =
@@ -42,11 +42,11 @@ function findAllInternal(
   root: ReactTestInstance,
   predicate: (element: ReactTestInstance) => boolean,
   options?: FindAllOptions
-): HostReactTestInstance[] {
-  const results: HostReactTestInstance[] = [];
+): HostTestInstance[] {
+  const results: HostTestInstance[] = [];
 
   // Match descendants first but do not add them to results yet.
-  const matchingDescendants: HostReactTestInstance[] = [];
+  const matchingDescendants: HostTestInstance[] = [];
   root.children.forEach((child) => {
     if (typeof child === 'string') {
       return;

--- a/src/helpers/host-component-names.tsx
+++ b/src/helpers/host-component-names.tsx
@@ -3,6 +3,7 @@ import { ReactTestInstance } from 'react-test-renderer';
 import { Switch, Text, TextInput, View } from 'react-native';
 import { configureInternal, getConfig, HostComponentNames } from '../config';
 import { renderWithAct } from '../render-act';
+import { HostTestInstance } from './component-tree';
 
 const userConfigErrorMessage = `There seems to be an issue with your configuration that prevents React Native Testing Library from working correctly.
 Please check if you are using compatible versions of React Native and React Native Testing Library.`;
@@ -66,10 +67,32 @@ function getByTestId(instance: ReactTestInstance, testID: string) {
   return nodes[0];
 }
 
-export function isHostText(element?: ReactTestInstance) {
+/**
+ * Checks if the given element is a host Text.
+ * @param element The element to check.
+ */
+export function isHostText(
+  element?: ReactTestInstance | null
+): element is HostTestInstance {
   return element?.type === getHostComponentNames().text;
 }
 
-export function isHostTextInput(element?: ReactTestInstance) {
+/**
+ * Checks if the given element is a host TextInput.
+ * @param element The element to check.
+ */
+export function isHostTextInput(
+  element?: ReactTestInstance | null
+): element is HostTestInstance {
   return element?.type === getHostComponentNames().textInput;
+}
+
+/**
+ * Checks if the given element is a host Switch.
+ * @param element The element to check.
+ */
+export function isHostSwitch(
+  element?: ReactTestInstance | null
+): element is HostTestInstance {
+  return element?.type === getHostComponentNames().switch;
 }

--- a/src/helpers/host-component-names.tsx
+++ b/src/helpers/host-component-names.tsx
@@ -86,13 +86,3 @@ export function isHostTextInput(
 ): element is HostTestInstance {
   return element?.type === getHostComponentNames().textInput;
 }
-
-/**
- * Checks if the given element is a host Switch.
- * @param element The element to check.
- */
-export function isHostSwitch(
-  element?: ReactTestInstance | null
-): element is HostTestInstance {
-  return element?.type === getHostComponentNames().switch;
-}

--- a/src/helpers/matchers/matchLabelText.ts
+++ b/src/helpers/matchers/matchLabelText.ts
@@ -43,7 +43,6 @@ function matchAccessibilityLabelledBy(
     findAll(
       root,
       (node) =>
-        typeof node.type === 'string' &&
         node.props.nativeID === nativeId &&
         matchTextContent(node, text, options)
     ).length > 0

--- a/src/queries/a11yState.ts
+++ b/src/queries/a11yState.ts
@@ -6,7 +6,7 @@ import {
   AccessibilityStateMatcher,
   matchAccessibilityState,
 } from '../helpers/matchers/accessibilityState';
-import { makeQueries } from './makeQueries';
+import { InternalQueryAllByQuery, makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
   FindByQuery,
@@ -19,7 +19,7 @@ import { CommonQueryOptions } from './options';
 
 const queryAllByA11yState = (
   instance: ReactTestInstance
-): QueryAllByQuery<AccessibilityStateMatcher, CommonQueryOptions> =>
+): InternalQueryAllByQuery<AccessibilityStateMatcher, CommonQueryOptions> =>
   function queryAllByA11yStateFn(matcher, queryOptions) {
     return findAll(
       instance,

--- a/src/queries/a11yState.ts
+++ b/src/queries/a11yState.ts
@@ -6,7 +6,7 @@ import {
   AccessibilityStateMatcher,
   matchAccessibilityState,
 } from '../helpers/matchers/accessibilityState';
-import { InternalQueryAllByQuery, makeQueries } from './makeQueries';
+import { makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
   FindByQuery,
@@ -19,7 +19,7 @@ import { CommonQueryOptions } from './options';
 
 const queryAllByA11yState = (
   instance: ReactTestInstance
-): InternalQueryAllByQuery<AccessibilityStateMatcher, CommonQueryOptions> =>
+): QueryAllByQuery<AccessibilityStateMatcher, CommonQueryOptions> =>
   function queryAllByA11yStateFn(matcher, queryOptions) {
     return findAll(
       instance,

--- a/src/queries/a11yState.ts
+++ b/src/queries/a11yState.ts
@@ -19,15 +19,11 @@ import { CommonQueryOptions } from './options';
 
 const queryAllByA11yState = (
   instance: ReactTestInstance
-): ((
-  matcher: AccessibilityStateMatcher,
-  queryOptions?: CommonQueryOptions
-) => Array<ReactTestInstance>) =>
+): QueryAllByQuery<AccessibilityStateMatcher, CommonQueryOptions> =>
   function queryAllByA11yStateFn(matcher, queryOptions) {
     return findAll(
       instance,
-      (node) =>
-        typeof node.type === 'string' && matchAccessibilityState(node, matcher),
+      (node) => matchAccessibilityState(node, matcher),
       queryOptions
     );
   };

--- a/src/queries/a11yValue.ts
+++ b/src/queries/a11yValue.ts
@@ -6,7 +6,7 @@ import {
   AccessibilityValueMatcher,
   matchAccessibilityValue,
 } from '../helpers/matchers/accessibilityValue';
-import { makeQueries } from './makeQueries';
+import { InternalQueryAllByQuery, makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
   FindByQuery,
@@ -19,7 +19,7 @@ import { CommonQueryOptions } from './options';
 
 const queryAllByA11yValue = (
   instance: ReactTestInstance
-): QueryAllByQuery<AccessibilityValueMatcher, CommonQueryOptions> =>
+): InternalQueryAllByQuery<AccessibilityValueMatcher, CommonQueryOptions> =>
   function queryAllByA11yValueFn(value, queryOptions) {
     return findAll(
       instance,

--- a/src/queries/a11yValue.ts
+++ b/src/queries/a11yValue.ts
@@ -6,7 +6,7 @@ import {
   AccessibilityValueMatcher,
   matchAccessibilityValue,
 } from '../helpers/matchers/accessibilityValue';
-import { InternalQueryAllByQuery, makeQueries } from './makeQueries';
+import { makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
   FindByQuery,
@@ -19,7 +19,7 @@ import { CommonQueryOptions } from './options';
 
 const queryAllByA11yValue = (
   instance: ReactTestInstance
-): InternalQueryAllByQuery<AccessibilityValueMatcher, CommonQueryOptions> =>
+): QueryAllByQuery<AccessibilityValueMatcher, CommonQueryOptions> =>
   function queryAllByA11yValueFn(value, queryOptions) {
     return findAll(
       instance,

--- a/src/queries/a11yValue.ts
+++ b/src/queries/a11yValue.ts
@@ -19,15 +19,11 @@ import { CommonQueryOptions } from './options';
 
 const queryAllByA11yValue = (
   instance: ReactTestInstance
-): ((
-  value: AccessibilityValueMatcher,
-  queryOptions?: CommonQueryOptions
-) => Array<ReactTestInstance>) =>
+): QueryAllByQuery<AccessibilityValueMatcher, CommonQueryOptions> =>
   function queryAllByA11yValueFn(value, queryOptions) {
     return findAll(
       instance,
-      (node) =>
-        typeof node.type === 'string' && matchAccessibilityValue(node, value),
+      (node) => matchAccessibilityValue(node, value),
       queryOptions
     );
   };

--- a/src/queries/displayValue.ts
+++ b/src/queries/displayValue.ts
@@ -3,7 +3,7 @@ import { filterNodeByType } from '../helpers/filterNodeByType';
 import { findAll } from '../helpers/findAll';
 import { matches, TextMatch, TextMatchOptions } from '../matches';
 import { getHostComponentNames } from '../helpers/host-component-names';
-import { makeQueries } from './makeQueries';
+import { InternalQueryAllByQuery, makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
   FindByQuery,
@@ -33,7 +33,7 @@ const getTextInputNodeByDisplayValue = (
 
 const queryAllByDisplayValue = (
   instance: ReactTestInstance
-): QueryAllByQuery<TextMatch, ByDisplayValueOptions> =>
+): InternalQueryAllByQuery<TextMatch, ByDisplayValueOptions> =>
   function queryAllByDisplayValueFn(displayValue, queryOptions) {
     return findAll(
       instance,

--- a/src/queries/displayValue.ts
+++ b/src/queries/displayValue.ts
@@ -1,8 +1,7 @@
 import type { ReactTestInstance } from 'react-test-renderer';
-import { filterNodeByType } from '../helpers/filterNodeByType';
 import { findAll } from '../helpers/findAll';
+import { isHostTextInput } from '../helpers/host-component-names';
 import { matches, TextMatch, TextMatchOptions } from '../matches';
-import { getHostComponentNames } from '../helpers/host-component-names';
 import { makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
@@ -16,19 +15,15 @@ import type { CommonQueryOptions } from './options';
 
 type ByDisplayValueOptions = CommonQueryOptions & TextMatchOptions;
 
-const getTextInputNodeByDisplayValue = (
+const matchDisplayValue = (
   node: ReactTestInstance,
   value: TextMatch,
   options: TextMatchOptions = {}
 ) => {
   const { exact, normalizer } = options;
-  const nodeValue =
-    node.props.value !== undefined ? node.props.value : node.props.defaultValue;
+  const nodeValue = node.props.value ?? node.props.defaultValue;
 
-  return (
-    filterNodeByType(node, getHostComponentNames().textInput) &&
-    matches(value, nodeValue, normalizer, exact)
-  );
+  return matches(value, nodeValue, normalizer, exact);
 };
 
 const queryAllByDisplayValue = (
@@ -38,7 +33,8 @@ const queryAllByDisplayValue = (
     return findAll(
       instance,
       (node) =>
-        getTextInputNodeByDisplayValue(node, displayValue, queryOptions),
+        isHostTextInput(node) &&
+        matchDisplayValue(node, displayValue, queryOptions),
       queryOptions
     );
   };

--- a/src/queries/displayValue.ts
+++ b/src/queries/displayValue.ts
@@ -33,10 +33,7 @@ const getTextInputNodeByDisplayValue = (
 
 const queryAllByDisplayValue = (
   instance: ReactTestInstance
-): ((
-  displayValue: TextMatch,
-  queryOptions?: ByDisplayValueOptions
-) => Array<ReactTestInstance>) =>
+): QueryAllByQuery<TextMatch, ByDisplayValueOptions> =>
   function queryAllByDisplayValueFn(displayValue, queryOptions) {
     return findAll(
       instance,

--- a/src/queries/displayValue.ts
+++ b/src/queries/displayValue.ts
@@ -3,7 +3,7 @@ import { filterNodeByType } from '../helpers/filterNodeByType';
 import { findAll } from '../helpers/findAll';
 import { matches, TextMatch, TextMatchOptions } from '../matches';
 import { getHostComponentNames } from '../helpers/host-component-names';
-import { InternalQueryAllByQuery, makeQueries } from './makeQueries';
+import { makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
   FindByQuery,
@@ -33,7 +33,7 @@ const getTextInputNodeByDisplayValue = (
 
 const queryAllByDisplayValue = (
   instance: ReactTestInstance
-): InternalQueryAllByQuery<TextMatch, ByDisplayValueOptions> =>
+): QueryAllByQuery<TextMatch, ByDisplayValueOptions> =>
   function queryAllByDisplayValueFn(displayValue, queryOptions) {
     return findAll(
       instance,

--- a/src/queries/hintText.ts
+++ b/src/queries/hintText.ts
@@ -25,16 +25,11 @@ const getNodeByHintText = (
 
 const queryAllByHintText = (
   instance: ReactTestInstance
-): ((
-  hint: TextMatch,
-  queryOptions?: ByHintTextOptions
-) => Array<ReactTestInstance>) =>
+): QueryAllByQuery<TextMatch, ByHintTextOptions> =>
   function queryAllByA11yHintFn(hint, queryOptions) {
     return findAll(
       instance,
-      (node) =>
-        typeof node.type === 'string' &&
-        getNodeByHintText(node, hint, queryOptions),
+      (node) => getNodeByHintText(node, hint, queryOptions),
       queryOptions
     );
   };

--- a/src/queries/hintText.ts
+++ b/src/queries/hintText.ts
@@ -1,7 +1,7 @@
 import type { ReactTestInstance } from 'react-test-renderer';
 import { findAll } from '../helpers/findAll';
 import { matches, TextMatch, TextMatchOptions } from '../matches';
-import { makeQueries } from './makeQueries';
+import { InternalQueryAllByQuery, makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
   FindByQuery,
@@ -25,7 +25,7 @@ const getNodeByHintText = (
 
 const queryAllByHintText = (
   instance: ReactTestInstance
-): QueryAllByQuery<TextMatch, ByHintTextOptions> =>
+): InternalQueryAllByQuery<TextMatch, ByHintTextOptions> =>
   function queryAllByA11yHintFn(hint, queryOptions) {
     return findAll(
       instance,

--- a/src/queries/hintText.ts
+++ b/src/queries/hintText.ts
@@ -1,7 +1,7 @@
 import type { ReactTestInstance } from 'react-test-renderer';
 import { findAll } from '../helpers/findAll';
 import { matches, TextMatch, TextMatchOptions } from '../matches';
-import { InternalQueryAllByQuery, makeQueries } from './makeQueries';
+import { makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
   FindByQuery,
@@ -25,7 +25,7 @@ const getNodeByHintText = (
 
 const queryAllByHintText = (
   instance: ReactTestInstance
-): InternalQueryAllByQuery<TextMatch, ByHintTextOptions> =>
+): QueryAllByQuery<TextMatch, ByHintTextOptions> =>
   function queryAllByA11yHintFn(hint, queryOptions) {
     return findAll(
       instance,

--- a/src/queries/labelText.ts
+++ b/src/queries/labelText.ts
@@ -19,9 +19,7 @@ function queryAllByLabelText(instance: ReactTestInstance) {
   return (text: TextMatch, queryOptions?: ByLabelTextOptions) => {
     return findAll(
       instance,
-      (node) =>
-        typeof node.type === 'string' &&
-        matchLabelText(instance, node, text, queryOptions),
+      (node) => matchLabelText(instance, node, text, queryOptions),
       queryOptions
     );
   };

--- a/src/queries/makeQueries.ts
+++ b/src/queries/makeQueries.ts
@@ -5,6 +5,7 @@ import type { WaitForOptions } from '../waitFor';
 import format from '../helpers/format';
 import { screen } from '../screen';
 import { defaultMapProps } from '../helpers/format-default';
+import { HostReactTestInstance } from '../helpers/component-tree';
 
 export type GetByQuery<Predicate, Options = void> = (
   predicate: Predicate,
@@ -25,6 +26,11 @@ export type QueryAllByQuery<Predicate, Options = void> = (
   predicate: Predicate,
   options?: Options
 ) => ReactTestInstance[];
+
+export type InternalQueryAllByQuery<Predicate, Options = void> = (
+  predicate: Predicate,
+  options?: Options
+) => HostReactTestInstance[];
 
 export type FindByQuery<Predicate, Options = void> = (
   predicate: Predicate,
@@ -112,7 +118,7 @@ function appendElementTreeToError(error: Error) {
 }
 
 export function makeQueries<Predicate, Options>(
-  queryAllByQuery: UnboundQuery<QueryAllByQuery<Predicate, Options>>,
+  queryAllByQuery: UnboundQuery<InternalQueryAllByQuery<Predicate, Options>>,
   getMissingError: (predicate: Predicate, options?: Options) => string,
   getMultipleError: (predicate: Predicate, options?: Options) => string
 ): UnboundQueries<Predicate, Options> {

--- a/src/queries/makeQueries.ts
+++ b/src/queries/makeQueries.ts
@@ -5,40 +5,41 @@ import type { WaitForOptions } from '../waitFor';
 import format from '../helpers/format';
 import { screen } from '../screen';
 import { defaultMapProps } from '../helpers/format-default';
+import type { HostReactTestInstance } from '../helpers/component-tree';
 
 export type GetByQuery<Predicate, Options = void> = (
   predicate: Predicate,
   options?: Options
-) => ReactTestInstance;
+) => HostReactTestInstance;
 
 export type GetAllByQuery<Predicate, Options = void> = (
   predicate: Predicate,
   options?: Options
-) => ReactTestInstance[];
+) => HostReactTestInstance[];
 
 export type QueryByQuery<Predicate, Options = void> = (
   predicate: Predicate,
   options?: Options
-) => ReactTestInstance | null;
+) => HostReactTestInstance | null;
 
 export type QueryAllByQuery<Predicate, Options = void> = (
   predicate: Predicate,
   options?: Options
-) => ReactTestInstance[];
+) => HostReactTestInstance[];
 
 export type FindByQuery<Predicate, Options = void> = (
   predicate: Predicate,
   // Remove `& WaitForOptions` when all queries have been migrated to support 2nd arg query options.
   options?: Options & WaitForOptions,
   waitForOptions?: WaitForOptions
-) => Promise<ReactTestInstance>;
+) => Promise<HostReactTestInstance>;
 
 export type FindAllByQuery<Predicate, Options = void> = (
   predicate: Predicate,
   // Remove `& WaitForOptions` when all queries have been migrated to support 2nd arg query options.
   options?: Options & WaitForOptions,
   waitForOptions?: WaitForOptions
-) => Promise<ReactTestInstance[]>;
+) => Promise<HostReactTestInstance[]>;
 
 type UnboundQuery<Query> = (instance: ReactTestInstance) => Query;
 

--- a/src/queries/makeQueries.ts
+++ b/src/queries/makeQueries.ts
@@ -5,7 +5,6 @@ import type { WaitForOptions } from '../waitFor';
 import format from '../helpers/format';
 import { screen } from '../screen';
 import { defaultMapProps } from '../helpers/format-default';
-import { HostReactTestInstance } from '../helpers/component-tree';
 
 export type GetByQuery<Predicate, Options = void> = (
   predicate: Predicate,
@@ -26,11 +25,6 @@ export type QueryAllByQuery<Predicate, Options = void> = (
   predicate: Predicate,
   options?: Options
 ) => ReactTestInstance[];
-
-export type InternalQueryAllByQuery<Predicate, Options = void> = (
-  predicate: Predicate,
-  options?: Options
-) => HostReactTestInstance[];
 
 export type FindByQuery<Predicate, Options = void> = (
   predicate: Predicate,
@@ -118,7 +112,7 @@ function appendElementTreeToError(error: Error) {
 }
 
 export function makeQueries<Predicate, Options>(
-  queryAllByQuery: UnboundQuery<InternalQueryAllByQuery<Predicate, Options>>,
+  queryAllByQuery: UnboundQuery<QueryAllByQuery<Predicate, Options>>,
   getMissingError: (predicate: Predicate, options?: Options) => string,
   getMultipleError: (predicate: Predicate, options?: Options) => string
 ): UnboundQueries<Predicate, Options> {

--- a/src/queries/makeQueries.ts
+++ b/src/queries/makeQueries.ts
@@ -5,41 +5,40 @@ import type { WaitForOptions } from '../waitFor';
 import format from '../helpers/format';
 import { screen } from '../screen';
 import { defaultMapProps } from '../helpers/format-default';
-import type { HostReactTestInstance } from '../helpers/component-tree';
 
 export type GetByQuery<Predicate, Options = void> = (
   predicate: Predicate,
   options?: Options
-) => HostReactTestInstance;
+) => ReactTestInstance;
 
 export type GetAllByQuery<Predicate, Options = void> = (
   predicate: Predicate,
   options?: Options
-) => HostReactTestInstance[];
+) => ReactTestInstance[];
 
 export type QueryByQuery<Predicate, Options = void> = (
   predicate: Predicate,
   options?: Options
-) => HostReactTestInstance | null;
+) => ReactTestInstance | null;
 
 export type QueryAllByQuery<Predicate, Options = void> = (
   predicate: Predicate,
   options?: Options
-) => HostReactTestInstance[];
+) => ReactTestInstance[];
 
 export type FindByQuery<Predicate, Options = void> = (
   predicate: Predicate,
   // Remove `& WaitForOptions` when all queries have been migrated to support 2nd arg query options.
   options?: Options & WaitForOptions,
   waitForOptions?: WaitForOptions
-) => Promise<HostReactTestInstance>;
+) => Promise<ReactTestInstance>;
 
 export type FindAllByQuery<Predicate, Options = void> = (
   predicate: Predicate,
   // Remove `& WaitForOptions` when all queries have been migrated to support 2nd arg query options.
   options?: Options & WaitForOptions,
   waitForOptions?: WaitForOptions
-) => Promise<HostReactTestInstance[]>;
+) => Promise<ReactTestInstance[]>;
 
 type UnboundQuery<Query> = (instance: ReactTestInstance) => Query;
 

--- a/src/queries/placeholderText.ts
+++ b/src/queries/placeholderText.ts
@@ -31,10 +31,7 @@ const getTextInputNodeByPlaceholderText = (
 
 const queryAllByPlaceholderText = (
   instance: ReactTestInstance
-): ((
-  placeholder: TextMatch,
-  queryOptions?: ByPlaceholderTextOptions
-) => Array<ReactTestInstance>) =>
+): QueryAllByQuery<TextMatch, ByPlaceholderTextOptions> =>
   function queryAllByPlaceholderFn(placeholder, queryOptions) {
     return findAll(
       instance,

--- a/src/queries/placeholderText.ts
+++ b/src/queries/placeholderText.ts
@@ -3,7 +3,7 @@ import { findAll } from '../helpers/findAll';
 import { matches, TextMatch, TextMatchOptions } from '../matches';
 import { filterNodeByType } from '../helpers/filterNodeByType';
 import { getHostComponentNames } from '../helpers/host-component-names';
-import { makeQueries } from './makeQueries';
+import { InternalQueryAllByQuery, makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
   FindByQuery,
@@ -31,7 +31,7 @@ const getTextInputNodeByPlaceholderText = (
 
 const queryAllByPlaceholderText = (
   instance: ReactTestInstance
-): QueryAllByQuery<TextMatch, ByPlaceholderTextOptions> =>
+): InternalQueryAllByQuery<TextMatch, ByPlaceholderTextOptions> =>
   function queryAllByPlaceholderFn(placeholder, queryOptions) {
     return findAll(
       instance,

--- a/src/queries/placeholderText.ts
+++ b/src/queries/placeholderText.ts
@@ -1,8 +1,7 @@
 import type { ReactTestInstance } from 'react-test-renderer';
 import { findAll } from '../helpers/findAll';
 import { matches, TextMatch, TextMatchOptions } from '../matches';
-import { filterNodeByType } from '../helpers/filterNodeByType';
-import { getHostComponentNames } from '../helpers/host-component-names';
+import { isHostTextInput } from '../helpers/host-component-names';
 import { makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
@@ -16,17 +15,13 @@ import type { CommonQueryOptions } from './options';
 
 type ByPlaceholderTextOptions = CommonQueryOptions & TextMatchOptions;
 
-const getTextInputNodeByPlaceholderText = (
+const matchPlaceholderText = (
   node: ReactTestInstance,
   placeholder: TextMatch,
   options: TextMatchOptions = {}
 ) => {
   const { exact, normalizer } = options;
-
-  return (
-    filterNodeByType(node, getHostComponentNames().textInput) &&
-    matches(placeholder, node.props.placeholder, normalizer, exact)
-  );
+  return matches(placeholder, node.props.placeholder, normalizer, exact);
 };
 
 const queryAllByPlaceholderText = (
@@ -36,7 +31,8 @@ const queryAllByPlaceholderText = (
     return findAll(
       instance,
       (node) =>
-        getTextInputNodeByPlaceholderText(node, placeholder, queryOptions),
+        isHostTextInput(node) &&
+        matchPlaceholderText(node, placeholder, queryOptions),
       queryOptions
     );
   };

--- a/src/queries/placeholderText.ts
+++ b/src/queries/placeholderText.ts
@@ -3,7 +3,7 @@ import { findAll } from '../helpers/findAll';
 import { matches, TextMatch, TextMatchOptions } from '../matches';
 import { filterNodeByType } from '../helpers/filterNodeByType';
 import { getHostComponentNames } from '../helpers/host-component-names';
-import { InternalQueryAllByQuery, makeQueries } from './makeQueries';
+import { makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
   FindByQuery,
@@ -31,7 +31,7 @@ const getTextInputNodeByPlaceholderText = (
 
 const queryAllByPlaceholderText = (
   instance: ReactTestInstance
-): InternalQueryAllByQuery<TextMatch, ByPlaceholderTextOptions> =>
+): QueryAllByQuery<TextMatch, ByPlaceholderTextOptions> =>
   function queryAllByPlaceholderFn(placeholder, queryOptions) {
     return findAll(
       instance,

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -16,7 +16,7 @@ import {
 import { matchStringProp } from '../helpers/matchers/matchStringProp';
 import type { TextMatch } from '../matches';
 import { getQueriesForElement } from '../within';
-import { InternalQueryAllByQuery, makeQueries } from './makeQueries';
+import { makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
   FindByQuery,
@@ -61,7 +61,7 @@ const matchAccessibilityValueIfNeeded = (
 
 const queryAllByRole = (
   instance: ReactTestInstance
-): InternalQueryAllByQuery<TextMatch, ByRoleOptions> =>
+): QueryAllByQuery<TextMatch, ByRoleOptions> =>
   function queryAllByRoleFn(role, options) {
     return findAll(
       instance,

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -61,13 +61,12 @@ const matchAccessibilityValueIfNeeded = (
 
 const queryAllByRole = (
   instance: ReactTestInstance
-): ((role: TextMatch, options?: ByRoleOptions) => Array<ReactTestInstance>) =>
+): QueryAllByQuery<TextMatch, ByRoleOptions> =>
   function queryAllByRoleFn(role, options) {
     return findAll(
       instance,
       (node) =>
         // run the cheapest checks first, and early exit to avoid unneeded computations
-        typeof node.type === 'string' &&
         isAccessibilityElement(node) &&
         matchStringProp(node.props.accessibilityRole, role) &&
         matchAccessibleStateIfNeeded(node, options) &&

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -16,7 +16,7 @@ import {
 import { matchStringProp } from '../helpers/matchers/matchStringProp';
 import type { TextMatch } from '../matches';
 import { getQueriesForElement } from '../within';
-import { makeQueries } from './makeQueries';
+import { InternalQueryAllByQuery, makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
   FindByQuery,
@@ -61,7 +61,7 @@ const matchAccessibilityValueIfNeeded = (
 
 const queryAllByRole = (
   instance: ReactTestInstance
-): QueryAllByQuery<TextMatch, ByRoleOptions> =>
+): InternalQueryAllByQuery<TextMatch, ByRoleOptions> =>
   function queryAllByRoleFn(role, options) {
     return findAll(
       instance,

--- a/src/queries/testId.ts
+++ b/src/queries/testId.ts
@@ -1,7 +1,7 @@
 import type { ReactTestInstance } from 'react-test-renderer';
 import { findAll } from '../helpers/findAll';
 import { matches, TextMatch, TextMatchOptions } from '../matches';
-import { InternalQueryAllByQuery, makeQueries } from './makeQueries';
+import { makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
   FindByQuery,
@@ -25,7 +25,7 @@ const getNodeByTestId = (
 
 const queryAllByTestId = (
   instance: ReactTestInstance
-): InternalQueryAllByQuery<TextMatch, ByTestIdOptions> =>
+): QueryAllByQuery<TextMatch, ByTestIdOptions> =>
   function queryAllByTestIdFn(testId, queryOptions) {
     return findAll(
       instance,

--- a/src/queries/testId.ts
+++ b/src/queries/testId.ts
@@ -1,7 +1,7 @@
 import type { ReactTestInstance } from 'react-test-renderer';
 import { findAll } from '../helpers/findAll';
 import { matches, TextMatch, TextMatchOptions } from '../matches';
-import { makeQueries } from './makeQueries';
+import { InternalQueryAllByQuery, makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
   FindByQuery,
@@ -25,7 +25,7 @@ const getNodeByTestId = (
 
 const queryAllByTestId = (
   instance: ReactTestInstance
-): QueryAllByQuery<TextMatch, ByTestIdOptions> =>
+): InternalQueryAllByQuery<TextMatch, ByTestIdOptions> =>
   function queryAllByTestIdFn(testId, queryOptions) {
     return findAll(
       instance,

--- a/src/queries/testId.ts
+++ b/src/queries/testId.ts
@@ -14,13 +14,13 @@ import type { CommonQueryOptions } from './options';
 
 type ByTestIdOptions = CommonQueryOptions & TextMatchOptions;
 
-const getNodeByTestId = (
+const matchTestId = (
   node: ReactTestInstance,
-  testID: TextMatch,
+  testId: TextMatch,
   options: TextMatchOptions = {}
 ) => {
   const { exact, normalizer } = options;
-  return matches(testID, node.props.testID, normalizer, exact);
+  return matches(testId, node.props.testID, normalizer, exact);
 };
 
 const queryAllByTestId = (
@@ -29,7 +29,7 @@ const queryAllByTestId = (
   function queryAllByTestIdFn(testId, queryOptions) {
     return findAll(
       instance,
-      (node) => getNodeByTestId(node, testId, queryOptions),
+      (node) => matchTestId(node, testId, queryOptions),
       queryOptions
     );
   };

--- a/src/queries/testId.ts
+++ b/src/queries/testId.ts
@@ -25,16 +25,11 @@ const getNodeByTestId = (
 
 const queryAllByTestId = (
   instance: ReactTestInstance
-): ((
-  testId: TextMatch,
-  queryOptions?: ByTestIdOptions
-) => Array<ReactTestInstance>) =>
+): QueryAllByQuery<TextMatch, ByTestIdOptions> =>
   function queryAllByTestIdFn(testId, queryOptions) {
     return findAll(
       instance,
-      (node) =>
-        typeof node.type === 'string' &&
-        getNodeByTestId(node, testId, queryOptions),
+      (node) => getNodeByTestId(node, testId, queryOptions),
       queryOptions
     );
   };

--- a/src/queries/text.ts
+++ b/src/queries/text.ts
@@ -4,7 +4,7 @@ import { findAll } from '../helpers/findAll';
 import { getHostComponentNames } from '../helpers/host-component-names';
 import { matchTextContent } from '../helpers/matchers/matchTextContent';
 import { TextMatch, TextMatchOptions } from '../matches';
-import { makeQueries } from './makeQueries';
+import { InternalQueryAllByQuery, makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
   FindByQuery,
@@ -19,7 +19,7 @@ type ByTextOptions = CommonQueryOptions & TextMatchOptions;
 
 const queryAllByText = (
   instance: ReactTestInstance
-): QueryAllByQuery<TextMatch, ByTextOptions> =>
+): InternalQueryAllByQuery<TextMatch, ByTextOptions> =>
   function queryAllByTextFn(text, options = {}) {
     return findAll(
       instance,

--- a/src/queries/text.ts
+++ b/src/queries/text.ts
@@ -4,7 +4,7 @@ import { findAll } from '../helpers/findAll';
 import { getHostComponentNames } from '../helpers/host-component-names';
 import { matchTextContent } from '../helpers/matchers/matchTextContent';
 import { TextMatch, TextMatchOptions } from '../matches';
-import { InternalQueryAllByQuery, makeQueries } from './makeQueries';
+import { makeQueries } from './makeQueries';
 import type {
   FindAllByQuery,
   FindByQuery,
@@ -19,7 +19,7 @@ type ByTextOptions = CommonQueryOptions & TextMatchOptions;
 
 const queryAllByText = (
   instance: ReactTestInstance
-): InternalQueryAllByQuery<TextMatch, ByTextOptions> =>
+): QueryAllByQuery<TextMatch, ByTextOptions> =>
   function queryAllByTextFn(text, options = {}) {
     return findAll(
       instance,

--- a/src/queries/text.ts
+++ b/src/queries/text.ts
@@ -19,7 +19,7 @@ type ByTextOptions = CommonQueryOptions & TextMatchOptions;
 
 const queryAllByText = (
   instance: ReactTestInstance
-): ((text: TextMatch, options?: ByTextOptions) => Array<ReactTestInstance>) =>
+): QueryAllByQuery<TextMatch, ByTextOptions> =>
   function queryAllByTextFn(text, options = {}) {
     return findAll(
       instance,

--- a/src/queries/text.ts
+++ b/src/queries/text.ts
@@ -1,7 +1,6 @@
 import type { ReactTestInstance } from 'react-test-renderer';
-import { filterNodeByType } from '../helpers/filterNodeByType';
 import { findAll } from '../helpers/findAll';
-import { getHostComponentNames } from '../helpers/host-component-names';
+import { isHostText } from '../helpers/host-component-names';
 import { matchTextContent } from '../helpers/matchers/matchTextContent';
 import { TextMatch, TextMatchOptions } from '../matches';
 import { makeQueries } from './makeQueries';
@@ -23,9 +22,7 @@ const queryAllByText = (
   function queryAllByTextFn(text, options = {}) {
     return findAll(
       instance,
-      (node) =>
-        filterNodeByType(node, getHostComponentNames().text) &&
-        matchTextContent(node, text, options),
+      (node) => isHostText(node) && matchTextContent(node, text, options),
       {
         ...options,
         matchDeepestOnly: true,

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -117,7 +117,7 @@ function buildRenderResult(
     rerender: update, // alias for `update`
     toJSON: renderer.toJSON,
     debug: debug(instance, renderer),
-    get root() {
+    get root(): ReactTestInstance {
       return getHostChildren(instance)[0];
     },
     UNSAFE_root: instance,


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

- Updates the return type of all queries to `HostReactTestInstance`
- Moves logic of filtering non host elements in `findAllInternal` rather than on each query level

Now that all queries return host elements, this can be made explicit by a more precise typing. It also ensures that queries will consistently return host elements from now on. I also moved the logic of filtering non host elements in `findAllInternal` rather than on each query level to remove some code duplication and most importantly remove checks that didn't use `isHostElement` and therefore were not explicit.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

All existing tests and type checks pass 
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
