### PR TITLE
feat: implement `toBeSelected` matcher

### DIFF
--- a/src/helpers/accessiblity.ts
+++ b/src/helpers/accessiblity.ts
@@ -176,6 +176,13 @@ export function getAccessibilityCheckedState(
   return ariaChecked ?? accessibilityState?.checked;
 }
 
+export function getAccessibilitySelectedState(
+  element: ReactTestInstance
+): NonNullable<AccessibilityState['selected']> {
+  const { accessibilityState, 'aria-selected': ariaSelected } = element.props;
+  return ariaSelected ?? accessibilityState?.selected ?? false;
+}
+
 export function getAccessibilityValue(
   element: ReactTestInstance
 ): AccessibilityValue | undefined {

--- a/src/matchers/__tests__/to-be-selected.test.tsx
+++ b/src/matchers/__tests__/to-be-selected.test.tsx
@@ -30,9 +30,7 @@ test('.toBeSelected() error messages', () => {
     .toThrowErrorMatchingInlineSnapshot(`
     "expect(element).toBeSelected()
 
-    Expected the element to have accessibility state selected:
-
-    Received element is not selected:
+    Received element is not selected
       <View
         accessibilityState={
           {
@@ -46,9 +44,7 @@ test('.toBeSelected() error messages', () => {
     .toThrowErrorMatchingInlineSnapshot(`
     "expect(element).not.toBeSelected()
 
-    Expected the element not to have accessibility state selected:
-
-    Received element is selected:
+    Received element is selected
       <View
         accessibilityState={
           {
@@ -63,9 +59,7 @@ test('.toBeSelected() error messages', () => {
   ).toThrowErrorMatchingInlineSnapshot(`
     "expect(element).toBeSelected()
 
-    Expected the element to have accessibility state selected:
-
-    Received element is not selected:
+    Received element is not selected
       <View
         testID="no-accessibilityState"
       />"

--- a/src/matchers/__tests__/to-be-selected.test.tsx
+++ b/src/matchers/__tests__/to-be-selected.test.tsx
@@ -5,26 +5,58 @@ import '../extend-expect';
 
 test('.toBeSelected() basic case', () => {
   render(
-    <View>
+    <>
       <View testID="selected" accessibilityState={{ selected: true }} />
+      <View testID="selected-aria" aria-selected />
       <View testID="not-selected" accessibilityState={{ selected: false }} />
-      <View testID="no-accessibilityState" />
-    </View>
+      <View testID="not-selected-aria" aria-selected={false} />
+      <View testID="default" />
+    </>
   );
 
   expect(screen.getByTestId('selected')).toBeSelected();
+  expect(screen.getByTestId('selected-aria')).toBeSelected();
   expect(screen.getByTestId('not-selected')).not.toBeSelected();
-  expect(screen.getByTestId('no-accessibilityState')).not.toBeSelected();
+  expect(screen.getByTestId('not-selected-aria')).not.toBeSelected();
+  expect(screen.getByTestId('default')).not.toBeSelected();
 });
 
 test('.toBeSelected() error messages', () => {
   render(
-    <View>
+    <>
       <View testID="selected" accessibilityState={{ selected: true }} />
+      <View testID="selected-aria" aria-selected />
       <View testID="not-selected" accessibilityState={{ selected: false }} />
-      <View testID="no-accessibilityState" />
-    </View>
+      <View testID="not-selected-aria" aria-selected={false} />
+      <View testID="default" />
+    </>
   );
+
+  expect(() => expect(screen.getByTestId('selected')).not.toBeSelected())
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).not.toBeSelected()
+
+    Received element is selected
+      <View
+        accessibilityState={
+          {
+            "selected": true,
+          }
+        }
+        testID="selected"
+      />"
+  `);
+
+  expect(() => expect(screen.getByTestId('selected-aria')).not.toBeSelected())
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).not.toBeSelected()
+
+    Received element is selected
+      <View
+        aria-selected={true}
+        testID="selected-aria"
+      />"
+  `);
 
   expect(() => expect(screen.getByTestId('not-selected')).toBeSelected())
     .toThrowErrorMatchingInlineSnapshot(`
@@ -40,28 +72,25 @@ test('.toBeSelected() error messages', () => {
         testID="not-selected"
       />"
   `);
-  expect(() => expect(screen.getByTestId('selected')).not.toBeSelected())
-    .toThrowErrorMatchingInlineSnapshot(`
-    "expect(element).not.toBeSelected()
 
-    Received element is selected
-      <View
-        accessibilityState={
-          {
-            "selected": true,
-          }
-        }
-        testID="selected"
-      />"
-  `);
-  expect(() =>
-    expect(screen.getByTestId('no-accessibilityState')).toBeSelected()
-  ).toThrowErrorMatchingInlineSnapshot(`
+  expect(() => expect(screen.getByTestId('not-selected-aria')).toBeSelected())
+    .toThrowErrorMatchingInlineSnapshot(`
     "expect(element).toBeSelected()
 
     Received element is not selected
       <View
-        testID="no-accessibilityState"
+        aria-selected={false}
+        testID="not-selected-aria"
+      />"
+  `);
+
+  expect(() => expect(screen.getByTestId('default')).toBeSelected())
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).toBeSelected()
+
+    Received element is not selected
+      <View
+        testID="default"
       />"
   `);
 });

--- a/src/matchers/__tests__/to-be-selected.test.tsx
+++ b/src/matchers/__tests__/to-be-selected.test.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { View } from 'react-native';
+import { render, screen } from '../..';
+import '../extend-expect';
+
+test('.toBeSelected() basic case', () => {
+  render(
+    <View>
+      <View testID="selected" accessibilityState={{ selected: true }} />
+      <View testID="not-selected" accessibilityState={{ selected: false }} />
+      <View testID="no-accessibilityState" />
+    </View>
+  );
+
+  expect(screen.getByTestId('selected')).toBeSelected();
+  expect(screen.getByTestId('not-selected')).not.toBeSelected();
+  expect(screen.getByTestId('no-accessibilityState')).not.toBeSelected();
+});
+
+test('.toBeSelected() error messages', () => {
+  render(
+    <View>
+      <View testID="selected" accessibilityState={{ selected: true }} />
+      <View testID="not-selected" accessibilityState={{ selected: false }} />
+      <View testID="no-accessibilityState" />
+    </View>
+  );
+
+  expect(() => expect(screen.getByTestId('not-selected')).toBeSelected())
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).toBeSelected()
+
+    Expected the element to have accessibility state selected:
+
+    Received element is not selected:
+      <View
+        accessibilityState={
+          {
+            "selected": false,
+          }
+        }
+        testID="not-selected"
+      />"
+  `);
+  expect(() => expect(screen.getByTestId('selected')).not.toBeSelected())
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).not.toBeSelected()
+
+    Expected the element not to have accessibility state selected:
+
+    Received element is selected:
+      <View
+        accessibilityState={
+          {
+            "selected": true,
+          }
+        }
+        testID="selected"
+      />"
+  `);
+  expect(() =>
+    expect(screen.getByTestId('no-accessibilityState')).toBeSelected()
+  ).toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).toBeSelected()
+
+    Expected the element to have accessibility state selected:
+
+    Received element is not selected:
+      <View
+        testID="no-accessibilityState"
+      />"
+  `);
+});

--- a/src/matchers/extend-expect.d.ts
+++ b/src/matchers/extend-expect.d.ts
@@ -11,6 +11,7 @@ export interface JestNativeMatchers<R> {
   toHaveDisplayValue(expectedValue: TextMatch, options?: TextMatchOptions): R;
   toHaveProp(name: string, expectedValue?: unknown): R;
   toHaveTextContent(expectedText: TextMatch, options?: TextMatchOptions): R;
+  toBeSelected(): R;
 }
 
 // Implicit Jest global `expect`.

--- a/src/matchers/extend-expect.d.ts
+++ b/src/matchers/extend-expect.d.ts
@@ -7,11 +7,11 @@ export interface JestNativeMatchers<R> {
   toBeEmptyElement(): R;
   toBeEnabled(): R;
   toBePartiallyChecked(): R;
+  toBeSelected(): R;
   toBeVisible(): R;
   toHaveDisplayValue(expectedValue: TextMatch, options?: TextMatchOptions): R;
   toHaveProp(name: string, expectedValue?: unknown): R;
   toHaveTextContent(expectedText: TextMatch, options?: TextMatchOptions): R;
-  toBeSelected(): R;
 }
 
 // Implicit Jest global `expect`.

--- a/src/matchers/extend-expect.ts
+++ b/src/matchers/extend-expect.ts
@@ -9,6 +9,7 @@ import { toBeVisible } from './to-be-visible';
 import { toHaveDisplayValue } from './to-have-display-value';
 import { toHaveProp } from './to-have-prop';
 import { toHaveTextContent } from './to-have-text-content';
+import { toBeSelected } from './to-be-selected';
 
 expect.extend({
   toBeOnTheScreen,
@@ -21,4 +22,5 @@ expect.extend({
   toHaveDisplayValue,
   toHaveProp,
   toHaveTextContent,
+  toBeSelected,
 });

--- a/src/matchers/extend-expect.ts
+++ b/src/matchers/extend-expect.ts
@@ -5,11 +5,11 @@ import { toBeChecked } from './to-be-checked';
 import { toBeDisabled, toBeEnabled } from './to-be-disabled';
 import { toBeEmptyElement } from './to-be-empty-element';
 import { toBePartiallyChecked } from './to-be-partially-checked';
+import { toBeSelected } from './to-be-selected';
 import { toBeVisible } from './to-be-visible';
 import { toHaveDisplayValue } from './to-have-display-value';
 import { toHaveProp } from './to-have-prop';
 import { toHaveTextContent } from './to-have-text-content';
-import { toBeSelected } from './to-be-selected';
 
 expect.extend({
   toBeOnTheScreen,
@@ -18,9 +18,9 @@ expect.extend({
   toBeEmptyElement,
   toBeEnabled,
   toBePartiallyChecked,
+  toBeSelected,
   toBeVisible,
   toHaveDisplayValue,
   toHaveProp,
   toHaveTextContent,
-  toBeSelected,
 });

--- a/src/matchers/index.tsx
+++ b/src/matchers/index.tsx
@@ -7,3 +7,4 @@ export { toBeVisible } from './to-be-visible';
 export { toHaveDisplayValue } from './to-have-display-value';
 export { toHaveProp } from './to-have-prop';
 export { toHaveTextContent } from './to-have-text-content';
+export { toBeSelected } from './to-be-selected';

--- a/src/matchers/to-be-selected.ts
+++ b/src/matchers/to-be-selected.ts
@@ -1,7 +1,7 @@
 import { ReactTestInstance } from 'react-test-renderer';
 import { matcherHint } from 'jest-matcher-utils';
-import { getAccessibilityState } from '../helpers/accessiblity';
-import { checkHostElement, formatElement, formatMessage } from './utils';
+import { getAccessibilitySelectedState } from '../helpers/accessiblity';
+import { checkHostElement, formatElement } from './utils';
 
 export function toBeSelected(
   this: jest.MatcherContext,
@@ -10,23 +10,15 @@ export function toBeSelected(
   checkHostElement(element, toBeSelected, this);
 
   return {
-    pass: getAccessibilityState(element)?.selected === true,
+    pass: getAccessibilitySelectedState(element),
     message: () => {
       const is = this.isNot ? 'is' : 'is not';
-      const matcher = matcherHint(
-        `${this.isNot ? '.not' : ''}.toBeSelected`,
-        'element',
-        ''
-      );
-      return formatMessage(
-        matcher,
-        `Expected the element ${
-          this.isNot ? 'not to' : 'to'
-        } have accessibility state selected`,
+      return [
+        matcherHint(`${this.isNot ? '.not' : ''}.toBeSelected`, 'element', ''),
         '',
         `Received element ${is} selected`,
-        formatElement(element)
-      );
+        formatElement(element),
+      ].join('\n');
     },
   };
 }

--- a/src/matchers/to-be-selected.ts
+++ b/src/matchers/to-be-selected.ts
@@ -1,0 +1,32 @@
+import { ReactTestInstance } from 'react-test-renderer';
+import { matcherHint } from 'jest-matcher-utils';
+import { getAccessibilityState } from '../helpers/accessiblity';
+import { checkHostElement, formatElement, formatMessage } from './utils';
+
+export function toBeSelected(
+  this: jest.MatcherContext,
+  element: ReactTestInstance
+) {
+  checkHostElement(element, toBeSelected, this);
+
+  return {
+    pass: getAccessibilityState(element)?.selected === true,
+    message: () => {
+      const is = this.isNot ? 'is' : 'is not';
+      const matcher = matcherHint(
+        `${this.isNot ? '.not' : ''}.toBeSelected`,
+        'element',
+        ''
+      );
+      return formatMessage(
+        matcher,
+        `Expected the element ${
+          this.isNot ? 'not to' : 'to'
+        } have accessibility state selected`,
+        '',
+        `Received element ${is} selected`,
+        formatElement(element)
+      );
+    },
+  };
+}


### PR DESCRIPTION
### Summary

Implement `toBeSelected` : check that the accessibilityState props is "selected".

### Test plan

- toBeSelected works, .not.toBeSelected works
- Display the propers error message if the test fail