### PR TITLE
feat: `toBeExpanded` matcher

### DIFF
--- a/src/helpers/accessiblity.ts
+++ b/src/helpers/accessiblity.ts
@@ -213,11 +213,11 @@ export function isElementBusy(
   return ariaBusy ?? accessibilityState?.busy ?? false;
 }
 
-export function isElementSelected(
+export function isElementCollapsed(
   element: ReactTestInstance
-): NonNullable<AccessibilityState['selected']> {
-  const { accessibilityState, 'aria-selected': ariaSelected } = element.props;
-  return ariaSelected ?? accessibilityState?.selected ?? false;
+): NonNullable<AccessibilityState['expanded']> {
+  const { accessibilityState, 'aria-expanded': ariaExpanded } = element.props;
+  return (ariaExpanded ?? accessibilityState?.expanded) === false;
 }
 
 export function isElementExpanded(
@@ -227,9 +227,9 @@ export function isElementExpanded(
   return ariaExpanded ?? accessibilityState?.expanded ?? false;
 }
 
-export function isElementCollapsed(
+export function isElementSelected(
   element: ReactTestInstance
-): NonNullable<AccessibilityState['expanded']> {
-  const { accessibilityState, 'aria-expanded': ariaExpanded } = element.props;
-  return (ariaExpanded ?? accessibilityState?.expanded) === false;
+): NonNullable<AccessibilityState['selected']> {
+  const { accessibilityState, 'aria-selected': ariaSelected } = element.props;
+  return ariaSelected ?? accessibilityState?.selected ?? false;
 }

--- a/src/helpers/accessiblity.ts
+++ b/src/helpers/accessiblity.ts
@@ -231,9 +231,5 @@ export function isElementCollapsed(
   element: ReactTestInstance
 ): NonNullable<AccessibilityState['expanded']> {
   const { accessibilityState, 'aria-expanded': ariaExpanded } = element.props;
-  return ariaExpanded !== undefined
-    ? !ariaExpanded
-    : accessibilityState !== undefined
-    ? !accessibilityState.expanded
-    : false;
+  return (ariaExpanded ?? accessibilityState?.expanded) === false;
 }

--- a/src/helpers/accessiblity.ts
+++ b/src/helpers/accessiblity.ts
@@ -219,3 +219,10 @@ export function isElementSelected(
   const { accessibilityState, 'aria-selected': ariaSelected } = element.props;
   return ariaSelected ?? accessibilityState?.selected ?? false;
 }
+
+export function isElementExpanded(
+  element: ReactTestInstance
+): NonNullable<AccessibilityState['expanded']> {
+  const { accessibilityState, 'aria-expanded': ariaExpanded } = element.props;
+  return ariaExpanded ?? accessibilityState?.expanded ?? false;
+}

--- a/src/helpers/accessiblity.ts
+++ b/src/helpers/accessiblity.ts
@@ -226,3 +226,14 @@ export function isElementExpanded(
   const { accessibilityState, 'aria-expanded': ariaExpanded } = element.props;
   return ariaExpanded ?? accessibilityState?.expanded ?? false;
 }
+
+export function isElementCollapsed(
+  element: ReactTestInstance
+): NonNullable<AccessibilityState['expanded']> {
+  const { accessibilityState, 'aria-expanded': ariaExpanded } = element.props;
+  return ariaExpanded !== undefined
+    ? !ariaExpanded
+    : accessibilityState !== undefined
+    ? !accessibilityState.expanded
+    : false;
+}

--- a/src/matchers/__tests__/to-be-collapsed.test.tsx
+++ b/src/matchers/__tests__/to-be-collapsed.test.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import { View } from 'react-native';
+import { render, screen } from '../..';
+import '../extend-expect';
+
+test('toBeCollapsed() basic case', () => {
+  render(
+    <>
+      <View testID="expanded" accessibilityState={{ expanded: true }} />
+      <View testID="expanded-aria" aria-expanded />
+      <View testID="not-expanded" accessibilityState={{ expanded: false }} />
+      <View testID="not-expanded-aria" aria-expanded={false} />
+      <View testID="default" />
+    </>
+  );
+
+  expect(screen.getByTestId('expanded')).not.toBeCollapsed();
+  expect(screen.getByTestId('expanded-aria')).not.toBeCollapsed();
+  expect(screen.getByTestId('not-expanded')).toBeCollapsed();
+  expect(screen.getByTestId('not-expanded-aria')).toBeCollapsed();
+  expect(screen.getByTestId('default')).not.toBeCollapsed();
+});
+
+test('toBeCollapsed() error messages', () => {
+  render(
+    <>
+      <View testID="expanded" accessibilityState={{ expanded: true }} />
+      <View testID="expanded-aria" aria-expanded />
+      <View testID="not-expanded" accessibilityState={{ expanded: false }} />
+      <View testID="not-expanded-aria" aria-expanded={false} />
+      <View testID="default" />
+    </>
+  );
+
+  expect(() => expect(screen.getByTestId('expanded')).toBeCollapsed())
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).toBeCollapsed()
+
+    Received element is not collapsed:
+      <View
+        accessibilityState={
+          {
+            "expanded": true,
+          }
+        }
+        testID="expanded"
+      />"
+  `);
+
+  expect(() => expect(screen.getByTestId('expanded-aria')).toBeCollapsed())
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).toBeCollapsed()
+
+    Received element is not collapsed:
+      <View
+        aria-expanded={true}
+        testID="expanded-aria"
+      />"
+  `);
+
+  expect(() => expect(screen.getByTestId('not-expanded')).not.toBeCollapsed())
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).not.toBeCollapsed()
+
+    Received element is collapsed:
+      <View
+        accessibilityState={
+          {
+            "expanded": false,
+          }
+        }
+        testID="not-expanded"
+      />"
+  `);
+
+  expect(() =>
+    expect(screen.getByTestId('not-expanded-aria')).not.toBeCollapsed()
+  ).toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).not.toBeCollapsed()
+
+    Received element is collapsed:
+      <View
+        aria-expanded={false}
+        testID="not-expanded-aria"
+      />"
+  `);
+
+  expect(() => expect(screen.getByTestId('default')).toBeCollapsed())
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).toBeCollapsed()
+
+    Received element is not collapsed:
+      <View
+        testID="default"
+      />"
+  `);
+});

--- a/src/matchers/__tests__/to-be-expanded.test.tsx
+++ b/src/matchers/__tests__/to-be-expanded.test.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { View } from 'react-native';
+import { render, screen } from '../..';
+import '../extend-expect';
+
+test('toBeExpanded() basic case', () => {
+  render(
+    <>
+      <View testID="expanded" accessibilityState={{ expanded: true }} />
+      <View testID="expanded-aria" aria-expanded />
+      <View testID="not-expanded" accessibilityState={{ expanded: false }} />
+      <View testID="not-expanded-aria" aria-expanded={false} />
+      <View testID="default" />
+    </>
+  );
+
+  expect(screen.getByTestId('expanded')).toBeExpanded();
+  expect(screen.getByTestId('expanded-aria')).toBeExpanded();
+  expect(screen.getByTestId('not-expanded')).not.toBeExpanded();
+  expect(screen.getByTestId('not-expanded-aria')).not.toBeExpanded();
+  expect(screen.getByTestId('default')).not.toBeExpanded();
+});
+
+test('toBeExpanded() error messages', () => {
+  render(
+    <>
+      <View testID="expanded" accessibilityState={{ expanded: true }} />
+      <View testID="expanded-aria" aria-expanded />
+      <View testID="not-expanded" accessibilityState={{ expanded: false }} />
+      <View testID="not-expanded-aria" aria-expanded={false} />
+      <View testID="default" />
+    </>
+  );
+
+  expect(() => expect(screen.getByTestId('expanded')).not.toBeExpanded())
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).not.toBeExpanded()
+
+    Received element is expanded:
+      <View
+        accessibilityState={
+          {
+            "expanded": true,
+          }
+        }
+        testID="expanded"
+      />"
+  `);
+
+  expect(() => expect(screen.getByTestId('expanded-aria')).not.toBeExpanded())
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).not.toBeExpanded()
+
+    Received element is expanded:
+      <View
+        aria-expanded={true}
+        testID="expanded-aria"
+      />"
+  `);
+
+  expect(() => expect(screen.getByTestId('not-expanded')).toBeExpanded())
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).toBeExpanded()
+
+    Received element is not expanded:
+      <View
+        accessibilityState={
+          {
+            "expanded": false,
+          }
+        }
+        testID="not-expanded"
+      />"
+  `);
+
+  expect(() => expect(screen.getByTestId('not-expanded-aria')).toBeExpanded())
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).toBeExpanded()
+
+    Received element is not expanded:
+      <View
+        aria-expanded={false}
+        testID="not-expanded-aria"
+      />"
+  `);
+
+  expect(() => expect(screen.getByTestId('default')).toBeExpanded())
+    .toThrowErrorMatchingInlineSnapshot(`
+    "expect(element).toBeExpanded()
+
+    Received element is not expanded:
+      <View
+        testID="default"
+      />"
+  `);
+});

--- a/src/matchers/extend-expect.d.ts
+++ b/src/matchers/extend-expect.d.ts
@@ -10,6 +10,7 @@ export interface JestNativeMatchers<R> {
   toBeBusy(): R;
   toBeEmptyElement(): R;
   toBeEnabled(): R;
+  toBeExpanded(): R;
   toBePartiallyChecked(): R;
   toBeSelected(): R;
   toBeVisible(): R;

--- a/src/matchers/extend-expect.d.ts
+++ b/src/matchers/extend-expect.d.ts
@@ -6,6 +6,7 @@ import type { Style } from './to-have-style';
 export interface JestNativeMatchers<R> {
   toBeOnTheScreen(): R;
   toBeChecked(): R;
+  toBeCollapsed(): R;
   toBeDisabled(): R;
   toBeBusy(): R;
   toBeEmptyElement(): R;

--- a/src/matchers/extend-expect.ts
+++ b/src/matchers/extend-expect.ts
@@ -5,6 +5,7 @@ import { toBeChecked } from './to-be-checked';
 import { toBeDisabled, toBeEnabled } from './to-be-disabled';
 import { toBeBusy } from './to-be-busy';
 import { toBeEmptyElement } from './to-be-empty-element';
+import { toBeExpanded } from './to-be-expanded';
 import { toBePartiallyChecked } from './to-be-partially-checked';
 import { toBeSelected } from './to-be-selected';
 import { toBeVisible } from './to-be-visible';
@@ -21,6 +22,7 @@ expect.extend({
   toBeBusy,
   toBeEmptyElement,
   toBeEnabled,
+  toBeExpanded,
   toBePartiallyChecked,
   toBeSelected,
   toBeVisible,

--- a/src/matchers/extend-expect.ts
+++ b/src/matchers/extend-expect.ts
@@ -2,6 +2,7 @@
 
 import { toBeOnTheScreen } from './to-be-on-the-screen';
 import { toBeChecked } from './to-be-checked';
+import { toBeCollapsed } from './to-be-collapsed';
 import { toBeDisabled, toBeEnabled } from './to-be-disabled';
 import { toBeBusy } from './to-be-busy';
 import { toBeEmptyElement } from './to-be-empty-element';
@@ -18,6 +19,7 @@ import { toHaveTextContent } from './to-have-text-content';
 expect.extend({
   toBeOnTheScreen,
   toBeChecked,
+  toBeCollapsed,
   toBeDisabled,
   toBeBusy,
   toBeEmptyElement,

--- a/src/matchers/index.tsx
+++ b/src/matchers/index.tsx
@@ -1,5 +1,6 @@
 export { toBeBusy } from './to-be-busy';
 export { toBeChecked } from './to-be-checked';
+export { toBeCollapsed } from './to-be-collapsed';
 export { toBeDisabled, toBeEnabled } from './to-be-disabled';
 export { toBeEmptyElement } from './to-be-empty-element';
 export { toBeExpanded } from './to-be-expanded';

--- a/src/matchers/index.tsx
+++ b/src/matchers/index.tsx
@@ -2,6 +2,7 @@ export { toBeBusy } from './to-be-busy';
 export { toBeChecked } from './to-be-checked';
 export { toBeDisabled, toBeEnabled } from './to-be-disabled';
 export { toBeEmptyElement } from './to-be-empty-element';
+export { toBeExpanded } from './to-be-expanded';
 export { toBeOnTheScreen } from './to-be-on-the-screen';
 export { toBePartiallyChecked } from './to-be-partially-checked';
 export { toBeSelected } from './to-be-selected';

--- a/src/matchers/to-be-collapsed.tsx
+++ b/src/matchers/to-be-collapsed.tsx
@@ -1,0 +1,28 @@
+import { ReactTestInstance } from 'react-test-renderer';
+import { matcherHint } from 'jest-matcher-utils';
+import { isElementCollapsed } from '../helpers/accessiblity';
+import { checkHostElement, formatElement } from './utils';
+
+export function toBeCollapsed(
+  this: jest.MatcherContext,
+  element: ReactTestInstance
+) {
+  checkHostElement(element, toBeCollapsed, this);
+
+  return {
+    pass: isElementCollapsed(element),
+    message: () => {
+      const matcher = matcherHint(
+        `${this.isNot ? '.not' : ''}.toBeCollapsed`,
+        'element',
+        ''
+      );
+      return [
+        matcher,
+        '',
+        `Received element is ${this.isNot ? '' : 'not '}collapsed:`,
+        formatElement(element),
+      ].join('\n');
+    },
+  };
+}

--- a/src/matchers/to-be-expanded.tsx
+++ b/src/matchers/to-be-expanded.tsx
@@ -1,0 +1,28 @@
+import { ReactTestInstance } from 'react-test-renderer';
+import { matcherHint } from 'jest-matcher-utils';
+import { isElementExpanded } from '../helpers/accessiblity';
+import { checkHostElement, formatElement } from './utils';
+
+export function toBeExpanded(
+  this: jest.MatcherContext,
+  element: ReactTestInstance
+) {
+  checkHostElement(element, toBeExpanded, this);
+
+  return {
+    pass: isElementExpanded(element),
+    message: () => {
+      const matcher = matcherHint(
+        `${this.isNot ? '.not' : ''}.toBeExpanded`,
+        'element',
+        ''
+      );
+      return [
+        matcher,
+        '',
+        `Received element is ${this.isNot ? '' : 'not '}expanded:`,
+        formatElement(element),
+      ].join('\n');
+    },
+  };
+}


### PR DESCRIPTION
### Summary

Part of Jest matchers migration
Following the example of https://github.com/callstack/react-native-testing-library/pull/1493

### Test plan

`yarn test`
