### PR TITLE
fix: support accessibility `aria-*` state props [WIP]

### DIFF
--- a/src/__tests__/react-native-api.test.tsx
+++ b/src/__tests__/react-native-api.test.tsx
@@ -132,6 +132,150 @@ test('React Native API assumption: <Switch> renders single host element', () => 
   `);
 });
 
+test('React Native API assumption: aria-* props render on host View', () => {
+  const view = render(
+    <View
+      testID="test"
+      aria-busy
+      aria-checked
+      aria-disabled
+      aria-expanded
+      aria-hidden
+      aria-label="Label"
+      aria-labelledby="LabelledBy"
+      aria-live="polite"
+      aria-modal
+      aria-pressed
+      aria-readonly
+      aria-required
+      aria-selected
+      aria-valuemax={10}
+      aria-valuemin={0}
+      aria-valuenow={5}
+      aria-valuetext="ValueText"
+    />
+  );
+
+  expect(view.toJSON()).toMatchInlineSnapshot(`
+    <View
+      aria-busy={true}
+      aria-checked={true}
+      aria-disabled={true}
+      aria-expanded={true}
+      aria-hidden={true}
+      aria-label="Label"
+      aria-labelledby="LabelledBy"
+      aria-live="polite"
+      aria-modal={true}
+      aria-pressed={true}
+      aria-readonly={true}
+      aria-required={true}
+      aria-selected={true}
+      aria-valuemax={10}
+      aria-valuemin={0}
+      aria-valuenow={5}
+      aria-valuetext="ValueText"
+      testID="test"
+    />
+  `);
+});
+
+test('React Native API assumption: aria-* props render on host Text', () => {
+  const text = render(
+    <Text
+      testID="test"
+      aria-busy
+      aria-checked
+      aria-disabled
+      aria-expanded
+      aria-hidden
+      aria-label="Label"
+      aria-labelledby="LabelledBy"
+      aria-live="polite"
+      aria-modal
+      aria-pressed
+      aria-readonly
+      aria-required
+      aria-selected
+      aria-valuemax={10}
+      aria-valuemin={0}
+      aria-valuenow={5}
+      aria-valuetext="ValueText"
+    />
+  );
+
+  expect(text.toJSON()).toMatchInlineSnapshot(`
+    <Text
+      aria-busy={true}
+      aria-checked={true}
+      aria-disabled={true}
+      aria-expanded={true}
+      aria-hidden={true}
+      aria-label="Label"
+      aria-labelledby="LabelledBy"
+      aria-live="polite"
+      aria-modal={true}
+      aria-pressed={true}
+      aria-readonly={true}
+      aria-required={true}
+      aria-selected={true}
+      aria-valuemax={10}
+      aria-valuemin={0}
+      aria-valuenow={5}
+      aria-valuetext="ValueText"
+      testID="test"
+    />
+  `);
+});
+
+test('React Native API assumption: aria-* props render on host TextInput', () => {
+  const text = render(
+    <TextInput
+      testID="test"
+      aria-busy
+      aria-checked
+      aria-disabled
+      aria-expanded
+      aria-hidden
+      aria-label="Label"
+      aria-labelledby="LabelledBy"
+      aria-live="polite"
+      aria-modal
+      aria-pressed
+      aria-readonly
+      aria-required
+      aria-selected
+      aria-valuemax={10}
+      aria-valuemin={0}
+      aria-valuenow={5}
+      aria-valuetext="ValueText"
+    />
+  );
+
+  expect(text.toJSON()).toMatchInlineSnapshot(`
+    <TextInput
+      aria-busy={true}
+      aria-checked={true}
+      aria-disabled={true}
+      aria-expanded={true}
+      aria-hidden={true}
+      aria-label="Label"
+      aria-labelledby="LabelledBy"
+      aria-live="polite"
+      aria-modal={true}
+      aria-pressed={true}
+      aria-readonly={true}
+      aria-required={true}
+      aria-selected={true}
+      aria-valuemax={10}
+      aria-valuemin={0}
+      aria-valuenow={5}
+      aria-valuetext="ValueText"
+      testID="test"
+    />
+  `);
+});
+
 test('ScrollView renders correctly', () => {
   const screen = render(
     <ScrollView testID="scrollView">

--- a/src/helpers/accessiblity.ts
+++ b/src/helpers/accessiblity.ts
@@ -110,3 +110,62 @@ export function isAccessibilityElement(
     element?.type === hostComponentNames?.switch
   );
 }
+
+/**
+ * Returns true if element is disabled. By default elements are not disabled.
+ * @param element - element to check
+ * @returns - true if element is disabled.
+ */
+export function isElementDisabled(element: ReactTestInstance): boolean {
+  return (
+    element.props['aria-disabled'] ??
+    element.props.accessibilityState.disabled ??
+    false
+  );
+}
+
+/**
+ * Returns true if element is selected. By default elements are not selected.
+ * @param element - element to check
+ * @returns - true if element is selected.
+ */
+export function isElementSelected(element: ReactTestInstance): boolean {
+  return (
+    element.props['aria-selected'] ??
+    element.props.accessibilityState.selected ??
+    false
+  );
+}
+
+/**
+ * Returns element checked state. By default elements do not have checked state.
+ * @param element - element to check
+ * @returns - true if element is checked, false if explicitly unchecked, 'mixed' if partially checked, undefined if not checked.
+ */
+export function getElementCheckedState(
+  element: ReactTestInstance
+): boolean | 'mixed' {
+  return (
+    element.props['aria-checked'] ?? element.props.accessibilityState.checked
+  );
+}
+
+/**
+ * Returns element busy state. By default elements do not have busy state.
+ * @param element - element to check
+ * @returns - true if element is checked, false if explicitly unchecked, undefined if not checked.
+ */
+export function isElementBusy(element: ReactTestInstance) {
+  return element.props['aria-busy'] ?? element.props.accessibilityState.busy;
+}
+
+/**
+ * Returns element busy state. By default elements do not have busy state.
+ * @param element - element to check
+ * @returns - true if element is checked, false if explicitly unchecked, undefined if not checked.
+ */
+export function isElementExpanded(element: ReactTestInstance) {
+  return (
+    element.props['aria-expanded'] ?? element.props.accessibilityState.expanded
+  );
+}

--- a/src/helpers/format-default.ts
+++ b/src/helpers/format-default.ts
@@ -15,6 +15,20 @@ const propsToDisplay = [
   'value',
   'defaultValue',
   'title',
+  'aria-hidden',
+  'aria-modal',
+  'aria-label',
+  'aria-labelledby',
+  'aria-hint',
+  'aria-busy',
+  'aria-checked',
+  'aria-disabled',
+  'aria-expanded',
+  'aria-selected',
+  'aria-valuemax',
+  'aria-valuemin',
+  'aria-valuenow',
+  'aria-valuetext',
 ];
 
 /**

--- a/src/helpers/matchers/accessibilityState.ts
+++ b/src/helpers/matchers/accessibilityState.ts
@@ -1,6 +1,11 @@
-import { AccessibilityState } from 'react-native';
 import { ReactTestInstance } from 'react-test-renderer';
-import { accessibilityStateKeys } from '../accessiblity';
+import {
+  getElementCheckedState,
+  isElementBusy,
+  isElementDisabled,
+  isElementExpanded,
+  isElementSelected,
+} from '../accessiblity';
 
 // This type is the same as AccessibilityState from `react-native` package
 // It is re-declared here due to issues with migration from `@types/react-native` to
@@ -14,35 +19,19 @@ export interface AccessibilityStateMatcher {
   expanded?: boolean;
 }
 
-/**
- * Default accessibility state values based on experiments using accessibility
- * inspector/screen reader on iOS and Android.
- *
- * @see https://github.com/callstack/react-native-testing-library/wiki/Accessibility:-State
- */
-const defaultState: AccessibilityState = {
-  disabled: false,
-  selected: false,
-  checked: undefined,
-  busy: false,
-  expanded: undefined,
-};
-
 export function matchAccessibilityState(
   node: ReactTestInstance,
   matcher: AccessibilityStateMatcher
 ) {
-  const state = node.props.accessibilityState;
-  return accessibilityStateKeys.every((key) => matchState(state, matcher, key));
+  return (
+    matchState(matcher.disabled, isElementDisabled(node)) &&
+    matchState(matcher.selected, isElementSelected(node)) &&
+    matchState(matcher.checked, getElementCheckedState(node)) &&
+    matchState(matcher.busy, isElementBusy(node)) &&
+    matchState(matcher.expanded, isElementExpanded(node))
+  );
 }
 
-function matchState(
-  state: AccessibilityState,
-  matcher: AccessibilityStateMatcher,
-  key: keyof AccessibilityState
-) {
-  return (
-    matcher[key] === undefined ||
-    matcher[key] === (state?.[key] ?? defaultState[key])
-  );
+function matchState(expectedState?: unknown, receivedState?: unknown) {
+  return expectedState === undefined || expectedState === receivedState;
 }


### PR DESCRIPTION
### Summary

The new `aria-*` props are being rendered to mocked `View`, `Text`, `TextInput` components directly without translation to original `accessibilityState` prop. Therefore, we need to modify related checks to account for these.

### Test plan

Add relevant test cases.