### PR TITLE
feat: `toBeEmptyElement` matcher

### DIFF
--- a/src/matchers/__tests__/to-be-empty-element.test.tsx
+++ b/src/matchers/__tests__/to-be-empty-element.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View } from 'react-native';
+import { render, screen } from '../..';
+import '../extend-expect';
+
+test('.toBeEmptyElement', () => {
+  render(
+    <View testID="not-empty">
+      <View testID="empty" />
+    </View>
+  );
+
+  const empty = screen.getByTestId('empty');
+  const notEmpty = screen.queryByTestId('not-empty');
+  const nonExistentElement = screen.queryByTestId('not-exists');
+  const fakeElement = { thisIsNot: 'an html element' };
+
+  expect(empty).toBeEmptyElement();
+  expect(notEmpty).not.toBeEmptyElement();
+
+  expect(() => expect(empty).not.toBeEmptyElement()).toThrow();
+
+  expect(() => expect(notEmpty).toBeEmptyElement()).toThrow();
+
+  expect(() => expect(fakeElement).toBeEmptyElement()).toThrow();
+
+  expect(() => {
+    expect(nonExistentElement).toBeEmptyElement();
+  }).toThrow();
+});

--- a/src/matchers/__tests__/to-be-empty-element.test.tsx
+++ b/src/matchers/__tests__/to-be-empty-element.test.tsx
@@ -3,7 +3,13 @@ import { View } from 'react-native';
 import { render, screen } from '../..';
 import '../extend-expect';
 
-test('.toBeEmptyElement', () => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function DoNotRenderChildren({ children }: { children: React.ReactNode }) {
+  // Intentionally do not render children.
+  return null;
+}
+
+test('toBeEmptyElement()', () => {
   render(
     <View testID="not-empty">
       <View testID="empty" />
@@ -11,20 +17,55 @@ test('.toBeEmptyElement', () => {
   );
 
   const empty = screen.getByTestId('empty');
-  const notEmpty = screen.queryByTestId('not-empty');
-  const nonExistentElement = screen.queryByTestId('not-exists');
-  const fakeElement = { thisIsNot: 'an html element' };
-
   expect(empty).toBeEmptyElement();
+  expect(() => expect(empty).not.toBeEmptyElement())
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).not.toBeEmptyElement()
+
+    Received:
+      (no elements)"
+  `);
+
+  const notEmpty = screen.getByTestId('not-empty');
   expect(notEmpty).not.toBeEmptyElement();
+  expect(() => expect(notEmpty).toBeEmptyElement())
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).toBeEmptyElement()
 
-  expect(() => expect(empty).not.toBeEmptyElement()).toThrow();
+    Received:
+      <View
+        testID="empty"
+      />"
+  `);
+});
 
-  expect(() => expect(notEmpty).toBeEmptyElement()).toThrow();
+test('toBeEmptyElement() ignores composite-only children', () => {
+  render(
+    <View testID="view">
+      <DoNotRenderChildren>
+        <View testID="not-rendered" />
+      </DoNotRenderChildren>
+    </View>
+  );
 
-  expect(() => expect(fakeElement).toBeEmptyElement()).toThrow();
+  const view = screen.getByTestId('view');
+  expect(view).toBeEmptyElement();
+  expect(() => expect(view).not.toBeEmptyElement())
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).not.toBeEmptyElement()
 
+    Received:
+      (no elements)"
+  `);
+});
+
+test('toBeEmptyElement() on null element', () => {
   expect(() => {
-    expect(nonExistentElement).toBeEmptyElement();
-  }).toThrow();
+    expect(null).toBeEmptyElement();
+  }).toThrowErrorMatchingInlineSnapshot(`
+    "expect(received).toBeEmptyElement()
+
+    received value must be a host element.
+    Received has value: null"
+  `);
 });

--- a/src/matchers/__tests__/utils.test.tsx
+++ b/src/matchers/__tests__/utils.test.tsx
@@ -8,7 +8,7 @@ function fakeMatcher() {
 }
 
 test('formatElement', () => {
-  expect(formatElement(null)).toMatchInlineSnapshot(`"null"`);
+  expect(formatElement(null)).toMatchInlineSnapshot(`"  null"`);
 });
 
 test('checkHostElement allows host element', () => {

--- a/src/matchers/extend-expect.d.ts
+++ b/src/matchers/extend-expect.d.ts
@@ -1,8 +1,6 @@
-import { TextMatch, TextMatchOptions } from '../matches';
-
 export interface JestNativeMatchers<R> {
   toBeOnTheScreen(): R;
-  toHaveTextContent(text: TextMatch, options?: TextMatchOptions): R;
+  toBeEmptyElement(): R;
 }
 
 // Implicit Jest global `expect`.

--- a/src/matchers/extend-expect.ts
+++ b/src/matchers/extend-expect.ts
@@ -1,7 +1,9 @@
 /// <reference path="./extend-expect.d.ts" />
 
 import { toBeOnTheScreen } from './to-be-on-the-screen';
+import { toBeEmptyElement } from './to-be-empty-element';
 
 expect.extend({
   toBeOnTheScreen,
+  toBeEmptyElement,
 });

--- a/src/matchers/index.tsx
+++ b/src/matchers/index.tsx
@@ -1,1 +1,2 @@
 export { toBeOnTheScreen } from './to-be-on-the-screen';
+export { toBeEmptyElement } from './to-be-empty-element';

--- a/src/matchers/to-be-empty-element.tsx
+++ b/src/matchers/to-be-empty-element.tsx
@@ -1,7 +1,7 @@
 import { ReactTestInstance } from 'react-test-renderer';
-import { matcherHint, printReceived } from 'jest-matcher-utils';
+import { matcherHint, RECEIVED_COLOR } from 'jest-matcher-utils';
 import { getHostChildren } from '../helpers/component-tree';
-import { checkHostElement } from './utils';
+import { checkHostElement, formatElementArray } from './utils';
 
 export function toBeEmptyElement(
   this: jest.MatcherContext,
@@ -9,10 +9,10 @@ export function toBeEmptyElement(
 ) {
   checkHostElement(element, toBeEmptyElement, this);
 
-  const pass = getHostChildren(element).length === 0;
+  const hostChildren = getHostChildren(element);
 
   return {
-    pass,
+    pass: hostChildren.length === 0,
     message: () => {
       return [
         matcherHint(
@@ -22,7 +22,7 @@ export function toBeEmptyElement(
         ),
         '',
         'Received:',
-        `  ${printReceived(element.children)}`,
+        `${RECEIVED_COLOR(formatElementArray(hostChildren))}`,
       ].join('\n');
     },
   };

--- a/src/matchers/to-be-empty-element.tsx
+++ b/src/matchers/to-be-empty-element.tsx
@@ -1,0 +1,29 @@
+import { ReactTestInstance } from 'react-test-renderer';
+import { matcherHint, printReceived } from 'jest-matcher-utils';
+import { getHostChildren } from '../helpers/component-tree';
+import { checkHostElement } from './utils';
+
+export function toBeEmptyElement(
+  this: jest.MatcherContext,
+  element: ReactTestInstance
+) {
+  checkHostElement(element, toBeEmptyElement, this);
+
+  const pass = getHostChildren(element).length === 0;
+
+  return {
+    pass,
+    message: () => {
+      return [
+        matcherHint(
+          `${this.isNot ? '.not' : ''}.toBeEmptyElement`,
+          'element',
+          ''
+        ),
+        '',
+        'Received:',
+        `  ${printReceived(element.children)}`,
+      ].join('\n');
+    },
+  };
+}

--- a/src/matchers/utils.tsx
+++ b/src/matchers/utils.tsx
@@ -69,7 +69,7 @@ export function checkHostElement(
  */
 export function formatElement(element: ReactTestInstance | null) {
   if (element == null) {
-    return 'null';
+    return '  null';
   }
 
   return redent(
@@ -90,6 +90,14 @@ export function formatElement(element: ReactTestInstance | null) {
     ),
     2
   );
+}
+
+export function formatElementArray(elements: ReactTestInstance[]) {
+  if (elements.length === 0) {
+    return '  (no elements)';
+  }
+
+  return redent(elements.map(formatElement).join('\n'), 2);
 }
 
 export function formatMessage(


### PR DESCRIPTION
### Summary

Fixes #1459 

### Test plan

`yarn test`
