### PR TITLE
add possibility to configure interval with configure method

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -7,14 +7,17 @@ import {
 
 test('getConfig() returns existing configuration', () => {
   expect(getConfig().asyncUtilTimeout).toEqual(1000);
+  expect(getConfig().asyncUtilInterval).toEqual(50);
   expect(getConfig().defaultIncludeHiddenElements).toEqual(false);
 });
 
 test('configure() overrides existing config values', () => {
   configure({ asyncUtilTimeout: 5000 });
   configure({ defaultDebugOptions: { message: 'debug message' } });
+  configure({ asyncUtilInterval: 10 });
   expect(getConfig()).toEqual({
     asyncUtilTimeout: 5000,
+    asyncUtilInterval: 10,
     defaultDebugOptions: { message: 'debug message' },
     defaultIncludeHiddenElements: false,
   });
@@ -23,13 +26,16 @@ test('configure() overrides existing config values', () => {
 test('resetToDefaults() resets config to defaults', () => {
   configure({
     asyncUtilTimeout: 5000,
+    asyncUtilInterval: 10,
     defaultIncludeHiddenElements: true,
   });
   expect(getConfig().asyncUtilTimeout).toEqual(5000);
+  expect(getConfig().asyncUtilInterval).toEqual(10);
   expect(getConfig().defaultIncludeHiddenElements).toEqual(true);
 
   resetToDefaults();
   expect(getConfig().asyncUtilTimeout).toEqual(1000);
+  expect(getConfig().asyncUtilInterval).toEqual(50);
   expect(getConfig().defaultIncludeHiddenElements).toEqual(false);
 });
 

--- a/src/__tests__/waitFor.test.tsx
+++ b/src/__tests__/waitFor.test.tsx
@@ -104,6 +104,52 @@ test('waits for element with custom interval', async () => {
   expect(mockFn).toHaveBeenCalledTimes(2);
 });
 
+test('waitFor interval defaults to asyncUtilInterval default value', async () => {
+  const mockFn = jest.fn(() => {
+    throw Error('test');
+  });
+
+  try {
+    await waitFor(() => mockFn(), { timeout: 100 });
+  } catch (e) {
+    // suppress
+  }
+
+  expect(mockFn).toHaveBeenCalledTimes(2); // Default interval is set to 50ms
+});
+
+test('waitFor interval defaults to asyncUtilInterval config option', async () => {
+  configure({ asyncUtilInterval: 10 });
+
+  const mockFn = jest.fn(() => {
+    throw Error('test');
+  });
+
+  try {
+    await waitFor(() => mockFn(), { timeout: 100 });
+  } catch (e) {
+    // suppress
+  }
+
+  expect(mockFn).toHaveBeenCalledTimes(10);
+});
+
+test('waitFor interval option takes precendence over asyncUtilInterval config option', async () => {
+  configure({ asyncUtilInterval: 10 });
+
+  const mockFn = jest.fn(() => {
+    throw Error('test');
+  });
+
+  try {
+    await waitFor(() => mockFn(), { timeout: 100, interval: 20 });
+  } catch (e) {
+    // suppress
+  }
+
+  expect(mockFn).toHaveBeenCalledTimes(5);
+});
+
 // this component is convoluted on purpose. It is not a good react pattern, but it is valid
 // react code that will run differently between different react versions (17 and 18), so we need
 // explicit tests for it

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,9 @@ export type Config = {
   /** Default timeout, in ms, for `waitFor` and `findBy*` queries. */
   asyncUtilTimeout: number;
 
+  /** Default interval, in ms, for `waitFor` and `findBy*` queries. */
+  asyncUtilInterval: number;
+
   /** Default value for `includeHiddenElements` query option. */
   defaultIncludeHiddenElements: boolean;
 
@@ -35,6 +38,7 @@ export type InternalConfig = Config & {
 
 const defaultConfig: InternalConfig = {
   asyncUtilTimeout: 1000,
+  asyncUtilInterval: 50,
   defaultIncludeHiddenElements: false,
 };
 

--- a/src/waitFor.ts
+++ b/src/waitFor.ts
@@ -10,8 +10,6 @@ import {
 } from './helpers/timers';
 import { checkReactVersionAtLeast } from './react-versions';
 
-const DEFAULT_INTERVAL = 50;
-
 export type WaitForOptions = {
   timeout?: number;
   interval?: number;
@@ -23,7 +21,7 @@ function waitForInternal<T>(
   expectation: () => T,
   {
     timeout = getConfig().asyncUtilTimeout,
-    interval = DEFAULT_INTERVAL,
+    interval = getConfig().asyncUtilInterval,
     stackTraceError,
     onTimeout,
   }: WaitForOptions

--- a/website/docs/API.md
+++ b/website/docs/API.md
@@ -552,7 +552,7 @@ Defined as:
 ```ts
 function waitForElementToBeRemoved<T>(
   expectation: () => T,
-  { timeout: number = 4500, interval: number = 50 }
+  { timeout: number = 1000, interval: number = 50 }
 ): Promise<T> {}
 ```
 
@@ -800,6 +800,7 @@ it('should use context value', () => {
 ```ts
 type Config = {
   asyncUtilTimeout: number;
+  asyncUtilInterval: number;
   defaultHidden: boolean;
   defaultDebugOptions: Partial<DebugOptions>;
 };
@@ -810,6 +811,10 @@ function configure(options: Partial<Config>) {}
 #### `asyncUtilTimeout` option
 
 Default timeout, in ms, for async helper functions (`waitFor`, `waitForElementToBeRemoved`) and `findBy*` queries. Defaults to 1000 ms.
+
+#### `asyncUtilInterval` option
+
+Default interval, in ms, for async helper functions (`waitFor`, `waitForElementToBeRemoved`) and `findBy*` queries. Defaults to 50 ms.
 
 #### `defaultIncludeHiddenElements` option
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

Currently, we're able to override the default timeout, but we can't do the same for the interval. For my test cases, 50ms has proven to be too long of an interval, and changing that setting for each case is tedious. I added a possibility to configure the default interval by configure method to solve that. 

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

I added tests based on those for interval and timeout.
