### PR TITLE
fix: find by timeout with detached screen

### DIFF
--- a/src/queries/__tests__/find-by.test.tsx
+++ b/src/queries/__tests__/find-by.test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { View } from 'react-native';
+import { render, screen } from '../..';
+import { clearRenderResult } from '../../screen';
+
+test('findByTestId detects screen being detached', async () => {
+  render(<View />);
+
+  const promise = screen.findByTestId('not-exists', {}, { timeout: 50 });
+
+  // Detach screen
+  clearRenderResult();
+
+  await expect(promise).rejects.toThrowErrorMatchingInlineSnapshot(`
+    "Unable to find an element with testID: not-exists
+
+    Screen is no longer attached."
+  `);
+});

--- a/src/queries/__tests__/find-by.test.tsx
+++ b/src/queries/__tests__/find-by.test.tsx
@@ -14,6 +14,6 @@ test('findByTestId detects screen being detached', async () => {
   await expect(promise).rejects.toThrowErrorMatchingInlineSnapshot(`
     "Unable to find an element with testID: not-exists
 
-    Screen is no longer attached."
+    Screen is no longer attached. Check your test for "findBy*" or "waitFor" calls that have not been awaited."
   `);
 });

--- a/src/queries/__tests__/find-by.test.tsx
+++ b/src/queries/__tests__/find-by.test.tsx
@@ -14,6 +14,9 @@ test('findByTestId detects screen being detached', async () => {
   await expect(promise).rejects.toThrowErrorMatchingInlineSnapshot(`
     "Unable to find an element with testID: not-exists
 
-    Screen is no longer attached. Check your test for "findBy*" or "waitFor" calls that have not been awaited."
+    Screen is no longer attached. Check your test for "findBy*" or "waitFor" calls that have not been awaited.
+
+    We recommend enabling Testing Library ESLint plugin to catch these issues at build time:
+    https://callstack.github.io/react-native-testing-library/docs/eslint-plugin-testing-library"
   `);
 });

--- a/src/queries/__tests__/find-by.test.tsx
+++ b/src/queries/__tests__/find-by.test.tsx
@@ -16,7 +16,7 @@ test('findByTestId detects screen being detached', async () => {
 
     Screen is no longer attached. Check your test for "findBy*" or "waitFor" calls that have not been awaited.
 
-    We recommend enabling Testing Library ESLint plugin to catch these issues at build time:
-    https://callstack.github.io/react-native-testing-library/docs/eslint-plugin-testing-library"
+    We recommend enabling "eslint-plugin-testing-library" to catch these issues at build time:
+    https://callstack.github.io/react-native-testing-library/docs/getting-started#eslint-plugin"
   `);
 });

--- a/src/queries/make-queries.ts
+++ b/src/queries/make-queries.ts
@@ -88,7 +88,7 @@ function formatErrorMessage(message: string, printElementTree: boolean) {
   }
 
   if (screen.isDetached) {
-    return `${message}\n\nScreen is no longer attached. Check your test for "findBy*" or "waitFor" calls that have not been awaited.`;
+    return `${message}\n\nScreen is no longer attached. Check your test for "findBy*" or "waitFor" calls that have not been awaited.\n\nWe recommend enabling Testing Library ESLint plugin to catch these issues at build time:\nhttps://callstack.github.io/react-native-testing-library/docs/eslint-plugin-testing-library`;
   }
 
   const json = screen.toJSON();

--- a/src/queries/make-queries.ts
+++ b/src/queries/make-queries.ts
@@ -88,7 +88,7 @@ function formatErrorMessage(message: string, printElementTree: boolean) {
   }
 
   if (screen.isDetached) {
-    return `${message}\n\nScreen is no longer attached. Check your test for "findBy*" or "waitFor" calls that have not been awaited.\n\nWe recommend enabling Testing Library ESLint plugin to catch these issues at build time:\nhttps://callstack.github.io/react-native-testing-library/docs/eslint-plugin-testing-library`;
+    return `${message}\n\nScreen is no longer attached. Check your test for "findBy*" or "waitFor" calls that have not been awaited.\n\nWe recommend enabling "eslint-plugin-testing-library" to catch these issues at build time:\nhttps://callstack.github.io/react-native-testing-library/docs/getting-started#eslint-plugin`;
   }
 
   const json = screen.toJSON();

--- a/src/queries/make-queries.ts
+++ b/src/queries/make-queries.ts
@@ -87,8 +87,8 @@ function formatErrorMessage(message: string, printElementTree: boolean) {
     return message;
   }
 
-  if (!screen.isAttached) {
-    return `${message}\n\nScreen is no longer attached.`;
+  if (screen.isDetached) {
+    return `${message}\n\nScreen is no longer attached. Check your test for "findBy*" or "waitFor" calls that have not been awaited.`;
   }
 
   const json = screen.toJSON();

--- a/src/queries/make-queries.ts
+++ b/src/queries/make-queries.ts
@@ -87,6 +87,10 @@ function formatErrorMessage(message: string, printElementTree: boolean) {
     return message;
   }
 
+  if (!screen.isAttached) {
+    return `${message}\n\nScreen is no longer attached.`;
+  }
+
   const json = screen.toJSON();
   if (!json) {
     return message;

--- a/src/screen.ts
+++ b/src/screen.ts
@@ -13,11 +13,11 @@ const notImplementedDebug = () => {
 notImplementedDebug.shallow = notImplemented;
 
 interface Screen extends RenderResult {
-  isAttached: boolean;
+  isDetached?: boolean;
 }
 
 const defaultScreen: Screen = {
-  isAttached: false,
+  isDetached: true,
   get root(): ReactTestInstance {
     throw new Error(SCREEN_ERROR);
   },
@@ -120,10 +120,7 @@ const defaultScreen: Screen = {
 export let screen: Screen = defaultScreen;
 
 export function setRenderResult(renderResult: RenderResult) {
-  screen = {
-    ...renderResult,
-    isAttached: true,
-  };
+  screen = renderResult;
 }
 
 export function clearRenderResult() {

--- a/src/screen.ts
+++ b/src/screen.ts
@@ -12,7 +12,12 @@ const notImplementedDebug = () => {
 };
 notImplementedDebug.shallow = notImplemented;
 
-const defaultScreen: RenderResult = {
+interface Screen extends RenderResult {
+  isAttached: boolean;
+}
+
+const defaultScreen: Screen = {
+  isAttached: false,
   get root(): ReactTestInstance {
     throw new Error(SCREEN_ERROR);
   },
@@ -112,10 +117,13 @@ const defaultScreen: RenderResult = {
   findAllByText: notImplemented,
 };
 
-export let screen: RenderResult = defaultScreen;
+export let screen: Screen = defaultScreen;
 
-export function setRenderResult(output: RenderResult) {
-  screen = output;
+export function setRenderResult(renderResult: RenderResult) {
+  screen = {
+    ...renderResult,
+    isAttached: true,
+  };
 }
 
 export function clearRenderResult() {


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Fixes error on access to detached `screen` object in `findBy` calls.

Resolves #1572 

### Test plan

