### PR TITLE
fix(user-event): Decouple press events from Jest dependency

### DIFF
--- a/src/user-event/event-builder/common.ts
+++ b/src/user-event/event-builder/common.ts
@@ -16,8 +16,8 @@ function touch() {
       timestamp: Date.now(),
       touches: [],
     },
-    persist: jest.fn(),
-    currentTarget: { measure: jest.fn() },
+    persist: noop,
+    currentTarget: { measure: noop },
     target: {},
   };
 }
@@ -69,3 +69,7 @@ export const CommonEventBuilder = {
     };
   },
 };
+
+function noop(): void {
+  // do nothing
+}

--- a/src/user-event/press/__tests__/__snapshots__/longPress.test.tsx.snap
+++ b/src/user-event/press/__tests__/__snapshots__/longPress.test.tsx.snap
@@ -6,26 +6,7 @@ exports[`userEvent.longPress with fake timers calls onLongPress if the delayLong
     "name": "longPress",
     "payload": {
       "currentTarget": {
-        "measure": [MockFunction] {
-          "calls": [
-            [
-              [Function],
-            ],
-            [
-              [Function],
-            ],
-          ],
-          "results": [
-            {
-              "type": "return",
-              "value": undefined,
-            },
-            {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        },
+        "measure": [Function],
       },
       "dispatchConfig": {
         "registrationName": "onResponderGrant",
@@ -41,17 +22,7 @@ exports[`userEvent.longPress with fake timers calls onLongPress if the delayLong
         "timestamp": 0,
         "touches": [],
       },
-      "persist": [MockFunction] {
-        "calls": [
-          [],
-        ],
-        "results": [
-          {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
+      "persist": [Function],
       "target": {},
     },
   },

--- a/src/user-event/press/__tests__/__snapshots__/press.test.tsx.snap
+++ b/src/user-event/press/__tests__/__snapshots__/press.test.tsx.snap
@@ -6,26 +6,7 @@ exports[`userEvent.press with fake timers calls onPressIn, onPress and onPressOu
     "name": "pressIn",
     "payload": {
       "currentTarget": {
-        "measure": [MockFunction] {
-          "calls": [
-            [
-              [Function],
-            ],
-            [
-              [Function],
-            ],
-          ],
-          "results": [
-            {
-              "type": "return",
-              "value": undefined,
-            },
-            {
-              "type": "return",
-              "value": undefined,
-            },
-          ],
-        },
+        "measure": [Function],
       },
       "dispatchConfig": {
         "registrationName": "onResponderGrant",
@@ -41,17 +22,7 @@ exports[`userEvent.press with fake timers calls onPressIn, onPress and onPressOu
         "timestamp": 0,
         "touches": [],
       },
-      "persist": [MockFunction] {
-        "calls": [
-          [],
-        ],
-        "results": [
-          {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
+      "persist": [Function],
       "target": {},
     },
   },
@@ -59,7 +30,7 @@ exports[`userEvent.press with fake timers calls onPressIn, onPress and onPressOu
     "name": "press",
     "payload": {
       "currentTarget": {
-        "measure": [MockFunction],
+        "measure": [Function],
       },
       "dispatchConfig": {
         "registrationName": "onResponderRelease",
@@ -75,17 +46,7 @@ exports[`userEvent.press with fake timers calls onPressIn, onPress and onPressOu
         "timestamp": 0,
         "touches": [],
       },
-      "persist": [MockFunction] {
-        "calls": [
-          [],
-        ],
-        "results": [
-          {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
+      "persist": [Function],
       "target": {},
     },
   },
@@ -93,7 +54,7 @@ exports[`userEvent.press with fake timers calls onPressIn, onPress and onPressOu
     "name": "pressOut",
     "payload": {
       "currentTarget": {
-        "measure": [MockFunction],
+        "measure": [Function],
       },
       "dispatchConfig": {
         "registrationName": "onResponderRelease",
@@ -109,17 +70,7 @@ exports[`userEvent.press with fake timers calls onPressIn, onPress and onPressOu
         "timestamp": 0,
         "touches": [],
       },
-      "persist": [MockFunction] {
-        "calls": [
-          [],
-        ],
-        "results": [
-          {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
+      "persist": [Function],
       "target": {},
     },
   },

--- a/src/user-event/type/__tests__/__snapshots__/type-managed.test.tsx.snap
+++ b/src/user-event/type/__tests__/__snapshots__/type-managed.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`type() for managed TextInput supports basic case: input: "Wow" 1`] = `
     "name": "pressIn",
     "payload": {
       "currentTarget": {
-        "measure": [MockFunction],
+        "measure": [Function],
       },
       "nativeEvent": {
         "changedTouches": [],
@@ -19,7 +19,7 @@ exports[`type() for managed TextInput supports basic case: input: "Wow" 1`] = `
         "timestamp": 100100100100,
         "touches": [],
       },
-      "persist": [MockFunction],
+      "persist": [Function],
       "target": {},
     },
   },
@@ -37,7 +37,7 @@ exports[`type() for managed TextInput supports basic case: input: "Wow" 1`] = `
     "name": "pressOut",
     "payload": {
       "currentTarget": {
-        "measure": [MockFunction],
+        "measure": [Function],
       },
       "nativeEvent": {
         "changedTouches": [],
@@ -50,7 +50,7 @@ exports[`type() for managed TextInput supports basic case: input: "Wow" 1`] = `
         "timestamp": 100100100100,
         "touches": [],
       },
-      "persist": [MockFunction],
+      "persist": [Function],
       "target": {},
     },
   },
@@ -201,7 +201,7 @@ exports[`type() for managed TextInput supports rejecting TextInput: input: "ABC"
     "name": "pressIn",
     "payload": {
       "currentTarget": {
-        "measure": [MockFunction],
+        "measure": [Function],
       },
       "nativeEvent": {
         "changedTouches": [],
@@ -214,7 +214,7 @@ exports[`type() for managed TextInput supports rejecting TextInput: input: "ABC"
         "timestamp": 100100100100,
         "touches": [],
       },
-      "persist": [MockFunction],
+      "persist": [Function],
       "target": {},
     },
   },
@@ -232,7 +232,7 @@ exports[`type() for managed TextInput supports rejecting TextInput: input: "ABC"
     "name": "pressOut",
     "payload": {
       "currentTarget": {
-        "measure": [MockFunction],
+        "measure": [Function],
       },
       "nativeEvent": {
         "changedTouches": [],
@@ -245,7 +245,7 @@ exports[`type() for managed TextInput supports rejecting TextInput: input: "ABC"
         "timestamp": 100100100100,
         "touches": [],
       },
-      "persist": [MockFunction],
+      "persist": [Function],
       "target": {},
     },
   },

--- a/src/user-event/type/__tests__/__snapshots__/type.test.tsx.snap
+++ b/src/user-event/type/__tests__/__snapshots__/type.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`type() supports backspace: input: "{Backspace}a", defaultValue: "xxx" 1
     "name": "pressIn",
     "payload": {
       "currentTarget": {
-        "measure": [MockFunction],
+        "measure": [Function],
       },
       "nativeEvent": {
         "changedTouches": [],
@@ -19,7 +19,7 @@ exports[`type() supports backspace: input: "{Backspace}a", defaultValue: "xxx" 1
         "timestamp": 100100100100,
         "touches": [],
       },
-      "persist": [MockFunction],
+      "persist": [Function],
       "target": {},
     },
   },
@@ -37,7 +37,7 @@ exports[`type() supports backspace: input: "{Backspace}a", defaultValue: "xxx" 1
     "name": "pressOut",
     "payload": {
       "currentTarget": {
-        "measure": [MockFunction],
+        "measure": [Function],
       },
       "nativeEvent": {
         "changedTouches": [],
@@ -50,7 +50,7 @@ exports[`type() supports backspace: input: "{Backspace}a", defaultValue: "xxx" 1
         "timestamp": 100100100100,
         "touches": [],
       },
-      "persist": [MockFunction],
+      "persist": [Function],
       "target": {},
     },
   },
@@ -162,7 +162,7 @@ exports[`type() supports basic case: input: "abc" 1`] = `
     "name": "pressIn",
     "payload": {
       "currentTarget": {
-        "measure": [MockFunction],
+        "measure": [Function],
       },
       "nativeEvent": {
         "changedTouches": [],
@@ -175,7 +175,7 @@ exports[`type() supports basic case: input: "abc" 1`] = `
         "timestamp": 100100100100,
         "touches": [],
       },
-      "persist": [MockFunction],
+      "persist": [Function],
       "target": {},
     },
   },
@@ -193,7 +193,7 @@ exports[`type() supports basic case: input: "abc" 1`] = `
     "name": "pressOut",
     "payload": {
       "currentTarget": {
-        "measure": [MockFunction],
+        "measure": [Function],
       },
       "nativeEvent": {
         "changedTouches": [],
@@ -206,7 +206,7 @@ exports[`type() supports basic case: input: "abc" 1`] = `
         "timestamp": 100100100100,
         "touches": [],
       },
-      "persist": [MockFunction],
+      "persist": [Function],
       "target": {},
     },
   },
@@ -357,7 +357,7 @@ exports[`type() supports defaultValue prop: input: "ab", defaultValue: "xxx" 1`]
     "name": "pressIn",
     "payload": {
       "currentTarget": {
-        "measure": [MockFunction],
+        "measure": [Function],
       },
       "nativeEvent": {
         "changedTouches": [],
@@ -370,7 +370,7 @@ exports[`type() supports defaultValue prop: input: "ab", defaultValue: "xxx" 1`]
         "timestamp": 100100100100,
         "touches": [],
       },
-      "persist": [MockFunction],
+      "persist": [Function],
       "target": {},
     },
   },
@@ -388,7 +388,7 @@ exports[`type() supports defaultValue prop: input: "ab", defaultValue: "xxx" 1`]
     "name": "pressOut",
     "payload": {
       "currentTarget": {
-        "measure": [MockFunction],
+        "measure": [Function],
       },
       "nativeEvent": {
         "changedTouches": [],
@@ -401,7 +401,7 @@ exports[`type() supports defaultValue prop: input: "ab", defaultValue: "xxx" 1`]
         "timestamp": 100100100100,
         "touches": [],
       },
-      "persist": [MockFunction],
+      "persist": [Function],
       "target": {},
     },
   },
@@ -513,7 +513,7 @@ exports[`type() supports multiline: input: "{Enter}\\n", multiline: true 1`] = `
     "name": "pressIn",
     "payload": {
       "currentTarget": {
-        "measure": [MockFunction],
+        "measure": [Function],
       },
       "nativeEvent": {
         "changedTouches": [],
@@ -526,7 +526,7 @@ exports[`type() supports multiline: input: "{Enter}\\n", multiline: true 1`] = `
         "timestamp": 100100100100,
         "touches": [],
       },
-      "persist": [MockFunction],
+      "persist": [Function],
       "target": {},
     },
   },
@@ -544,7 +544,7 @@ exports[`type() supports multiline: input: "{Enter}\\n", multiline: true 1`] = `
     "name": "pressOut",
     "payload": {
       "currentTarget": {
-        "measure": [MockFunction],
+        "measure": [Function],
       },
       "nativeEvent": {
         "changedTouches": [],
@@ -557,7 +557,7 @@ exports[`type() supports multiline: input: "{Enter}\\n", multiline: true 1`] = `
         "timestamp": 100100100100,
         "touches": [],
       },
-      "persist": [MockFunction],
+      "persist": [Function],
       "target": {},
     },
   },

--- a/src/user-event/utils/warn-about-real-timers.ts
+++ b/src/user-event/utils/warn-about-real-timers.ts
@@ -2,7 +2,7 @@ import { jestFakeTimersAreEnabled } from '../../helpers/timers';
 
 export const warnAboutRealTimersIfNeeded = () => {
   const areFakeTimersEnabled = jestFakeTimersAreEnabled();
-  if (areFakeTimersEnabled) {
+  if (process.env.RNTL_SKIP_AUTO_DETECT_FAKE_TIMERS || areFakeTimersEnabled) {
     return;
   }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Solves #1568 by decoupling press events in `user-event` from Jest dependency. As mentioned in the issue, this is done by replacing instances of `jest.fn()` with a simple `noop()` function, which does not cause any breaking change.

Additionally, it solves a small bug with `warnAboutRealTimersIfNeeded()` that caused the warning to be triggered even when `RNTL_SKIP_AUTO_DETECT_FAKE_TIMERS` is present.

### Test plan

This PR can be tested following the issue's **Steps to Reproduce**:

1. Setup test without Jest. For example, using Mocha.js together with [react-native-testing-mocks](https://github.com/JoseLion/react-native-testing-mocks).
2. Create a simple test containing a `userEvent.press(..)` call
3. Because Jest is not present in the project, an error should be triggered: `TypeError: event.persist is not a function`
4. Apply this PR changes and run the test again
5. The error should be gone and the test runs as expected