### PR TITLE
feat: simulated native TextInput state

### DIFF
--- a/src/__tests__/fire-event.test.tsx
+++ b/src/__tests__/fire-event.test.tsx
@@ -140,7 +140,6 @@ test('fireEvent.scroll', () => {
 
 test('fireEvent.changeText', () => {
   const onChangeTextMock = jest.fn();
-  const CHANGE_TEXT = 'content';
 
   render(
     <View>
@@ -148,9 +147,19 @@ test('fireEvent.changeText', () => {
     </View>,
   );
 
-  fireEvent.changeText(screen.getByPlaceholderText('Customer placeholder'), CHANGE_TEXT);
+  const input = screen.getByPlaceholderText('Customer placeholder');
+  fireEvent.changeText(input, 'content');
+  expect(onChangeTextMock).toHaveBeenCalledWith('content');
+});
 
-  expect(onChangeTextMock).toHaveBeenCalledWith(CHANGE_TEXT);
+it('sets native state value for unmanaged text inputs', () => {
+  render(<TextInput testID="input" />);
+
+  const input = screen.getByTestId('input');
+  expect(input).toHaveDisplayValue('');
+
+  fireEvent.changeText(input, 'abc');
+  expect(input).toHaveDisplayValue('abc');
 });
 
 test('custom component with custom event name', () => {
@@ -443,15 +452,5 @@ describe('native events', () => {
 
     fireEvent(screen.getByTestId('test-id'), 'onMomentumScrollEnd');
     expect(onMomentumScrollEndSpy).toHaveBeenCalled();
-  });
-
-  it('sets native state value for unmanaged text inputs', () => {
-    render(<TextInput testID="input" />);
-
-    const input = screen.getByTestId('input');
-    expect(input).toHaveDisplayValue('');
-
-    fireEvent.changeText(input, 'abc');
-    expect(input).toHaveDisplayValue('abc');
   });
 });

--- a/src/__tests__/fire-event.test.tsx
+++ b/src/__tests__/fire-event.test.tsx
@@ -9,6 +9,7 @@ import {
   View,
 } from 'react-native';
 import { fireEvent, render, screen } from '..';
+import '../matchers/extend-expect';
 
 type OnPressComponentProps = {
   onPress: () => void;
@@ -442,5 +443,15 @@ describe('native events', () => {
 
     fireEvent(screen.getByTestId('test-id'), 'onMomentumScrollEnd');
     expect(onMomentumScrollEndSpy).toHaveBeenCalled();
+  });
+
+  it('sets native state value for unmanaged text inputs', () => {
+    render(<TextInput testID="input" />);
+
+    const input = screen.getByTestId('input');
+    expect(input).toHaveDisplayValue('');
+
+    fireEvent.changeText(input, 'abc');
+    expect(input).toHaveDisplayValue('abc');
   });
 });

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -1,11 +1,14 @@
-import * as React from 'react';
+import { clearNativeState } from './native-state';
 import { clearRenderResult } from './screen';
 
-type CleanUpFunction = (nextElement?: React.ReactElement<any>) => void;
-let cleanupQueue = new Set<CleanUpFunction>();
+type CleanUpFunction = () => void;
+
+const cleanupQueue = new Set<CleanUpFunction>();
 
 export default function cleanup() {
+  clearNativeState();
   clearRenderResult();
+
   cleanupQueue.forEach((fn) => fn());
   cleanupQueue.clear();
 }

--- a/src/fire-event.ts
+++ b/src/fire-event.ts
@@ -121,9 +121,7 @@ type EventName = StringWithAutocomplete<
 >;
 
 function fireEvent(element: ReactTestInstance, eventName: EventName, ...data: unknown[]) {
-  if (eventName === 'changeText' && isHostTextInput(element) && typeof data[0] === 'string') {
-    nativeState?.elementValues.set(element, data[0]);
-  }
+  setNativeStateIfNeeded(element, eventName, data[0]);
 
   const handler = findEventHandler(element, eventName);
   if (!handler) {
@@ -148,3 +146,14 @@ fireEvent.scroll = (element: ReactTestInstance, ...data: unknown[]) =>
   fireEvent(element, 'scroll', ...data);
 
 export default fireEvent;
+
+function setNativeStateIfNeeded(element: ReactTestInstance, eventName: string, value: unknown) {
+  if (
+    eventName === 'changeText' &&
+    typeof value === 'string' &&
+    isHostTextInput(element) &&
+    isTextInputEditable(element)
+  ) {
+    nativeState?.elementValues.set(element, value);
+  }
+}

--- a/src/fire-event.ts
+++ b/src/fire-event.ts
@@ -12,6 +12,7 @@ import { isHostTextInput } from './helpers/host-component-names';
 import { isPointerEventEnabled } from './helpers/pointer-events';
 import { isTextInputEditable } from './helpers/text-input';
 import { StringWithAutocomplete } from './types';
+import { nativeState } from './native-state';
 
 type EventHandler = (...args: unknown[]) => unknown;
 
@@ -120,6 +121,10 @@ type EventName = StringWithAutocomplete<
 >;
 
 function fireEvent(element: ReactTestInstance, eventName: EventName, ...data: unknown[]) {
+  if (eventName === 'changeText' && isHostTextInput(element) && typeof data[0] === 'string') {
+    nativeState?.elementValues.set(element, data[0]);
+  }
+
   const handler = findEventHandler(element, eventName);
   if (!handler) {
     return;

--- a/src/helpers/text-input.ts
+++ b/src/helpers/text-input.ts
@@ -1,4 +1,5 @@
 import { ReactTestInstance } from 'react-test-renderer';
+import { nativeState } from '../native-state';
 import { isHostTextInput } from './host-component-names';
 
 export function isTextInputEditable(element: ReactTestInstance) {
@@ -14,5 +15,10 @@ export function getTextInputValue(element: ReactTestInstance) {
     throw new Error(`Element is not a "TextInput", but it has type "${element.type}".`);
   }
 
-  return element.props.value ?? element.props.defaultValue;
+  return (
+    element.props.value ??
+    nativeState?.elementValues.get(element) ??
+    element.props.defaultValue ??
+    ''
+  );
 }

--- a/src/native-state.ts
+++ b/src/native-state.ts
@@ -1,0 +1,17 @@
+import { ReactTestInstance } from 'react-test-renderer';
+
+export type NativeState = {
+  elementValues: WeakMap<ReactTestInstance, string>;
+};
+
+export let nativeState: NativeState | null = null;
+
+export function initNativeState(): void {
+  nativeState = {
+    elementValues: new WeakMap(),
+  };
+}
+
+export function clearNativeState(): void {
+  nativeState = null;
+}

--- a/src/native-state.ts
+++ b/src/native-state.ts
@@ -1,5 +1,10 @@
 import { ReactTestInstance } from 'react-test-renderer';
 
+/**
+ * Simulated native state for unmanaged controls.
+ *
+ * Values from `value` props (managed controls) should take precedence over these values.
+ */
 export type NativeState = {
   elementValues: WeakMap<ReactTestInstance, string>;
 };

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -12,6 +12,7 @@ import { validateStringsRenderedWithinText } from './helpers/string-validation';
 import { renderWithAct } from './render-act';
 import { setRenderResult } from './screen';
 import { getQueriesForElement } from './within';
+import { initNativeState } from './native-state';
 
 export interface RenderOptions {
   wrapper?: React.ComponentType<any>;
@@ -127,6 +128,8 @@ function buildRenderResult(
   });
 
   setRenderResult(result);
+  initNativeState();
+
   return result;
 }
 

--- a/src/user-event/__tests__/clear.test.tsx
+++ b/src/user-event/__tests__/clear.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { TextInput, TextInputProps, View } from 'react-native';
 import { createEventLogger, getEventsNames } from '../../test-utils';
 import { render, userEvent, screen } from '../..';
+import '../../matchers/extend-expect';
 
 beforeEach(() => {
   jest.useRealTimers();
@@ -204,5 +205,17 @@ describe('clear()', () => {
     const user = userEvent.setup();
     await user.clear(screen.getByTestId('input'));
     expect(parentHandler).not.toHaveBeenCalled();
+  });
+
+  it('sets native state value for unmanaged text inputs', async () => {
+    render(<TextInput testID="input" />);
+
+    const user = userEvent.setup();
+    const input = screen.getByTestId('input');
+    await user.type(input, 'abc');
+    expect(input).toHaveDisplayValue('abc');
+
+    await user.clear(input);
+    expect(input).toHaveDisplayValue('');
   });
 });

--- a/src/user-event/__tests__/paste.test.tsx
+++ b/src/user-event/__tests__/paste.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { TextInput, TextInputProps, View } from 'react-native';
 import { createEventLogger, getEventsNames } from '../../test-utils';
 import { render, userEvent, screen } from '../..';
+import '../../matchers/extend-expect';
 
 beforeEach(() => {
   jest.useRealTimers();
@@ -220,5 +221,16 @@ describe('paste()', () => {
     const user = userEvent.setup();
     await user.paste(screen.getByTestId('input'), 'Hi!');
     expect(parentHandler).not.toHaveBeenCalled();
+  });
+
+  it('sets native state value for unmanaged text inputs', async () => {
+    render(<TextInput testID="input" />);
+
+    const user = userEvent.setup();
+    const input = screen.getByTestId('input');
+    expect(input).toHaveDisplayValue('');
+
+    await user.paste(input, 'abc');
+    expect(input).toHaveDisplayValue('abc');
   });
 });

--- a/src/user-event/paste.ts
+++ b/src/user-event/paste.ts
@@ -3,6 +3,7 @@ import { ErrorWithStack } from '../helpers/errors';
 import { isHostTextInput } from '../helpers/host-component-names';
 import { isPointerEventEnabled } from '../helpers/pointer-events';
 import { isTextInputEditable } from '../helpers/text-input';
+import { nativeState } from '../native-state';
 import { EventBuilder } from './event-builder';
 import { UserEventInstance } from './setup';
 import { dispatchEvent, getTextContentSize, wait } from './utils';
@@ -32,6 +33,7 @@ export async function paste(
   dispatchEvent(element, 'selectionChange', EventBuilder.TextInput.selectionChange(rangeToClear));
 
   // 3. Paste the text
+  nativeState?.elementValues.set(element, text);
   dispatchEvent(element, 'change', EventBuilder.TextInput.change(text));
   dispatchEvent(element, 'changeText', text);
 

--- a/src/user-event/type/__tests__/type.test.tsx
+++ b/src/user-event/type/__tests__/type.test.tsx
@@ -3,6 +3,7 @@ import { TextInput, TextInputProps, View } from 'react-native';
 import { createEventLogger, getEventsNames, lastEventPayload } from '../../../test-utils';
 import { render, screen } from '../../..';
 import { userEvent } from '../..';
+import '../../../matchers/extend-expect';
 
 beforeEach(() => {
   jest.useRealTimers();
@@ -371,5 +372,16 @@ describe('type()', () => {
         text: 'ab',
       },
     });
+  });
+
+  it('supports value of unmanaged text inputs', async () => {
+    render(<TextInput testID="input" />);
+
+    const user = userEvent.setup();
+    const input = screen.getByTestId('input');
+    expect(input).toHaveDisplayValue('');
+
+    await user.type(input, 'abc');
+    expect(input).toHaveDisplayValue('abc');
   });
 });

--- a/src/user-event/type/__tests__/type.test.tsx
+++ b/src/user-event/type/__tests__/type.test.tsx
@@ -374,7 +374,7 @@ describe('type()', () => {
     });
   });
 
-  it('supports value of unmanaged text inputs', async () => {
+  it('sets native state value for unmanaged text inputs', async () => {
     render(<TextInput testID="input" />);
 
     const user = userEvent.setup();

--- a/src/user-event/type/type.ts
+++ b/src/user-event/type/type.ts
@@ -1,5 +1,6 @@
 import { ReactTestInstance } from 'react-test-renderer';
 import { isHostTextInput } from '../../helpers/host-component-names';
+import { nativeState } from '../../native-state';
 import { EventBuilder } from '../event-builder';
 import { ErrorWithStack } from '../../helpers/errors';
 import { isTextInputEditable } from '../../helpers/text-input';
@@ -96,6 +97,7 @@ export async function emitTypingEvents(
 
   dispatchEvent(element, 'change', EventBuilder.TextInput.change(text));
   dispatchEvent(element, 'changeText', text);
+  nativeState?.elementValues.set(element, text);
 
   const selectionRange = {
     start: text.length,

--- a/src/user-event/type/type.ts
+++ b/src/user-event/type/type.ts
@@ -95,9 +95,9 @@ export async function emitTypingEvents(
     return;
   }
 
+  nativeState?.elementValues.set(element, text);
   dispatchEvent(element, 'change', EventBuilder.TextInput.change(text));
   dispatchEvent(element, 'changeText', text);
-  nativeState?.elementValues.set(element, text);
 
   const selectionRange = {
     start: text.length,


### PR DESCRIPTION
### Summary

This PR introduces the concept of simulated native view state. The PR supports tracking the value of host `TextInput` elements. 

```
test('sets native state value for unmanaged text inputs', async () => {
  render(<TextInput testID="input" />);

  const user = userEvent.setup();
  const input = screen.getByTestId('input');
  expect(input).toHaveDisplayValue('');

  await user.type(input, 'abc'); // or fireEvent.changeText(input, 'abc')

  // Below assertion now passes
  expect(input).toHaveDisplayValue('abc'); 
});
```

This PR supports setting native state value through `fireEvent.changeText` and  User Event `type()`, `clear()` and `paste()` methods.

When `TextInput` is managed through `value` prop, that value takes precedence over simulated native value.

### Test plan

Add 