### PR TITLE
fix: change broken hyperlink in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ test('form submits two answers', () => {
 });
 ```
 
-You can find the source of `QuestionsBoard` component and this example [here](https://github.com/callstack/react-native-testing-library/blob/main/src/__tests__/questionsBoard.test.js).
+You can find the source of `QuestionsBoard` component and this example [here](https://github.com/callstack/react-native-testing-library/blob/main/src/__tests__/questionsBoard.test.tsx).
 
 ## API / Usage
 


### PR DESCRIPTION
### Summary

Fix broken hyperlink in README.md. Encountered 404 with the old URL link. 

### Test plan

