### PR TITLE
fix: proper act usage

### DIFF
--- a/src/helpers/wrap-async.ts
+++ b/src/helpers/wrap-async.ts
@@ -1,7 +1,6 @@
 /* istanbul ignore file */
 
-import { act } from 'react-test-renderer';
-import { getIsReactActEnvironment, setReactActEnvironment } from '../act';
+import act, { getIsReactActEnvironment, setReactActEnvironment } from '../act';
 import { flushMicroTasksLegacy } from '../flush-micro-tasks';
 import { checkReactVersionAtLeast } from '../react-versions';
 

--- a/src/render-act.ts
+++ b/src/render-act.ts
@@ -1,5 +1,6 @@
 import TestRenderer from 'react-test-renderer';
 import type { ReactTestRenderer, TestRendererOptions } from 'react-test-renderer';
+import act from './act';
 
 export function renderWithAct(
   component: React.ReactElement,
@@ -8,7 +9,7 @@ export function renderWithAct(
   let renderer: ReactTestRenderer;
 
   // This will be called synchronously.
-  void TestRenderer.act(() => {
+  void act(() => {
     renderer = TestRenderer.create(component, options);
   });
 

--- a/src/user-event/press/__tests__/press.real-timers.test.tsx
+++ b/src/user-event/press/__tests__/press.real-timers.test.tsx
@@ -203,7 +203,7 @@ describe('userEvent.press with real timers', () => {
     expect(getEventsName(events)).toEqual(['pressIn', 'press', 'pressOut']);
   });
 
-  test('doesnt trigger on disabled Text', async () => {
+  test('does not trigger on disabled Text', async () => {
     const { events, logEvent } = createEventLogger();
 
     render(
@@ -222,7 +222,7 @@ describe('userEvent.press with real timers', () => {
     expect(events).toEqual([]);
   });
 
-  test('doesnt trigger on Text with disabled pointer events', async () => {
+  test('does not trigger on Text with disabled pointer events', async () => {
     const { events, logEvent } = createEventLogger();
 
     render(

--- a/src/user-event/press/__tests__/press.test.tsx
+++ b/src/user-event/press/__tests__/press.test.tsx
@@ -6,6 +6,7 @@ import {
   TouchableHighlight,
   TouchableOpacity,
   View,
+  Button,
 } from 'react-native';
 import { createEventLogger, getEventsName } from '../../../test-utils';
 import { render, screen } from '../../..';
@@ -199,6 +200,15 @@ describe('userEvent.press with fake timers', () => {
 
     await userEvent.press(screen.getByText('press me'));
     expect(getEventsName(events)).toEqual(['pressIn', 'press', 'pressOut']);
+  });
+
+  test('press works on Button', async () => {
+    const { events, logEvent } = createEventLogger();
+
+    render(<Button title="press me" onPress={logEvent('press')} />);
+
+    await userEvent.press(screen.getByText('press me'));
+    expect(getEventsName(events)).toEqual(['press']);
   });
 
   test('longPress works Text', async () => {

--- a/src/user-event/press/__tests__/press.test.tsx
+++ b/src/user-event/press/__tests__/press.test.tsx
@@ -229,7 +229,7 @@ describe('userEvent.press with fake timers', () => {
     expect(getEventsName(events)).toEqual(['pressIn', 'longPress', 'pressOut']);
   });
 
-  test('doesnt trigger on disabled Text', async () => {
+  test('does not trigger on disabled Text', async () => {
     const { events, logEvent } = createEventLogger();
 
     render(
@@ -248,7 +248,7 @@ describe('userEvent.press with fake timers', () => {
     expect(events).toEqual([]);
   });
 
-  test('doesnt trigger on Text with disabled pointer events', async () => {
+  test('does not trigger on Text with disabled pointer events', async () => {
     const { events, logEvent } = createEventLogger();
 
     render(

--- a/src/user-event/press/press.ts
+++ b/src/user-event/press/press.ts
@@ -1,4 +1,5 @@
 import { ReactTestInstance } from 'react-test-renderer';
+import act from '../../act';
 import { getHostParent } from '../../helpers/component-tree';
 import { isTextInputEditable } from '../../helpers/text-input';
 import { isPointerEventEnabled } from '../../helpers/pointer-events';
@@ -82,7 +83,9 @@ const emitPressablePressEvents = async (
   // before emitting the `pressOut` event. We need to wait here, so that
   // `press()` function does not return before that.
   if (DEFAULT_MIN_PRESS_DURATION - options.duration > 0) {
-    await wait(config, DEFAULT_MIN_PRESS_DURATION - options.duration);
+    await act(async () => {
+      await wait(config, DEFAULT_MIN_PRESS_DURATION - options.duration);
+    });
   }
 };
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

`renderWithAct` didn't used the right `act` method. It used the one straight from React Test Renderer, instead of our internal `act` which has support for `global.IS_REACT_ACT_ENVIRONMENT` and React 18

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

All test should pass.

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
