### PR TITLE
docs: add an in-depth RNTL guide link to the Getting Started page

### DIFF
--- a/website/docs/GettingStarted.md
+++ b/website/docs/GettingStarted.md
@@ -81,3 +81,5 @@ test('form submits two answers', () => {
 ```
 
 You can find the source of the `QuestionsBoard` component and this example [here](https://github.com/callstack/react-native-testing-library/blob/main/src/__tests__/questionsBoard.test.tsx).
+
+If you want to learn from more examples on how to write tests with code, how to set up `Jest` config for RNTL, how to do `mocking` with RNTL, common errors in Jest config, and much more, then check out this [**guide**](https://github.com/anisurrahman072/React-Native-Advanced-Guide/blob/master/Testing/RNTL-Component-Testing-ultimate-guide.md).


### PR DESCRIPTION
### Summary
- Added a link of [**RNTL in depth guide**](https://github.com/anisurrahman072/React-Native-Advanced-Guide/blob/master/Testing/RNTL-Component-Testing-ultimate-guide.md) to the Getting Started page `Example` section
- The Guide link that was added, got huge response from community ([**800+ GitHub STAR**](https://github.com/anisurrahman072/React-Native-Advanced-Guide?tab=readme-ov-file#-003---ultimate-guide-on-component-js-testing-by-rntl-with-jest-setup) in a repo where the Guide was added & [**~400 CLAP from Medium**](https://medium.com/@anisurrahmanbup/react-native-testing-ultimate-guide-219a5e7ea5dc) devs)
- The Guide covered 👇

          1. Almost all the parts of RNTL in most easiest way
          2. Almost all types of JEST config for RNTL with examples
          3. All types of Mocking by RNTL
          4. Common errors of Jest configs & their solutions
          5. Many more with proper examples & guide
          
- **RNTL Discussion Link:** #1555 
- **RNTL Guide Link:** https://github.com/anisurrahman072/React-Native-Advanced-Guide/blob/master/Testing/RNTL-Component-Testing-ultimate-guide.md

### Test plan
- Please review changed content
- Also, please check the [**RNTL in depth guide**](https://github.com/anisurrahman072/React-Native-Advanced-Guide/blob/master/Testing/RNTL-Component-Testing-ultimate-guide.md), as it can benefit the CallStack community.

### Change to the Guide
- I’m eager to accept any suggestions to modify the guide so that it can help the CallStack community.