### PR TITLE
feat: remove 'textInput'

### DIFF
--- a/src/user-event/__tests__/__snapshots__/clear.test.tsx.snap
+++ b/src/user-event/__tests__/__snapshots__/clear.test.tsx.snap
@@ -332,30 +332,6 @@ How are you?" multiline: true, 1`] = `
     },
   },
   {
-    "name": "textInput",
-    "payload": {
-      "currentTarget": {},
-      "isDefaultPrevented": [Function],
-      "isPersistent": [Function],
-      "isPropagationStopped": [Function],
-      "nativeEvent": {
-        "previousText": "Hello World!
-How are you?",
-        "range": {
-          "end": 0,
-          "start": 0,
-        },
-        "target": 0,
-        "text": "",
-      },
-      "persist": [Function],
-      "preventDefault": [Function],
-      "stopPropagation": [Function],
-      "target": {},
-      "timeStamp": 0,
-    },
-  },
-  {
     "name": "change",
     "payload": {
       "currentTarget": {},

--- a/src/user-event/__tests__/clear.test.tsx
+++ b/src/user-event/__tests__/clear.test.tsx
@@ -20,8 +20,6 @@ function renderTextInputWithToolkit(props: TextInputProps = {}) {
       onChange={logEvent('change')}
       onChangeText={logEvent('changeText')}
       onKeyPress={logEvent('keyPress')}
-      /** @ts-expect-error property typedef removed in RN 0.75 */
-      onTextInput={logEvent('textInput')}
       onSelectionChange={logEvent('selectionChange')}
       onSubmitEditing={logEvent('submitEditing')}
       onEndEditing={logEvent('endEditing')}
@@ -142,7 +140,6 @@ describe('clear()', () => {
       'focus',
       'selectionChange',
       'keyPress',
-      'textInput',
       'change',
       'changeText',
       'selectionChange',

--- a/src/user-event/type/__tests__/__snapshots__/type.test.tsx.snap
+++ b/src/user-event/type/__tests__/__snapshots__/type.test.tsx.snap
@@ -844,30 +844,6 @@ exports[`type() supports multiline: input: "{Enter}\\n", multiline: true 1`] = `
     },
   },
   {
-    "name": "textInput",
-    "payload": {
-      "currentTarget": {},
-      "isDefaultPrevented": [Function],
-      "isPersistent": [Function],
-      "isPropagationStopped": [Function],
-      "nativeEvent": {
-        "previousText": "",
-        "range": {
-          "end": 1,
-          "start": 1,
-        },
-        "target": 0,
-        "text": "
-",
-      },
-      "persist": [Function],
-      "preventDefault": [Function],
-      "stopPropagation": [Function],
-      "target": {},
-      "timeStamp": 0,
-    },
-  },
-  {
     "name": "change",
     "payload": {
       "currentTarget": {},
@@ -942,32 +918,6 @@ exports[`type() supports multiline: input: "{Enter}\\n", multiline: true 1`] = `
       "isPropagationStopped": [Function],
       "nativeEvent": {
         "key": "Enter",
-      },
-      "persist": [Function],
-      "preventDefault": [Function],
-      "stopPropagation": [Function],
-      "target": {},
-      "timeStamp": 0,
-    },
-  },
-  {
-    "name": "textInput",
-    "payload": {
-      "currentTarget": {},
-      "isDefaultPrevented": [Function],
-      "isPersistent": [Function],
-      "isPropagationStopped": [Function],
-      "nativeEvent": {
-        "previousText": "
-",
-        "range": {
-          "end": 2,
-          "start": 2,
-        },
-        "target": 0,
-        "text": "
-
-",
       },
       "persist": [Function],
       "preventDefault": [Function],

--- a/src/user-event/type/__tests__/type-managed.test.tsx
+++ b/src/user-event/type/__tests__/type-managed.test.tsx
@@ -38,8 +38,6 @@ function ManagedTextInput({
       onPressOut={logEvent('pressOut')}
       onChange={logEvent('change')}
       onKeyPress={logEvent('keyPress')}
-      /** @ts-expect-error property typedef removed in RN 0.75 */
-      onTextInput={logEvent('textInput')}
       onSelectionChange={logEvent('selectionChange')}
       onSubmitEditing={logEvent('submitEditing')}
       onEndEditing={logEvent('endEditing')}

--- a/src/user-event/type/__tests__/type.test.tsx
+++ b/src/user-event/type/__tests__/type.test.tsx
@@ -21,8 +21,6 @@ function renderTextInputWithToolkit(props: TextInputProps = {}) {
       onChange={logEvent('change')}
       onChangeText={logEvent('changeText')}
       onKeyPress={logEvent('keyPress')}
-      /** @ts-expect-error property typedef removed in RN 0.75 */
-      onTextInput={logEvent('textInput')}
       onSelectionChange={logEvent('selectionChange')}
       onSubmitEditing={logEvent('submitEditing')}
       onEndEditing={logEvent('endEditing')}
@@ -173,13 +171,11 @@ describe('type()', () => {
       'focus',
       'pressOut',
       'keyPress',
-      'textInput',
       'change',
       'changeText',
       'selectionChange',
       'contentSizeChange',
       'keyPress',
-      'textInput',
       'change',
       'changeText',
       'selectionChange',

--- a/src/user-event/type/type.ts
+++ b/src/user-event/type/type.ts
@@ -55,7 +55,6 @@ export async function type(
       config: this.config,
       key,
       text: currentText,
-      previousText,
       isAccepted,
     });
   }
@@ -76,13 +75,12 @@ type EmitTypingEventsContext = {
   config: UserEventConfig;
   key: string;
   text: string;
-  previousText: string;
   isAccepted?: boolean;
 };
 
 export async function emitTypingEvents(
   element: ReactTestInstance,
-  { config, key, text, previousText, isAccepted }: EmitTypingEventsContext,
+  { config, key, text, isAccepted }: EmitTypingEventsContext,
 ) {
   const isMultiline = element.props.multiline === true;
 
@@ -94,12 +92,6 @@ export async function emitTypingEvents(
   // - Android: TextInputs does not emit any events
   if (isAccepted === false) {
     return;
-  }
-
-  // According to the docs only multiline TextInput emits textInput event
-  // @see: https://github.com/facebook/react-native/blob/42a2898617da1d7a98ef574a5b9e500681c8f738/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts#L754
-  if (isMultiline) {
-    dispatchEvent(element, 'textInput', EventBuilder.TextInput.textInput(text, previousText));
   }
 
   dispatchEvent(element, 'change', EventBuilder.TextInput.change(text));


### PR DESCRIPTION
### Summary

RN 0.75 no longer emits `textInput` events for `TextInput` component.
This PR brings User Event in line with this change and stops emitting `textInput` event in `type()` interaction.

Note:
This is not considered a breaking change in RNTL, as the RNTL API did not cause the change, it's the underlying RN behavior (we are simulating) that is changing. The `textInput` is relatively rarely used event (`changeText` would be the most popular one). 
If users tests start failing, it's actually a positive development, prompting user to notice the problem before discovering in production with RN 0.75 runtime behavior. 

### Test plan

Validated RN 0.75 behavior using side app created with RN CLI. Updated automated tests to match experimental behavior.