### PR TITLE
feat: `toContainElement` matcher

### DIFF
--- a/src/matchers/__tests__/to-contain-element.test.tsx
+++ b/src/matchers/__tests__/to-contain-element.test.tsx
@@ -84,6 +84,20 @@ test('toContainElement() passing null', () => {
   `);
 });
 
+test('toContainElement() on null elements', () => {
+  render(<View testID="view" />);
+
+  const view = screen.getByTestId('view');
+
+  expect(() => expect(null).toContainElement(view))
+    .toThrowErrorMatchingInlineSnapshot(`
+      "expect(received).toContainElement()
+
+      received value must be a host element.
+      Received has value: null"
+    `);
+});
+
 test('toContainElement() on non-React elements', () => {
   render(<View testID="view" />);
 

--- a/src/matchers/__tests__/to-contain-element.test.tsx
+++ b/src/matchers/__tests__/to-contain-element.test.tsx
@@ -20,11 +20,6 @@ test('toContainElement() on parent view', () => {
     "expect(element).not.toContainElement(element)
 
       <View
-        children={
-          <View
-            testID="child"
-          />
-        }
         testID="parent"
       /> 
 

--- a/src/matchers/__tests__/to-contain-element.test.tsx
+++ b/src/matchers/__tests__/to-contain-element.test.tsx
@@ -17,7 +17,7 @@ test('toContainElement() supports basic case', () => {
 
   expect(() => expect(parent).not.toContainElement(child))
     .toThrowErrorMatchingInlineSnapshot(`
-    "expect(element).not.toContainElement(element)
+    "expect(container).not.toContainElement(element)
 
       <View
         testID="parent"
@@ -44,10 +44,11 @@ test('toContainElement() supports negative case', () => {
   const view2 = screen.getByTestId('view2');
 
   expect(view1).not.toContainElement(view2);
+  expect(view2).not.toContainElement(view1);
 
   expect(() => expect(view1).toContainElement(view2))
     .toThrowErrorMatchingInlineSnapshot(`
-    "expect(element).toContainElement(element)
+    "expect(container).toContainElement(element)
 
       <View
         testID="view1"
@@ -62,7 +63,21 @@ test('toContainElement() supports negative case', () => {
   `);
 });
 
-test('toContainElement() passing null', () => {
+test('toContainElement() handles null container', () => {
+  render(<View testID="view" />);
+
+  const view = screen.getByTestId('view');
+
+  expect(() => expect(null).toContainElement(view))
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(received).toContainElement()
+
+    received value must be a host element.
+    Received has value: null"
+  `);
+});
+
+test('toContainElement() handles null element', () => {
   render(<View testID="view" />);
 
   const view = screen.getByTestId('view');
@@ -71,7 +86,7 @@ test('toContainElement() passing null', () => {
 
   expect(() => expect(view).toContainElement(null))
     .toThrowErrorMatchingInlineSnapshot(`
-    "expect(element).toContainElement(element)
+    "expect(container).toContainElement(element)
 
       <View
         testID="view"
@@ -84,32 +99,18 @@ test('toContainElement() passing null', () => {
   `);
 });
 
-test('toContainElement() on null elements', () => {
+test('toContainElement() handles non-element container', () => {
   render(<View testID="view" />);
 
   const view = screen.getByTestId('view');
 
-  expect(() => expect(null).toContainElement(view))
-    .toThrowErrorMatchingInlineSnapshot(`
-      "expect(received).toContainElement()
-
-      received value must be a host element.
-      Received has value: null"
-    `);
-});
-
-test('toContainElement() on non-React elements', () => {
-  render(<View testID="view" />);
-
-  const view = screen.getByTestId('view');
-
-  expect(() => expect({ name: 'Non-React element' }).not.toContainElement(view))
+  expect(() => expect({ name: 'non-element' }).not.toContainElement(view))
     .toThrowErrorMatchingInlineSnapshot(`
     "expect(received).not.toContainElement()
 
     received value must be a host element.
     Received has type:  object
-    Received has value: {"name": "Non-React element"}"
+    Received has value: {"name": "non-element"}"
   `);
 
   expect(() => expect(true).not.toContainElement(view))
@@ -122,30 +123,19 @@ test('toContainElement() on non-React elements', () => {
     `);
 });
 
-test('toContainElement() passing non-React element', () => {
+test('toContainElement() handles non-element element', () => {
   render(<View testID="view" />);
 
   const view = screen.getByTestId('view');
 
   expect(() =>
     // @ts-expect-error
-    expect(view).not.toContainElement(true)
+    expect(view).not.toContainElement({ name: 'non-element' })
   ).toThrowErrorMatchingInlineSnapshot(`
     "expect(received).not.toContainElement()
 
     received value must be a host element.
-    Received has type:  boolean
-    Received has value: true"
-  `);
-});
-
-test('toContainElement() passing null on non-React element', () => {
-  expect(() => expect(true).not.toContainElement(null))
-    .toThrowErrorMatchingInlineSnapshot(`
-    "expect(received).not.toContainElement()
-
-    received value must be a host element.
-    Received has type:  boolean
-    Received has value: true"
+    Received has type:  object
+    Received has value: {"name": "non-element"}"
   `);
 });

--- a/src/matchers/__tests__/to-contain-element.test.tsx
+++ b/src/matchers/__tests__/to-contain-element.test.tsx
@@ -31,3 +31,27 @@ test('toContainElement() on parent view', () => {
             "
   `);
 });
+
+test('toContainElement() on non-React elements', () => {
+  render(<View testID="view" />);
+
+  const view = screen.getByTestId('view');
+
+  expect(() => expect({ name: 'Non-React element' }).not.toContainElement(view))
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(received).not.toContainElement()
+
+    received value must be a host element.
+    Received has type:  object
+    Received has value: {"name": "Non-React element"}"
+  `);
+
+  expect(() => expect(true).not.toContainElement(view))
+    .toThrowErrorMatchingInlineSnapshot(`
+      "expect(received).not.toContainElement()
+
+      received value must be a host element.
+      Received has type:  boolean
+      Received has value: true"
+    `);
+});

--- a/src/matchers/__tests__/to-contain-element.test.tsx
+++ b/src/matchers/__tests__/to-contain-element.test.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { View } from 'react-native';
+import { render, screen } from '../..';
+import '../extend-expect';
+
+test('toContainElement() on parent view', () => {
+  render(
+    <View testID="parent">
+      <View testID="child" />
+    </View>
+  );
+
+  const parent = screen.getByTestId('parent');
+  const child = screen.getByTestId('child');
+
+  expect(parent).toContainElement(child);
+
+  expect(() => expect(parent).not.toContainElement(child))
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).not.toContainElement(element)
+
+      <View
+        children={
+          <View
+            testID="child"
+          />
+        }
+        testID="parent"
+      /> 
+
+    contains:
+
+       <View
+        testID="child"
+      />
+            "
+  `);
+});

--- a/src/matchers/__tests__/to-contain-element.test.tsx
+++ b/src/matchers/__tests__/to-contain-element.test.tsx
@@ -32,6 +32,36 @@ test('toContainElement() supports basic case', () => {
   `);
 });
 
+test('toContainElement() supports negative case', () => {
+  render(
+    <>
+      <View testID="view1" />
+      <View testID="view2" />
+    </>
+  );
+
+  const view1 = screen.getByTestId('view1');
+  const view2 = screen.getByTestId('view2');
+
+  expect(view1).not.toContainElement(view2);
+
+  expect(() => expect(view1).toContainElement(view2))
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).toContainElement(element)
+
+      <View
+        testID="view1"
+      /> 
+
+    does not contain:
+
+       <View
+        testID="view2"
+      />
+            "
+  `);
+});
+
 test('toContainElement() passing null', () => {
   render(<View testID="view" />);
 

--- a/src/matchers/__tests__/to-contain-element.test.tsx
+++ b/src/matchers/__tests__/to-contain-element.test.tsx
@@ -32,6 +32,28 @@ test('toContainElement() on parent view', () => {
   `);
 });
 
+test('toContainElement() passing null', () => {
+  render(<View testID="view" />);
+
+  const view = screen.getByTestId('view');
+
+  expect(view).not.toContainElement(null);
+
+  expect(() => expect(view).toContainElement(null))
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).toContainElement(element)
+
+      <View
+        testID="view"
+      /> 
+
+    does not contain:
+
+       null
+            "
+  `);
+});
+
 test('toContainElement() on non-React elements', () => {
   render(<View testID="view" />);
 

--- a/src/matchers/__tests__/to-contain-element.test.tsx
+++ b/src/matchers/__tests__/to-contain-element.test.tsx
@@ -3,7 +3,7 @@ import { View } from 'react-native';
 import { render, screen } from '../..';
 import '../extend-expect';
 
-test('toContainElement() on parent view', () => {
+test('toContainElement() supports basic case', () => {
   render(
     <View testID="parent">
       <View testID="child" />

--- a/src/matchers/__tests__/to-contain-element.test.tsx
+++ b/src/matchers/__tests__/to-contain-element.test.tsx
@@ -121,3 +121,31 @@ test('toContainElement() on non-React elements', () => {
       Received has value: true"
     `);
 });
+
+test('toContainElement() passing non-React element', () => {
+  render(<View testID="view" />);
+
+  const view = screen.getByTestId('view');
+
+  expect(() =>
+    // @ts-expect-error
+    expect(view).not.toContainElement(true)
+  ).toThrowErrorMatchingInlineSnapshot(`
+    "expect(received).not.toContainElement()
+
+    received value must be a host element.
+    Received has type:  boolean
+    Received has value: true"
+  `);
+});
+
+test('toContainElement() passing null on non-React element', () => {
+  expect(() => expect(true).not.toContainElement(null))
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(received).not.toContainElement()
+
+    received value must be a host element.
+    Received has type:  boolean
+    Received has value: true"
+  `);
+});

--- a/src/matchers/extend-expect.d.ts
+++ b/src/matchers/extend-expect.d.ts
@@ -1,5 +1,5 @@
 import type { StyleProp } from 'react-native';
-import { ReactTestInstance } from 'react-test-renderer';
+import type { ReactTestInstance } from 'react-test-renderer';
 import type { TextMatch, TextMatchOptions } from '../matches';
 import type { Style } from './to-have-style';
 

--- a/src/matchers/extend-expect.d.ts
+++ b/src/matchers/extend-expect.d.ts
@@ -1,4 +1,5 @@
 import type { StyleProp } from 'react-native';
+import { ReactTestInstance } from 'react-test-renderer';
 import type { TextMatch, TextMatchOptions } from '../matches';
 import type { Style } from './to-have-style';
 
@@ -12,6 +13,7 @@ export interface JestNativeMatchers<R> {
   toBePartiallyChecked(): R;
   toBeSelected(): R;
   toBeVisible(): R;
+  toContainElement(element: ReactTestInstance | null): R;
   toHaveDisplayValue(expectedValue: TextMatch, options?: TextMatchOptions): R;
   toHaveProp(name: string, expectedValue?: unknown): R;
   toHaveStyle(style: StyleProp<Style>): R;

--- a/src/matchers/extend-expect.ts
+++ b/src/matchers/extend-expect.ts
@@ -8,6 +8,7 @@ import { toBeEmptyElement } from './to-be-empty-element';
 import { toBePartiallyChecked } from './to-be-partially-checked';
 import { toBeSelected } from './to-be-selected';
 import { toBeVisible } from './to-be-visible';
+import { toContainElement } from './to-contain-element';
 import { toHaveDisplayValue } from './to-have-display-value';
 import { toHaveProp } from './to-have-prop';
 import { toHaveStyle } from './to-have-style';
@@ -23,6 +24,7 @@ expect.extend({
   toBePartiallyChecked,
   toBeSelected,
   toBeVisible,
+  toContainElement,
   toHaveDisplayValue,
   toHaveProp,
   toHaveStyle,

--- a/src/matchers/index.tsx
+++ b/src/matchers/index.tsx
@@ -1,13 +1,13 @@
-export { toBeOnTheScreen } from './to-be-on-the-screen';
+export { toBeBusy } from './to-be-busy';
 export { toBeChecked } from './to-be-checked';
 export { toBeDisabled, toBeEnabled } from './to-be-disabled';
-export { toBeBusy } from './to-be-busy';
 export { toBeEmptyElement } from './to-be-empty-element';
+export { toBeOnTheScreen } from './to-be-on-the-screen';
 export { toBePartiallyChecked } from './to-be-partially-checked';
+export { toBeSelected } from './to-be-selected';
 export { toBeVisible } from './to-be-visible';
+export { toContainElement } from './to-contain-element';
 export { toHaveDisplayValue } from './to-have-display-value';
 export { toHaveProp } from './to-have-prop';
 export { toHaveStyle } from './to-have-style';
 export { toHaveTextContent } from './to-have-text-content';
-export { toBeSelected } from './to-be-selected';
-export { toContainElement } from './to-contain-element';

--- a/src/matchers/index.tsx
+++ b/src/matchers/index.tsx
@@ -10,3 +10,4 @@ export { toHaveProp } from './to-have-prop';
 export { toHaveStyle } from './to-have-style';
 export { toHaveTextContent } from './to-have-text-content';
 export { toBeSelected } from './to-be-selected';
+export { toContainElement } from './to-contain-element';

--- a/src/matchers/to-contain-element.tsx
+++ b/src/matchers/to-contain-element.tsx
@@ -1,5 +1,8 @@
 import { ReactTestInstance } from 'react-test-renderer';
-import { matcherHint, RECEIVED_COLOR as receivedColor } from 'jest-matcher-utils';
+import {
+  matcherHint,
+  RECEIVED_COLOR as receivedColor,
+} from 'jest-matcher-utils';
 import { checkHostElement, formatElement } from './utils';
 
 export function toContainElement(
@@ -8,7 +11,7 @@ export function toContainElement(
   element: ReactTestInstance | null
 ) {
   if (element !== null || !this.isNot) {
-    checkHostElement(element, toContainElement, this);
+    checkHostElement(container, toContainElement, this);
   }
 
   let matches: ReactTestInstance[] = [];

--- a/src/matchers/to-contain-element.tsx
+++ b/src/matchers/to-contain-element.tsx
@@ -1,8 +1,5 @@
 import { ReactTestInstance } from 'react-test-renderer';
-import {
-  matcherHint,
-  RECEIVED_COLOR as receivedColor,
-} from 'jest-matcher-utils';
+import { matcherHint, RECEIVED_COLOR } from 'jest-matcher-utils';
 import { checkHostElement, formatElement } from './utils';
 
 export function toContainElement(
@@ -17,22 +14,21 @@ export function toContainElement(
   }
 
   let matches: ReactTestInstance[] = [];
-
   if (element) {
     matches = container.findAll((node) => node === element);
   }
 
   return {
-    pass: Boolean(matches.length),
+    pass: matches.length > 0,
     message: () => {
       return [
         matcherHint(
           `${this.isNot ? '.not' : ''}.toContainElement`,
-          'element',
+          'container',
           'element'
         ),
         '',
-        receivedColor(`${formatElement(container)} ${
+        RECEIVED_COLOR(`${formatElement(container)} ${
           this.isNot ? '\n\ncontains:\n\n' : '\n\ndoes not contain:\n\n'
         } ${formatElement(element)}
         `),

--- a/src/matchers/to-contain-element.tsx
+++ b/src/matchers/to-contain-element.tsx
@@ -1,6 +1,6 @@
 import { ReactTestInstance } from 'react-test-renderer';
 import { matcherHint, RECEIVED_COLOR as receivedColor } from 'jest-matcher-utils';
-import { checkHostElement, printElement } from './utils';
+import { checkHostElement, formatElement } from './utils';
 
 export function toContainElement(
   this: jest.MatcherContext,
@@ -31,9 +31,9 @@ export function toContainElement(
           'element'
         ),
         '',
-        receivedColor(`${printElement(container)} ${
+        receivedColor(`${formatElement(container)} ${
           this.isNot ? '\n\ncontains:\n\n' : '\n\ndoes not contain:\n\n'
-        } ${printElement(element)}
+        } ${formatElement(element)}
         `),
       ].join('\n');
     },

--- a/src/matchers/to-contain-element.tsx
+++ b/src/matchers/to-contain-element.tsx
@@ -10,8 +10,10 @@ export function toContainElement(
   container: ReactTestInstance,
   element: ReactTestInstance | null
 ) {
-  if (element !== null || !this.isNot) {
-    checkHostElement(container, toContainElement, this);
+  checkHostElement(container, toContainElement, this);
+
+  if (element !== null) {
+    checkHostElement(element, toContainElement, this);
   }
 
   let matches: ReactTestInstance[] = [];

--- a/src/matchers/to-contain-element.tsx
+++ b/src/matchers/to-contain-element.tsx
@@ -1,0 +1,41 @@
+import { ReactTestInstance } from 'react-test-renderer';
+import { matcherHint, RECEIVED_COLOR as receivedColor } from 'jest-matcher-utils';
+import { checkHostElement, printElement } from './utils';
+
+export function toContainElement(
+  this: jest.MatcherContext,
+  container: ReactTestInstance,
+  element: ReactTestInstance | null
+) {
+  if (element !== null || !this.isNot) {
+    checkHostElement(element, toContainElement, this);
+  }
+
+  let matches = [];
+
+  if (element) {
+    matches = container.findAll((node) => {
+      return (
+        node.type === element.type && this.equals(node.props, element.props)
+      );
+    });
+  }
+
+  return {
+    pass: Boolean(matches.length),
+    message: () => {
+      return [
+        matcherHint(
+          `${this.isNot ? '.not' : ''}.toContainElement`,
+          'element',
+          'element'
+        ),
+        '',
+        receivedColor(`${printElement(container)} ${
+          this.isNot ? '\n\ncontains:\n\n' : '\n\ndoes not contain:\n\n'
+        } ${printElement(element)}
+        `),
+      ].join('\n');
+    },
+  };
+}

--- a/src/matchers/to-contain-element.tsx
+++ b/src/matchers/to-contain-element.tsx
@@ -11,14 +11,10 @@ export function toContainElement(
     checkHostElement(element, toContainElement, this);
   }
 
-  let matches = [];
+  let matches: ReactTestInstance[] = [];
 
   if (element) {
-    matches = container.findAll((node) => {
-      return (
-        node.type === element.type && this.equals(node.props, element.props)
-      );
-    });
+    matches = container.findAll((node) => node === element);
   }
 
   return {

--- a/src/matchers/utils.tsx
+++ b/src/matchers/utils.tsx
@@ -12,8 +12,6 @@ import redent from 'redent';
 import { isHostElement } from '../helpers/component-tree';
 import { defaultMapProps } from '../helpers/format-default';
 
-const { ReactTestComponent, ReactElement } = plugins;
-
 class HostElementTypeError extends Error {
   constructor(
     received: unknown,
@@ -128,29 +126,4 @@ export function formatMessage(
 
 function formatValue(value: unknown) {
   return typeof value === 'string' ? value : stringify(value);
-}
-
-export function printElement(element: ReactTestInstance | null) {
-  if (element == null) {
-    return 'null';
-  }
-
-  return redent(
-    prettyFormat(
-      {
-        // This prop is needed persuade the prettyFormat that the element is
-        // a ReactTestRendererJSON instance, so it is formatted as JSX.
-        $$typeof: Symbol.for('react.test.json'),
-        type: element.type,
-        props: element.props,
-      },
-      {
-        plugins: [ReactTestComponent, ReactElement],
-        printFunctionName: false,
-        printBasicPrototype: false,
-        highlight: true,
-      }
-    ),
-    2
-  );
 }

--- a/src/matchers/utils.tsx
+++ b/src/matchers/utils.tsx
@@ -12,6 +12,8 @@ import redent from 'redent';
 import { isHostElement } from '../helpers/component-tree';
 import { defaultMapProps } from '../helpers/format-default';
 
+const { ReactTestComponent, ReactElement } = plugins;
+
 class HostElementTypeError extends Error {
   constructor(
     received: unknown,
@@ -126,4 +128,29 @@ export function formatMessage(
 
 function formatValue(value: unknown) {
   return typeof value === 'string' ? value : stringify(value);
+}
+
+export function printElement(element: ReactTestInstance | null) {
+  if (element == null) {
+    return 'null';
+  }
+
+  return redent(
+    prettyFormat(
+      {
+        // This prop is needed persuade the prettyFormat that the element is
+        // a ReactTestRendererJSON instance, so it is formatted as JSX.
+        $$typeof: Symbol.for('react.test.json'),
+        type: element.type,
+        props: element.props,
+      },
+      {
+        plugins: [ReactTestComponent, ReactElement],
+        printFunctionName: false,
+        printBasicPrototype: false,
+        highlight: true,
+      }
+    ),
+    2
+  );
 }


### PR DESCRIPTION
### Summary

https://github.com/callstack/react-native-testing-library/issues/1486 - Implement `toContainElement()` matcher.

Based on [Jest Native's toContainElement()](https://github.com/testing-library/jest-native/blob/main/src/to-contain-element.ts)

### Test plan

`yarn test`
