### PR TITLE
feature: userEvent `clear()`

### DIFF
--- a/src/user-event/__tests__/__snapshots__/clear.test.tsx.snap
+++ b/src/user-event/__tests__/__snapshots__/clear.test.tsx.snap
@@ -1,0 +1,269 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`clear() supports basic case: value: "Hello! 1`] = `
+[
+  {
+    "name": "focus",
+    "payload": {
+      "nativeEvent": {
+        "target": 0,
+      },
+    },
+  },
+  {
+    "name": "selectionChange",
+    "payload": {
+      "nativeEvent": {
+        "selection": {
+          "end": 6,
+          "start": 0,
+        },
+      },
+    },
+  },
+  {
+    "name": "keyPress",
+    "payload": {
+      "nativeEvent": {
+        "key": "Backspace",
+      },
+    },
+  },
+  {
+    "name": "change",
+    "payload": {
+      "nativeEvent": {
+        "eventCount": 0,
+        "target": 0,
+        "text": "",
+      },
+    },
+  },
+  {
+    "name": "changeText",
+    "payload": "",
+  },
+  {
+    "name": "selectionChange",
+    "payload": {
+      "nativeEvent": {
+        "selection": {
+          "end": 0,
+          "start": 0,
+        },
+      },
+    },
+  },
+  {
+    "name": "endEditing",
+    "payload": {
+      "nativeEvent": {
+        "target": 0,
+        "text": "",
+      },
+    },
+  },
+  {
+    "name": "blur",
+    "payload": {
+      "nativeEvent": {
+        "target": 0,
+      },
+    },
+  },
+]
+`;
+
+exports[`clear() supports defaultValue prop: defaultValue: "Hello Default!" 1`] = `
+[
+  {
+    "name": "focus",
+    "payload": {
+      "nativeEvent": {
+        "target": 0,
+      },
+    },
+  },
+  {
+    "name": "selectionChange",
+    "payload": {
+      "nativeEvent": {
+        "selection": {
+          "end": 14,
+          "start": 0,
+        },
+      },
+    },
+  },
+  {
+    "name": "keyPress",
+    "payload": {
+      "nativeEvent": {
+        "key": "Backspace",
+      },
+    },
+  },
+  {
+    "name": "change",
+    "payload": {
+      "nativeEvent": {
+        "eventCount": 0,
+        "target": 0,
+        "text": "",
+      },
+    },
+  },
+  {
+    "name": "changeText",
+    "payload": "",
+  },
+  {
+    "name": "selectionChange",
+    "payload": {
+      "nativeEvent": {
+        "selection": {
+          "end": 0,
+          "start": 0,
+        },
+      },
+    },
+  },
+  {
+    "name": "endEditing",
+    "payload": {
+      "nativeEvent": {
+        "target": 0,
+        "text": "",
+      },
+    },
+  },
+  {
+    "name": "blur",
+    "payload": {
+      "nativeEvent": {
+        "target": 0,
+      },
+    },
+  },
+]
+`;
+
+exports[`clear() supports multiline: value: "Hello World!
+How are you?" multiline: true, 1`] = `
+[
+  {
+    "name": "focus",
+    "payload": {
+      "nativeEvent": {
+        "target": 0,
+      },
+    },
+  },
+  {
+    "name": "selectionChange",
+    "payload": {
+      "nativeEvent": {
+        "selection": {
+          "end": 25,
+          "start": 0,
+        },
+      },
+    },
+  },
+  {
+    "name": "keyPress",
+    "payload": {
+      "nativeEvent": {
+        "key": "Backspace",
+      },
+    },
+  },
+  {
+    "name": "textInput",
+    "payload": {
+      "nativeEvent": {
+        "previousText": "Hello World!
+How are you?",
+        "range": {
+          "end": 0,
+          "start": 0,
+        },
+        "target": 0,
+        "text": "",
+      },
+    },
+  },
+  {
+    "name": "change",
+    "payload": {
+      "nativeEvent": {
+        "eventCount": 0,
+        "target": 0,
+        "text": "",
+      },
+    },
+  },
+  {
+    "name": "changeText",
+    "payload": "",
+  },
+  {
+    "name": "selectionChange",
+    "payload": {
+      "nativeEvent": {
+        "selection": {
+          "end": 0,
+          "start": 0,
+        },
+      },
+    },
+  },
+  {
+    "name": "contentSizeChange",
+    "payload": {
+      "nativeEvent": {
+        "contentSize": {
+          "height": 16,
+          "width": 0,
+        },
+        "target": 0,
+      },
+    },
+  },
+  {
+    "name": "endEditing",
+    "payload": {
+      "nativeEvent": {
+        "target": 0,
+        "text": "",
+      },
+    },
+  },
+  {
+    "name": "blur",
+    "payload": {
+      "nativeEvent": {
+        "target": 0,
+      },
+    },
+  },
+]
+`;
+
+exports[`clear() works when not all events have handlers 1`] = `
+[
+  {
+    "name": "changeText",
+    "payload": "",
+  },
+  {
+    "name": "endEditing",
+    "payload": {
+      "nativeEvent": {
+        "target": 0,
+        "text": "",
+      },
+    },
+  },
+]
+`;

--- a/src/user-event/__tests__/clear.test.tsx
+++ b/src/user-event/__tests__/clear.test.tsx
@@ -5,7 +5,6 @@ import { render, userEvent } from '../..';
 
 beforeEach(() => {
   jest.useRealTimers();
-  jest.clearAllMocks();
 });
 
 function renderTextInputWithToolkit(props: TextInputProps = {}) {

--- a/src/user-event/__tests__/clear.test.tsx
+++ b/src/user-event/__tests__/clear.test.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { View, TextInput, TextInputProps } from 'react-native';
 import { createEventLogger } from '../../test-utils/events';
-import { render } from '../../..';
-import { userEvent } from '../..';
+import { render, userEvent } from '../..';
 
 beforeEach(() => {
   jest.useRealTimers();

--- a/src/user-event/__tests__/clear.test.tsx
+++ b/src/user-event/__tests__/clear.test.tsx
@@ -114,11 +114,7 @@ describe('clear()', () => {
     });
 
     const user = userEvent.setup();
-    await expect(
-      user.clear(textInput)
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"clear() only supports editable elements."`
-    );
+    user.clear(textInput);
 
     expect(textInput.props.value).toBe('Hello!');
   });
@@ -130,11 +126,7 @@ describe('clear()', () => {
     });
 
     const user = userEvent.setup();
-    await expect(
-      user.clear(textInput)
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"clear() cannot focus on given element due to "pointerEvents" prop."`
-    );
+    user.clear(textInput);
 
     expect(textInput.props.value).toBe('Hello!');
   });

--- a/src/user-event/__tests__/clear.test.tsx
+++ b/src/user-event/__tests__/clear.test.tsx
@@ -29,21 +29,23 @@ function renderTextInputWithToolkit(props: TextInputProps = {}) {
     />
   );
 
+  const textInput = screen.getByTestId('input');
+
   return {
-    ...screen,
     events,
+    textInput,
   };
 }
 
 describe('clear()', () => {
   it('supports basic case', async () => {
     jest.spyOn(Date, 'now').mockImplementation(() => 100100100100);
-    const { events, ...queries } = renderTextInputWithToolkit({
+    const { textInput, events } = renderTextInputWithToolkit({
       value: 'Hello!',
     });
 
     const user = userEvent.setup();
-    await user.clear(queries.getByTestId('input'));
+    await user.clear(textInput);
 
     const eventNames = events.map((e) => e.name);
     expect(eventNames).toEqual([
@@ -62,12 +64,12 @@ describe('clear()', () => {
 
   it.each(['modern', 'legacy'])('works with %s fake timers', async (type) => {
     jest.useFakeTimers({ legacyFakeTimers: type === 'legacy' });
-    const { events, ...queries } = renderTextInputWithToolkit({
+    const { textInput, events } = renderTextInputWithToolkit({
       value: 'Hello!',
     });
 
     const user = userEvent.setup();
-    await user.clear(queries.getByTestId('input'));
+    await user.clear(textInput);
 
     const eventNames = events.map((e) => e.name);
     expect(eventNames).toEqual([
@@ -83,12 +85,12 @@ describe('clear()', () => {
   });
 
   it('supports defaultValue prop', async () => {
-    const { events, ...queries } = renderTextInputWithToolkit({
+    const { textInput, events } = renderTextInputWithToolkit({
       defaultValue: 'Hello Default!',
     });
 
     const user = userEvent.setup();
-    await user.clear(queries.getByTestId('input'));
+    await user.clear(textInput);
 
     const eventNames = events.map((e) => e.name);
     expect(eventNames).toEqual([
@@ -106,26 +108,45 @@ describe('clear()', () => {
   });
 
   it('does respect editable prop', async () => {
-    const { events, ...queries } = renderTextInputWithToolkit({
+    const { textInput } = renderTextInputWithToolkit({
       value: 'Hello!',
       editable: false,
     });
 
     const user = userEvent.setup();
-    await user.clear(queries.getByTestId('input'));
+    await expect(
+      user.clear(textInput)
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"clear() works only on editable "TextInput" elements."`
+    );
 
-    const eventNames = events.map((e) => e.name);
-    expect(eventNames).toEqual([]);
+    expect(textInput.props.value).toBe('Hello!');
+  });
+
+  it('does respect pointer-events prop', async () => {
+    const { textInput } = renderTextInputWithToolkit({
+      value: 'Hello!',
+      pointerEvents: 'none',
+    });
+
+    const user = userEvent.setup();
+    await expect(
+      user.clear(textInput)
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"clear() works only on focusable "TextInput" elements."`
+    );
+
+    expect(textInput.props.value).toBe('Hello!');
   });
 
   it('supports multiline', async () => {
-    const { events, ...queries } = renderTextInputWithToolkit({
+    const { textInput, events } = renderTextInputWithToolkit({
       value: 'Hello World!\nHow are you?',
       multiline: true,
     });
 
     const user = userEvent.setup();
-    await user.clear(queries.getByTestId('input'));
+    await user.clear(textInput);
 
     const eventNames = events.map((e) => e.name);
     expect(eventNames).toEqual([

--- a/src/user-event/__tests__/clear.test.tsx
+++ b/src/user-event/__tests__/clear.test.tsx
@@ -117,7 +117,7 @@ describe('clear()', () => {
     await expect(
       user.clear(textInput)
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"clear() works only on editable "TextInput" elements."`
+      `"clear() only supports editable elements."`
     );
 
     expect(textInput.props.value).toBe('Hello!');
@@ -133,7 +133,7 @@ describe('clear()', () => {
     await expect(
       user.clear(textInput)
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"clear() works only on focusable "TextInput" elements."`
+      `"clear() cannot focus on given element due to "pointerEvents" prop."`
     );
 
     expect(textInput.props.value).toBe('Hello!');
@@ -193,7 +193,7 @@ describe('clear()', () => {
     await expect(
       user.clear(screen.getByTestId('input'))
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"clear() works only with host "TextInput" elements. Passed element has type "View"."`
+      `"clear() only supports host "TextInput" elements. Passed element has type: "View"."`
     );
   });
 

--- a/src/user-event/__tests__/clear.test.tsx
+++ b/src/user-event/__tests__/clear.test.tsx
@@ -1,0 +1,206 @@
+import * as React from 'react';
+import { View, TextInput, TextInputProps } from 'react-native';
+import { createEventLogger } from '../../test-utils/events';
+import { render } from '../../..';
+import { userEvent } from '../..';
+
+beforeEach(() => {
+  jest.useRealTimers();
+  jest.clearAllMocks();
+});
+
+function renderTextInputWithToolkit(props: TextInputProps = {}) {
+  const { events, logEvent } = createEventLogger();
+
+  const screen = render(
+    <TextInput
+      testID="input"
+      onFocus={logEvent('focus')}
+      onBlur={logEvent('blur')}
+      onPressIn={logEvent('pressIn')}
+      onPressOut={logEvent('pressOut')}
+      onChange={logEvent('change')}
+      onChangeText={logEvent('changeText')}
+      onKeyPress={logEvent('keyPress')}
+      onTextInput={logEvent('textInput')}
+      onSelectionChange={logEvent('selectionChange')}
+      onSubmitEditing={logEvent('submitEditing')}
+      onEndEditing={logEvent('endEditing')}
+      onContentSizeChange={logEvent('contentSizeChange')}
+      {...props}
+    />
+  );
+
+  return {
+    ...screen,
+    events,
+  };
+}
+
+describe('clear()', () => {
+  it('supports basic case', async () => {
+    jest.spyOn(Date, 'now').mockImplementation(() => 100100100100);
+    const { events, ...queries } = renderTextInputWithToolkit({
+      value: 'Hello!',
+    });
+
+    const user = userEvent.setup();
+    await user.clear(queries.getByTestId('input'));
+
+    const eventNames = events.map((e) => e.name);
+    expect(eventNames).toEqual([
+      'focus',
+      'selectionChange',
+      'keyPress',
+      'change',
+      'changeText',
+      'selectionChange',
+      'endEditing',
+      'blur',
+    ]);
+
+    expect(events).toMatchSnapshot('value: "Hello!');
+  });
+
+  it.each(['modern', 'legacy'])('works with %s fake timers', async (type) => {
+    jest.useFakeTimers({ legacyFakeTimers: type === 'legacy' });
+    const { events, ...queries } = renderTextInputWithToolkit({
+      value: 'Hello!',
+    });
+
+    const user = userEvent.setup();
+    await user.clear(queries.getByTestId('input'));
+
+    const eventNames = events.map((e) => e.name);
+    expect(eventNames).toEqual([
+      'focus',
+      'selectionChange',
+      'keyPress',
+      'change',
+      'changeText',
+      'selectionChange',
+      'endEditing',
+      'blur',
+    ]);
+  });
+
+  it('supports defaultValue prop', async () => {
+    const { events, ...queries } = renderTextInputWithToolkit({
+      defaultValue: 'Hello Default!',
+    });
+
+    const user = userEvent.setup();
+    await user.clear(queries.getByTestId('input'));
+
+    const eventNames = events.map((e) => e.name);
+    expect(eventNames).toEqual([
+      'focus',
+      'selectionChange',
+      'keyPress',
+      'change',
+      'changeText',
+      'selectionChange',
+      'endEditing',
+      'blur',
+    ]);
+
+    expect(events).toMatchSnapshot('defaultValue: "Hello Default!"');
+  });
+
+  it('does respect editable prop', async () => {
+    const { events, ...queries } = renderTextInputWithToolkit({
+      value: 'Hello!',
+      editable: false,
+    });
+
+    const user = userEvent.setup();
+    await user.clear(queries.getByTestId('input'));
+
+    const eventNames = events.map((e) => e.name);
+    expect(eventNames).toEqual([]);
+  });
+
+  it('supports multiline', async () => {
+    const { events, ...queries } = renderTextInputWithToolkit({
+      value: 'Hello World!\nHow are you?',
+      multiline: true,
+    });
+
+    const user = userEvent.setup();
+    await user.clear(queries.getByTestId('input'));
+
+    const eventNames = events.map((e) => e.name);
+    expect(eventNames).toEqual([
+      'focus',
+      'selectionChange',
+      'keyPress',
+      'textInput',
+      'change',
+      'changeText',
+      'selectionChange',
+      'contentSizeChange',
+      'endEditing',
+      'blur',
+    ]);
+
+    expect(events).toMatchSnapshot(
+      'value: "Hello World!\nHow are you?" multiline: true,'
+    );
+  });
+
+  it('works when not all events have handlers', async () => {
+    const { events, logEvent } = createEventLogger();
+    const screen = render(
+      <TextInput
+        testID="input"
+        onChangeText={logEvent('changeText')}
+        onEndEditing={logEvent('endEditing')}
+      />
+    );
+
+    const user = userEvent.setup();
+    await user.clear(screen.getByTestId('input'));
+
+    const eventNames = events.map((e) => e.name);
+    expect(eventNames).toEqual(['changeText', 'endEditing']);
+
+    expect(events).toMatchSnapshot();
+  });
+
+  it('does NOT work on View', async () => {
+    const screen = render(<View testID="input" />);
+
+    const user = userEvent.setup();
+    await expect(
+      user.clear(screen.getByTestId('input'))
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"clear() works only with host "TextInput" elements. Passed element has type "View"."`
+    );
+  });
+
+  // View that ignores props type checking
+  const AnyView = View as React.ComponentType<any>;
+
+  it('does NOT bubble up', async () => {
+    const parentHandler = jest.fn();
+    const screen = render(
+      <AnyView
+        onChangeText={parentHandler}
+        onChange={parentHandler}
+        onKeyPress={parentHandler}
+        onTextInput={parentHandler}
+        onFocus={parentHandler}
+        onBlur={parentHandler}
+        onEndEditing={parentHandler}
+        onPressIn={parentHandler}
+        onPressOut={parentHandler}
+      >
+        <TextInput testID="input" />
+      </AnyView>
+    );
+
+    const user = userEvent.setup();
+    await user.clear(screen.getByTestId('input'));
+    expect(parentHandler).not.toHaveBeenCalled();
+  });
+});

--- a/src/user-event/clear.ts
+++ b/src/user-event/clear.ts
@@ -1,14 +1,10 @@
 import { ReactTestInstance } from 'react-test-renderer';
 import { ErrorWithStack } from '../helpers/errors';
 import { isHostTextInput } from '../helpers/host-component-names';
+import { isPointerEventEnabled } from '../helpers/pointer-events';
 import { EventBuilder } from './event-builder';
 import { UserEventInstance } from './setup';
-import {
-  dispatchEvent,
-  wait,
-  isEditableTextInput,
-  isFocusableTextInput,
-} from './utils';
+import { dispatchEvent, wait, isEditableTextInput } from './utils';
 import { emitTypingEvents } from './type/type';
 
 export async function clear(
@@ -17,21 +13,18 @@ export async function clear(
 ): Promise<void> {
   if (!isHostTextInput(element)) {
     throw new ErrorWithStack(
-      `clear() works only with host "TextInput" elements. Passed element has type "${element.type}".`,
+      `clear() only supports host "TextInput" elements. Passed element has type: "${element.type}".`,
       clear
     );
   }
 
   if (!isEditableTextInput(element)) {
-    throw new ErrorWithStack(
-      `clear() works only on editable "TextInput" elements.`,
-      clear
-    );
+    throw new ErrorWithStack('clear() only supports editable elements.', clear);
   }
 
-  if (!isFocusableTextInput(element)) {
+  if (!isPointerEventEnabled(element)) {
     throw new ErrorWithStack(
-      `clear() works only on focusable "TextInput" elements.`,
+      'clear() cannot focus on given element due to "pointerEvents" prop.',
       clear
     );
   }

--- a/src/user-event/clear.ts
+++ b/src/user-event/clear.ts
@@ -18,15 +18,8 @@ export async function clear(
     );
   }
 
-  if (!isEditableTextInput(element)) {
-    throw new ErrorWithStack('clear() only supports editable elements.', clear);
-  }
-
-  if (!isPointerEventEnabled(element)) {
-    throw new ErrorWithStack(
-      'clear() cannot focus on given element due to "pointerEvents" prop.',
-      clear
-    );
+  if (!isEditableTextInput(element) || !isPointerEventEnabled(element)) {
+    return;
   }
 
   // 1. Enter element

--- a/src/user-event/clear.ts
+++ b/src/user-event/clear.ts
@@ -1,10 +1,14 @@
 import { ReactTestInstance } from 'react-test-renderer';
 import { ErrorWithStack } from '../helpers/errors';
 import { isHostTextInput } from '../helpers/host-component-names';
-import { isPointerEventEnabled } from '../helpers/pointer-events';
 import { EventBuilder } from './event-builder';
 import { UserEventInstance } from './setup';
-import { dispatchEvent, wait } from './utils';
+import {
+  dispatchEvent,
+  wait,
+  isEditableTextInput,
+  isFocusableTextInput,
+} from './utils';
 import { emitTypingEvents } from './type/type';
 
 export async function clear(
@@ -18,9 +22,18 @@ export async function clear(
     );
   }
 
-  // Skip events if the element is disabled
-  if (element.props.editable === false || !isPointerEventEnabled(element)) {
-    return;
+  if (!isEditableTextInput(element)) {
+    throw new ErrorWithStack(
+      `clear() works only on editable "TextInput" elements.`,
+      clear
+    );
+  }
+
+  if (!isFocusableTextInput(element)) {
+    throw new ErrorWithStack(
+      `clear() works only on focusable "TextInput" elements.`,
+      clear
+    );
   }
 
   // 1. Enter element

--- a/src/user-event/clear.ts
+++ b/src/user-event/clear.ts
@@ -1,0 +1,60 @@
+import { ReactTestInstance } from 'react-test-renderer';
+import { ErrorWithStack } from '../helpers/errors';
+import { isHostTextInput } from '../helpers/host-component-names';
+import { isPointerEventEnabled } from '../helpers/pointer-events';
+import { EventBuilder } from './event-builder';
+import { UserEventInstance } from './setup';
+import { dispatchEvent, wait } from './utils';
+import { emitTypingEvents } from './type/type';
+
+export async function clear(
+  this: UserEventInstance,
+  element: ReactTestInstance
+): Promise<void> {
+  if (!isHostTextInput(element)) {
+    throw new ErrorWithStack(
+      `clear() works only with host "TextInput" elements. Passed element has type "${element.type}".`,
+      clear
+    );
+  }
+
+  // Skip events if the element is disabled
+  if (element.props.editable === false || !isPointerEventEnabled(element)) {
+    return;
+  }
+
+  // 1. Enter element
+  dispatchEvent(element, 'focus', EventBuilder.Common.focus());
+
+  // 2. Select all
+  const previousText = element.props.value ?? element.props.defaultValue ?? '';
+  const selectionRange = {
+    start: 0,
+    end: previousText.length,
+  };
+  dispatchEvent(
+    element,
+    'selectionChange',
+    EventBuilder.TextInput.selectionChange(selectionRange)
+  );
+
+  // 3. Press backspace
+  const finalText = '';
+  await emitTypingEvents(
+    this.config,
+    element,
+    'Backspace',
+    finalText,
+    previousText
+  );
+
+  // 4. Exit element
+  await wait(this.config);
+  dispatchEvent(
+    element,
+    'endEditing',
+    EventBuilder.TextInput.endEditing(finalText)
+  );
+
+  dispatchEvent(element, 'blur', EventBuilder.Common.blur());
+}

--- a/src/user-event/index.ts
+++ b/src/user-event/index.ts
@@ -14,4 +14,5 @@ export const userEvent = {
     setup().longPress(element, options),
   type: (element: ReactTestInstance, text: string, options?: TypeOptions) =>
     setup().type(element, text, options),
+  clear: (element: ReactTestInstance) => setup().clear(element),
 };

--- a/src/user-event/press/press.ts
+++ b/src/user-event/press/press.ts
@@ -2,13 +2,15 @@ import { ReactTestInstance } from 'react-test-renderer';
 import act from '../../act';
 import { getHostParent } from '../../helpers/component-tree';
 import { isPointerEventEnabled } from '../../helpers/pointer-events';
-import {
-  isHostText,
-  isHostTextInput,
-} from '../../helpers/host-component-names';
+import { isHostText } from '../../helpers/host-component-names';
 import { EventBuilder } from '../event-builder';
 import { UserEventConfig, UserEventInstance } from '../setup';
-import { dispatchEvent, wait, warnAboutRealTimersIfNeeded } from '../utils';
+import {
+  dispatchEvent,
+  isEditableTextInput,
+  wait,
+  warnAboutRealTimersIfNeeded,
+} from '../utils';
 import { DEFAULT_MIN_PRESS_DURATION } from './constants';
 
 export interface PressOptions {
@@ -51,7 +53,7 @@ const basePress = async (
     return;
   }
 
-  if (isEnabledTextInput(element)) {
+  if (isEditableTextInput(element) && isPointerEventEnabled(element)) {
     await emitTextInputPressEvents(config, element, options);
     return;
   }
@@ -122,14 +124,6 @@ const isPressableText = (element: ReactTestInstance) => {
     isPointerEventEnabled(element) &&
     !element.props.disabled &&
     hasPressEventHandler
-  );
-};
-
-const isEnabledTextInput = (element: ReactTestInstance) => {
-  return (
-    isHostTextInput(element) &&
-    isPointerEventEnabled(element) &&
-    element.props.editable !== false
   );
 };
 

--- a/src/user-event/setup/setup.ts
+++ b/src/user-event/setup/setup.ts
@@ -2,6 +2,7 @@ import { ReactTestInstance } from 'react-test-renderer';
 import { jestFakeTimersAreEnabled } from '../../helpers/timers';
 import { PressOptions, press, longPress } from '../press';
 import { TypeOptions, type } from '../type';
+import { clear } from '../clear';
 
 export interface UserEventSetupOptions {
   /**
@@ -84,7 +85,7 @@ export interface UserEventInstance {
   ) => Promise<void>;
 
   /**
-   * Simulate user pressing on given `TextInput` element and typing given text.
+   * Simulate user pressing on a given `TextInput` element and typing given text.
    *
    * This method will trigger the events for each character of the text:
    * `keyPress`, `change`, `changeText`, `endEditing`, etc.
@@ -92,7 +93,7 @@ export interface UserEventInstance {
    * It will also trigger events connected with entering and leaving the text
    * input.
    *
-   * The exact events sent depend on the props of TextInput (`editable`,
+   * The exact events sent depend on the props of the TextInput (`editable`,
    * `multiline`, value, defaultValue, etc) and passed options.
    *
    * @param element TextInput element to type on
@@ -108,6 +109,19 @@ export interface UserEventInstance {
     text: string,
     options?: TypeOptions
   ) => Promise<void>;
+
+  /**
+   * Simulate user clearing the text of a given `TextInput` element.
+   *
+   * This method will simulate:
+   * 1. entering TextInput
+   * 2. selecting all text
+   * 3. pressing backspace to delete all text
+   * 4. leaving TextInput
+   *
+   * @param element TextInput element to clear
+   */
+  clear: (element: ReactTestInstance) => Promise<void>;
 }
 
 function createInstance(config: UserEventConfig): UserEventInstance {
@@ -120,6 +134,7 @@ function createInstance(config: UserEventConfig): UserEventInstance {
     press: press.bind(instance),
     longPress: longPress.bind(instance),
     type: type.bind(instance),
+    clear: clear.bind(instance),
   };
 
   Object.assign(instance, api);

--- a/src/user-event/type/__tests__/type-managed.test.tsx
+++ b/src/user-event/type/__tests__/type-managed.test.tsx
@@ -6,7 +6,6 @@ import { userEvent } from '../..';
 
 beforeEach(() => {
   jest.useRealTimers();
-  jest.clearAllMocks();
 });
 
 interface ManagedTextInputProps {

--- a/src/user-event/type/__tests__/type.test.tsx
+++ b/src/user-event/type/__tests__/type.test.tsx
@@ -6,7 +6,6 @@ import { userEvent } from '../..';
 
 beforeEach(() => {
   jest.useRealTimers();
-  jest.clearAllMocks();
 });
 
 function renderTextInputWithToolkit(props: TextInputProps = {}) {

--- a/src/user-event/utils/__tests__/wait.test.ts
+++ b/src/user-event/utils/__tests__/wait.test.ts
@@ -2,7 +2,6 @@ import { wait } from '../wait';
 
 beforeEach(() => {
   jest.useRealTimers();
-  jest.clearAllMocks();
 });
 
 describe('wait()', () => {

--- a/src/user-event/utils/host-components.ts
+++ b/src/user-event/utils/host-components.ts
@@ -1,0 +1,11 @@
+import { ReactTestInstance } from 'react-test-renderer';
+import { isPointerEventEnabled } from '../../helpers/pointer-events';
+import { isHostTextInput } from '../../helpers/host-component-names';
+
+export function isEditableTextInput(element: ReactTestInstance) {
+  return isHostTextInput(element) && element.props.editable !== false;
+}
+
+export function isFocusableTextInput(element: ReactTestInstance) {
+  return isHostTextInput(element) && isPointerEventEnabled(element);
+}

--- a/src/user-event/utils/host-components.ts
+++ b/src/user-event/utils/host-components.ts
@@ -1,11 +1,6 @@
 import { ReactTestInstance } from 'react-test-renderer';
-import { isPointerEventEnabled } from '../../helpers/pointer-events';
 import { isHostTextInput } from '../../helpers/host-component-names';
 
 export function isEditableTextInput(element: ReactTestInstance) {
   return isHostTextInput(element) && element.props.editable !== false;
-}
-
-export function isFocusableTextInput(element: ReactTestInstance) {
-  return isHostTextInput(element) && isPointerEventEnabled(element);
 }

--- a/src/user-event/utils/index.ts
+++ b/src/user-event/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './content-size';
 export * from './dispatch-event';
+export * from './host-components';
 export * from './text-range';
 export * from './wait';
 export * from './warn-about-real-timers';

--- a/src/user-event/utils/text-range.ts
+++ b/src/user-event/utils/text-range.ts
@@ -2,10 +2,3 @@ export interface TextRange {
   start: number;
   end: number;
 }
-
-export function getTextRange(text: string): TextRange {
-  return {
-    start: text.length,
-    end: text.length,
-  };
-}

--- a/website/docs/UserEvent.md
+++ b/website/docs/UserEvent.md
@@ -14,6 +14,8 @@ title: User Event
 - [`type()`](#type)
   - [Options](#options-2)
   - [Sequence of events](#sequence-of-events)
+- [`clear()`](#clear)
+  - [Sequence of events](#sequence-of-events-1)
 
 :::caution
 User Event API is in beta stage.
@@ -108,6 +110,10 @@ This helper simulates user focusing on `TextInput` element, typing `text` one ch
 
 This function supports only host `TextInput` elements. Passing other element type will result in throwing error.
 
+:::note
+This function will add text to the text already present in the text input (as specified by `value` or `defaultValue` props). In order to replace existing text, use [`clear()`](#clear) helper first.
+:::
+
 ### Options
  - `skipPress` - if true, `pressIn` and `pressOut` events will not be triggered.
  - `submitEditing` - if true, `submitEditing` event will be triggered after typing the text.
@@ -141,3 +147,45 @@ The `textInput` event is sent only for mutliline text inputs.
 
 The `submitEditing` event is skipped by default. It can sent by setting `submitEditing: true` option.
 
+## `clear()`
+
+```ts
+clear(
+  element: ReactTestInstance,
+}
+```
+
+Example
+```ts
+const user = userEvent.setup();
+await user.clear(textInput);
+```
+
+This helper simulates user clearing content of `TextInput` element.
+
+This function supports only host `TextInput` elements. Passing other element type will result in throwing error.
+
+### Sequence of events
+
+The sequence of events depends on `multiline` prop, as well as passed options.
+
+Events will not be emitted if `editable` prop is set to `false`.
+
+**Entering the element**:
+- `focus`
+
+**Selecting all content**:
+- `selectionChange`
+
+**Pressing backspace**:
+- `keyPress`
+- `textInput` (optional)
+- `change`
+- `changeText`
+- `selectionChange`
+
+The `textInput` event is sent only for mutliline text inputs.
+
+**Leaving the element**:
+- `endEditing`
+- `blur`


### PR DESCRIPTION
### Summary

Method for clearing the content of `TextInput` element. This method is useful as `type()` helper, following OG User Event implementation, is appending text and not replacing it. Hence, users need a way to clear it in some cases. Currently they have to resort to `fireEvent.changeText(element, '')` workaround.

### Test plan

Added tests based on subset `type()` tests.