### PR TITLE
Disable prettier error alert

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "extends": "@callstack",
   "rules": {
+    "prettier/prettier": 0, 
     "flowtype/no-weak-types": 0,
     "react-native/no-raw-text": 0,
     "no-console": 1,


### PR DESCRIPTION
Prettier alerts disabled. Focusing on disabling unnecessary errors.