### PR TITLE
feat: add autocomplete for fireEvent event names

### DIFF
--- a/src/fireEvent.ts
+++ b/src/fireEvent.ts
@@ -2,9 +2,9 @@ import { ReactTestInstance } from 'react-test-renderer';
 import {
   ViewProps,
   TextProps,
-  ScrollViewProps,
+  TextInputProps,
   PressableProps,
-  TextInput,
+  ScrollViewProps,
 } from 'react-native';
 import act from './act';
 import { isHostElement } from './helpers/component-tree';
@@ -128,9 +128,9 @@ type OnKeys<T> = keyof {
 type EventName = StringWithAutoComplete<
   | OnKeys<ViewProps>
   | OnKeys<TextProps>
-  | OnKeys<ScrollViewProps>
+  | OnKeys<TextInputProps>
   | OnKeys<PressableProps>
-  | OnKeys<TextInput>
+  | OnKeys<ScrollViewProps>
 >;
 
 function fireEvent(


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This is an attempt to improve `fireEvent`'s DX by adding autocomplete for handler props. `fireEvent` still accepts any string so this is not a breaking change but it now also comes with an autocomplete. The autocomplete will propose any prop name from `ViewProps`, `TextProps`, `ScrollViewProps` or `PressableProps` that starts with on but without the on. So for instance `MomentumScrollEnd` will be proposed because `ScrollViewProps` has the `onMomentumScrollEnd`

![Capture d’écran 2023-07-18 à 09 41 55](https://github.com/callstack/react-native-testing-library/assets/64224599/5c4b2503-0b98-48c5-85e7-e3e29b969785)

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

I have tested manually the autocomplete and made sure that `fireEvent` still accepts any string
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
