### PR TITLE
fix: disable React 17 tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
   test:
     needs: [install-cache-deps]
     runs-on: ubuntu-latest
-    name: Test React 18
+    name: Test
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -69,25 +69,11 @@ jobs:
       - name: Setup Node.js and deps
         uses: ./.github/actions/setup-deps
 
-      - name: Test React 18
+      - name: Test
         run: yarn test:ci
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
-
-  test-react-17:
-    needs: [install-cache-deps]
-    runs-on: ubuntu-latest
-    name: Test React 17
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Setup Node.js and deps
-        uses: ./.github/actions/setup-deps
-
-      - name: Test React 17
-        run: yarn test:ci:react:17
 
   test-website:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "clean": "del build",
     "test": "jest",
     "test:ci": "jest --maxWorkers=2 --collectCoverage=true --coverage-provider=v8",
-    "test:ci:react:17": "scripts/test_react_17",
+    "test:react-17": "scripts/test_react_17",
     "typecheck": "tsc",
     "flow": "flow",
     "copy-flowtypes": "cp typings/index.flow.js build",


### PR DESCRIPTION
### Summary

Disable React 17 tests on CI, as they were always failing due to snapshot miss match as well of some unsupported features like the new ARIA props. On the other hand the way the test script has been written quietly consumed this failure, so that React 17 tests always indicated success.


I've tried to disable just this tests on the CI but could not overcome following error (local & CI):
```
Jest has detected the following 1 open handle potentially keeping Jest from exiting:

  ●  MESSAGEPORT

      1 | // This file and the act() implementation is sourced from react-testing-library
      2 | // https://github.com/testing-library/react-testing-library/blob/c80809a956b0b9f3289c4a6fa8b5e8cc72d6ef6d/src/act-compat.js
    > 3 | import { act as reactTestRendererAct } from 'react-test-renderer';
        | ^
      4 | import { checkReactVersionAtLeast } from './react-versions';
      5 |
      6 | type ReactAct = typeof reactTestRendererAct;

      at node_modules/scheduler/cjs/scheduler.development.js:178:17
      at Object.<anonymous> (node_modules/scheduler/cjs/scheduler.development.js:645:5)
      at Object.<anonymous> (node_modules/scheduler/index.js:6:20)
      at node_modules/react-test-renderer/cjs/react-test-renderer.development.js:19:19
      at Object.<anonymous> (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:17382:5)
      at Object.<anonymous> (node_modules/react-test-renderer/index.js:6:20)
      at Object.require (src/act.ts:3:1)
      at Object.require (src/pure.ts:1:1)
      at Object.require (jest-setup.ts:1:1)
```

React 17 tests could still be run locally using `yarn test:react-17` script.

### Test plan

