### PR TITLE
docs: note required RNTL version for user-event in user-event.md

### DIFF
--- a/website/docs/UserEvent.md
+++ b/website/docs/UserEvent.md
@@ -13,7 +13,7 @@ This means that we plan to keep the public API signatures to remain stable, but 
 :::
 
 :::note
-User Event interactions require RNTL v12.2.0.
+User Event interactions require RNTL v12.2.0 or later.
 :::
 
 
@@ -187,7 +187,7 @@ The `textInput` event is sent only for mutliline text inputs.
 ## `scrollTo()`
 
 :::note
-`scrollTo` interaction requires RNTL v12.4.0.
+`scrollTo` interaction has been introduced in RNTL v12.4.0.
 :::
 
 ```ts

--- a/website/docs/UserEvent.md
+++ b/website/docs/UserEvent.md
@@ -6,15 +6,16 @@ import TOCInline from '@theme/TOCInline';
 
 <TOCInline toc={toc} />
 
-:::note
-Requires `@testing-library/react-native` version 12.2.0.
-:::
-
 :::caution
 User Event API is in beta stage.
 
 This means that we plan to keep the public API signatures to remain stable, but we might introduce breaking behavioural changes, e.g. changing the ordering or timing of emitted events, without a major version update. Hopefully, well written code should not rely on such specific details.
 :::
+
+:::note
+User Event interactions require v12.2.0.
+:::
+
 
 ## Comparison with Fire Event API
 

--- a/website/docs/UserEvent.md
+++ b/website/docs/UserEvent.md
@@ -13,7 +13,7 @@ This means that we plan to keep the public API signatures to remain stable, but 
 :::
 
 :::note
-User Event interactions require v12.2.0.
+User Event interactions require RNTL v12.2.0.
 :::
 
 
@@ -184,10 +184,14 @@ The `textInput` event is sent only for mutliline text inputs.
 - `endEditing`
 - `blur`
 
-## `scroll()`
+## `scrollTo()`
+
+:::note
+`scrollTo` interaction requires RNTL v12.4.0.
+:::
 
 ```ts
-type(
+scrollTo(
   element: ReactTestInstance,
   options: {
     y: number,

--- a/website/docs/UserEvent.md
+++ b/website/docs/UserEvent.md
@@ -6,6 +6,10 @@ import TOCInline from '@theme/TOCInline';
 
 <TOCInline toc={toc} />
 
+:::note
+Requires `@testing-library/react-native` version 12.2.0.
+:::
+
 :::caution
 User Event API is in beta stage.
 


### PR DESCRIPTION
### Summary
I had to go through the changelog to figure out what version of RNTL I needed to use user-event, as simply being on the latest major isn't sufficient (12.0.1). I thought this might save others time/frustration.

### Test plan
Make sure the updated docs look okay and are clear.