### PR TITLE
fix: UserEvent longPress on Text component

### DIFF
--- a/src/user-event/press/__tests__/press.test.tsx
+++ b/src/user-event/press/__tests__/press.test.tsx
@@ -304,7 +304,7 @@ describe('userEvent.press with fake timers', () => {
     expect(mockOnPress).toHaveBeenCalled();
   });
 
-  test('works on Text', async () => {
+  test('press works on Text', async () => {
     const { events, logEvent } = createEventLogger();
 
     render(
@@ -317,9 +317,27 @@ describe('userEvent.press with fake timers', () => {
         press me
       </Text>
     );
-    await userEvent.press(screen.getByText('press me'));
 
+    await userEvent.press(screen.getByText('press me'));
     expect(getEventsName(events)).toEqual(['pressIn', 'press', 'pressOut']);
+  });
+
+  test('longPress works Text', async () => {
+    const { events, logEvent } = createEventLogger();
+
+    render(
+      <Text
+        onPress={logEvent('press')}
+        onPressIn={logEvent('pressIn')}
+        onPressOut={logEvent('pressOut')}
+        onLongPress={logEvent('longPress')}
+      >
+        press me
+      </Text>
+    );
+
+    await userEvent.longPress(screen.getByText('press me'));
+    expect(getEventsName(events)).toEqual(['pressIn', 'longPress', 'pressOut']);
   });
 
   test('doesnt trigger on disabled Text', async () => {
@@ -361,7 +379,7 @@ describe('userEvent.press with fake timers', () => {
     expect(events).toEqual([]);
   });
 
-  test('works on TetInput', async () => {
+  test('press works on TextInput', async () => {
     const { events, logEvent } = createEventLogger();
 
     render(
@@ -371,12 +389,27 @@ describe('userEvent.press with fake timers', () => {
         onPressOut={logEvent('pressOut')}
       />
     );
-    await userEvent.press(screen.getByPlaceholderText('email'));
 
+    await userEvent.press(screen.getByPlaceholderText('email'));
     expect(getEventsName(events)).toEqual(['pressIn', 'pressOut']);
   });
 
-  test('does not call onPressIn and onPressOut on non editable TetInput', async () => {
+  test('longPress works on TextInput', async () => {
+    const { events, logEvent } = createEventLogger();
+
+    render(
+      <TextInput
+        placeholder="email"
+        onPressIn={logEvent('pressIn')}
+        onPressOut={logEvent('pressOut')}
+      />
+    );
+
+    await userEvent.longPress(screen.getByPlaceholderText('email'));
+    expect(getEventsName(events)).toEqual(['pressIn', 'pressOut']);
+  });
+
+  test('does not call onPressIn and onPressOut on non editable TextInput', async () => {
     const { events, logEvent } = createEventLogger();
 
     render(
@@ -387,11 +420,12 @@ describe('userEvent.press with fake timers', () => {
         onPressOut={logEvent('pressOut')}
       />
     );
+
     await userEvent.press(screen.getByPlaceholderText('email'));
     expect(events).toEqual([]);
   });
 
-  test('does not call onPressIn and onPressOut on TetInput with pointer events disabled', async () => {
+  test('does not call onPressIn and onPressOut on TextInput with pointer events disabled', async () => {
     const { events, logEvent } = createEventLogger();
 
     render(
@@ -402,6 +436,7 @@ describe('userEvent.press with fake timers', () => {
         onPressOut={logEvent('pressOut')}
       />
     );
+
     await userEvent.press(screen.getByPlaceholderText('email'));
     expect(events).toEqual([]);
   });

--- a/src/user-event/press/press.ts
+++ b/src/user-event/press/press.ts
@@ -64,7 +64,7 @@ const basePress = async (
 const emitPressablePressEvents = async (
   config: UserEventConfig,
   element: ReactTestInstance,
-  options: PressOptions = { duration: 0 }
+  options: PressOptions
 ) => {
   warnAboutRealTimersIfNeeded();
 
@@ -132,14 +132,14 @@ async function emitTextPressEvents(
   config: UserEventConfig,
   element: ReactTestInstance,
   type: PressType,
-  options?: PressOptions
+  options: PressOptions
 ) {
   await wait(config);
   dispatchEvent(element, 'pressIn', EventBuilder.Common.touch());
 
   dispatchEvent(element, type, EventBuilder.Common.touch());
 
-  await wait(config, options?.duration);
+  await wait(config, options.duration);
   dispatchEvent(element, 'pressOut', EventBuilder.Common.touch());
 }
 
@@ -149,13 +149,13 @@ async function emitTextPressEvents(
 async function emitTextInputPressEvents(
   config: UserEventConfig,
   element: ReactTestInstance,
-  options?: PressOptions
+  options: PressOptions
 ) {
   await wait(config);
   dispatchEvent(element, 'pressIn', EventBuilder.Common.touch());
 
   // Note: TextInput does not have `onPress`/`onLongPress` props.
 
-  await wait(config, options?.duration);
+  await wait(config, options.duration);
   dispatchEvent(element, 'pressOut', EventBuilder.Common.touch());
 }


### PR DESCRIPTION
### Summary

Fixed small issues with `UserEvent.press()`:
* `longPress` should call `onLongPress` on `Text` element
* avoid calling `onPress` on `TextInput` as it's not supported
* consider `Text` to pressable if it has any press-related event handler


### Test plan

Added `longPress` tests for `Text` and `TextInput`