### PR TITLE
chore: fix extend-expect.d.ts types by internalizing them

### DIFF
--- a/src/matchers/extend-expect.d.ts
+++ b/src/matchers/extend-expect.d.ts
@@ -1,8 +1,5 @@
 import type { StyleProp } from 'react-native';
 import type { ReactTestInstance } from 'react-test-renderer';
-import type { TextMatch, TextMatchOptions } from '../matches';
-import type { AccessibilityValueMatcher } from '../helpers/matchers/match-accessibility-value';
-import type { Style } from './to-have-style';
 
 export interface JestNativeMatchers<R> {
   toBeOnTheScreen(): R;
@@ -38,3 +35,22 @@ declare module '@jest/expect' {
   interface Matchers<R extends void | Promise<void>>
     extends JestNativeMatchers<R> {}
 }
+
+// Used types
+
+export type Style = ViewStyle | TextStyle | ImageStyle;
+
+export interface AccessibilityValueMatcher {
+  min?: number;
+  max?: number;
+  now?: number;
+  text?: TextMatch;
+}
+
+export type TextMatch = string | RegExp;
+export type TextMatchOptions = {
+  exact?: boolean;
+  normalizer?: NormalizerFn;
+};
+
+export type NormalizerFn = (textToNormalize: string) => string;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes #1534 

It moves are dependant types definitions for things like `Style`, `AccessibilityValueMatcher`, etc to inside the file, are referencing other  TS did not seem to work.

This is more of a workaround, as we now have mentioned types declared twice, so it would be to refactor it later to work it more automatically.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
