### PR TITLE
chore: remove negative "files" entry which confused Yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "jest-preset/",
     "typings/index.flow.js",
     "pure.js",
-    "dont-cleanup-after-each.js",
-    "!**/test-utils"
+    "dont-cleanup-after-each.js"
   ],
   "devDependencies": {
     "@babel/cli": "^7.19.3",


### PR DESCRIPTION
### Summary

Seems like negative `files` entries confuse Yarn, so that it bundles all folders (e.g. `website`, `examples`, etc in the NPM package).

https://packagephobia.com/result?p=@testing-library/react-native@12.1.3

Fixes #1452 

See [Yarn issue](https://github.com/yarnpkg/yarn/issues/8332)

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
