### PR TITLE
fix: flatlist not rendering in rntl repo

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -12,7 +12,6 @@ module.exports = {
       },
     ],
   ],
-  plugins: ['@babel/plugin-proposal-class-properties'],
   env: {
     test: {
       // https://github.com/react-native-community/upgrade-support/issues/152

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@babel/cli": "^7.19.3",
     "@babel/core": "^7.20.2",
-    "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-transform-flow-strip-types": "^7.19.0",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-flow": "^7.18.6",

--- a/src/__tests__/__snapshots__/render-debug.test.tsx.snap
+++ b/src/__tests__/__snapshots__/render-debug.test.tsx.snap
@@ -393,7 +393,7 @@ exports[`debug: shallow 1`] = `
     value=""
   />
   <MyButton
-    onPress={[Function anonymous]}
+    onPress={[Function changeFresh]}
     type="primary"
   >
     Change freshness!
@@ -445,7 +445,7 @@ exports[`debug: shallow with message 1`] = `
     value=""
   />
   <MyButton
-    onPress={[Function anonymous]}
+    onPress={[Function changeFresh]}
     type="primary"
   >
     Change freshness!

--- a/src/__tests__/react-native-api.test.tsx
+++ b/src/__tests__/react-native-api.test.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { View, Text, TextInput, Switch } from 'react-native';
+import {
+  View,
+  Text,
+  TextInput,
+  Switch,
+  ScrollView,
+  FlatList,
+} from 'react-native';
 import { render } from '..';
 
 /**
@@ -122,5 +129,83 @@ test('React Native API assumption: <Switch> renders single host element', () => 
       testID="test"
       value={true}
     />
+  `);
+});
+
+test('ScrollView renders correctly', () => {
+  const screen = render(
+    <ScrollView testID="scrollView">
+      <View testID="view" />
+    </ScrollView>
+  );
+
+  expect(screen.toJSON()).toMatchInlineSnapshot(`
+    <RCTScrollView
+      testID="scrollView"
+    >
+      <View>
+        <View
+          testID="view"
+        />
+      </View>
+    </RCTScrollView>
+  `);
+});
+
+test('FlatList renders correctly', () => {
+  const screen = render(
+    <FlatList
+      testID="flatList"
+      data={[1, 2]}
+      renderItem={({ item }) => <Text>{item}</Text>}
+    />
+  );
+
+  expect(screen.toJSON()).toMatchInlineSnapshot(`
+    <RCTScrollView
+      data={
+        [
+          1,
+          2,
+        ]
+      }
+      getItem={[Function]}
+      getItemCount={[Function]}
+      keyExtractor={[Function]}
+      onContentSizeChange={[Function]}
+      onLayout={[Function]}
+      onMomentumScrollBegin={[Function]}
+      onMomentumScrollEnd={[Function]}
+      onScroll={[Function]}
+      onScrollBeginDrag={[Function]}
+      onScrollEndDrag={[Function]}
+      removeClippedSubviews={false}
+      renderItem={[Function]}
+      scrollEventThrottle={50}
+      stickyHeaderIndices={[]}
+      testID="flatList"
+      viewabilityConfigCallbackPairs={[]}
+    >
+      <View>
+        <View
+          onFocusCapture={[Function]}
+          onLayout={[Function]}
+          style={null}
+        >
+          <Text>
+            1
+          </Text>
+        </View>
+        <View
+          onFocusCapture={[Function]}
+          onLayout={[Function]}
+          style={null}
+        >
+          <Text>
+            2
+          </Text>
+        </View>
+      </View>
+    </RCTScrollView>
   `);
 });

--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import * as React from 'react';
-import { View, Text, TextInput, Pressable, FlatList } from 'react-native';
+import { View, Text, TextInput, Pressable } from 'react-native';
 import { getConfig, resetToDefaults } from '../config';
 import { render, screen, fireEvent, RenderAPI } from '..';
 
@@ -253,16 +253,4 @@ test('render calls detects host component names', () => {
 
   render(<View testID="test" />);
   expect(getConfig().hostComponentNames).not.toBeUndefined();
-});
-
-test('render FlatList', () => {
-  const screen = render(
-    <FlatList
-      testID="flatList"
-      data={[1, 2, 3]}
-      renderItem={({ item }) => <Text>{item}</Text>}
-    />
-  );
-
-  expect(screen.getByTestId('flatList')).toBeTruthy();
 });

--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import * as React from 'react';
-import { View, Text, TextInput, Pressable } from 'react-native';
+import { View, Text, TextInput, Pressable, FlatList } from 'react-native';
 import { getConfig, resetToDefaults } from '../config';
 import { render, screen, fireEvent, RenderAPI } from '..';
 
@@ -253,4 +253,16 @@ test('render calls detects host component names', () => {
 
   render(<View testID="test" />);
   expect(getConfig().hostComponentNames).not.toBeUndefined();
+});
+
+test('render FlatList', () => {
+  const screen = render(
+    <FlatList
+      testID="flatList"
+      data={[1, 2, 3]}
+      renderItem={({ item }) => <Text>{item}</Text>}
+    />
+  );
+
+  expect(screen.getByTestId('flatList')).toBeTruthy();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -312,7 +312,7 @@
     "@babel/helper-remap-async-to-generator" "^7.18.9"
     "@babel/plugin-syntax-async-generators" "^7.8.4"
 
-"@babel/plugin-proposal-class-properties@^7.0.0", "@babel/plugin-proposal-class-properties@^7.13.0", "@babel/plugin-proposal-class-properties@^7.18.6":
+"@babel/plugin-proposal-class-properties@^7.0.0", "@babel/plugin-proposal-class-properties@^7.13.0":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz#b110f59741895f7ec21a6fff696ec46265c446a3"
   integrity sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes #1449

Because of the babel plugin for class properties (see this [comment on the react native repo](https://github.com/facebook/react-native/issues/34783#issuecomment-1414609922)), rendering a flatlist would result in an error. Removing the plugin fixes the error, although I'm not sure why because that plugin is included in babel/preset-env for versions > 7 so we should have it no matter what. It may be an issue with different versions of the plugin, I haven't really understood what was the exact problem, I've tried to look at the transpiled files using the babel cli but they look exactly the same 
 
<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

I added a test case for rendering a flatlist and all tests are passing
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
