### PR TITLE
Fix changelog commit range in v12 migration guide

### DIFF
--- a/website/docs/MigrationV12.md
+++ b/website/docs/MigrationV12.md
@@ -63,5 +63,5 @@ RNTL v12 introduces `root` API as an alternative that returns a root **host** el
 If you use `toBeOnTheScreen` matcher from [@testing-library/jest-native](https://github.com/testing-library/jest-native) your tests will fail because it uses the `container` api. To fix this, update `@testing-library/jest-native` to version 5.4.2.    
 
 # Full Changelog
-https://github.com/callstack/react-native-testing-library/compare/v11.5.2...v11.5.2...v12.0.0-rc.0
+https://github.com/callstack/react-native-testing-library/compare/v11.5.2...v12.0.0
 


### PR DESCRIPTION
The "Migration to 12.0" guide contained a broken link to GitHub's compare feature.