### PR TITLE
fix: fixing TypeScript accessibility issue for custom render function

### DIFF
--- a/src/pure.ts
+++ b/src/pure.ts
@@ -19,6 +19,7 @@ export type {
   RenderOptions,
   RenderResult,
   RenderResult as RenderAPI,
+  DebugFunction,
 } from './render';
 export type { RenderHookOptions, RenderHookResult } from './renderHook';
 export type { Config } from './config';

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -136,7 +136,7 @@ function updateWithAct(
   };
 }
 
-interface DebugFunction {
+export interface DebugFunction {
   (options?: DebugOptions | string): void;
   shallow: (message?: string) => void;
 }


### PR DESCRIPTION
### Summary

This Pull Request addresses a problem encountered when trying to use a custom render function in TypeScript. The issue throws an error:
"Exported variable 'customRender' has or is using name 'DebugFunction' from external module '/node_modules/@testing-library/react-native/build/render' but cannot be named."

To resolve this problem, we're exporting the DebugFunction interface from the module it's declared in. This change will allow the TypeScript compiler to recognize the DebugFunction type when it's used in external modules, thus eliminating the naming error that is currently being thrown.

### Test plan

The error:

![image](https://github.com/callstack/react-native-testing-library/assets/50564212/8fdc576f-bf10-4421-81c4-ccd99c7fc171)


With this change the error goes away:

![image](https://github.com/callstack/react-native-testing-library/assets/50564212/8fff9715-d8ba-4239-afd7-8c5edb7a53c6)
![image](https://github.com/callstack/react-native-testing-library/assets/50564212/777f6639-3d30-4017-9244-f28e2e31362d)

The error can be solved in the custom render by using `RenderResult` as the return type, but it'd be nice to work directly. 😀

![image](https://github.com/callstack/react-native-testing-library/assets/50564212/2b11245d-8572-4882-abce-9e46d133ea56)

