### PR TITLE
docs: Update outdated Expo command in Troubleshooting guide

### DIFF
--- a/website/docs/12.x/docs/guides/troubleshooting.mdx
+++ b/website/docs/12.x/docs/guides/troubleshooting.mdx
@@ -10,7 +10,7 @@ Check that you have matching versions of core dependencies:
 - React
 - React Test Renderer
 
-React Native uses different versioning scheme from React, you can use [React Native Upgrade Helper](https://react-native-community.github.io/upgrade-helper/) to find the correct matching between React Native & React versions. In case you use Expo, use `npx expo install --fix` in your project to validate and install compatible versions of these dependencies.
+React Native uses different versioning scheme from React, you can use [React Native Upgrade Helper](https://react-native-community.github.io/upgrade-helper/) to find the correct matching between React Native & React versions. In case you use Expo, run `npx expo install --fix` in your project to validate and install compatible versions of these dependencies.
 
 React Test Renderer usually has same major & minor version as React, as they are closely related and React Test Renderer is part of [React monorepo](https://github.com/facebook/react).
 

--- a/website/docs/12.x/docs/guides/troubleshooting.mdx
+++ b/website/docs/12.x/docs/guides/troubleshooting.mdx
@@ -10,7 +10,7 @@ Check that you have matching versions of core dependencies:
 - React
 - React Test Renderer
 
-React Native uses different versioning scheme from React, you can use [React Native Upgrade Helper](https://react-native-community.github.io/upgrade-helper/) to find the correct matching between React Native & React versions. In case you use Expo, you should use dependency versions recommended by them and set by `expo upgrade` command.
+React Native uses different versioning scheme from React, you can use [React Native Upgrade Helper](https://react-native-community.github.io/upgrade-helper/) to find the correct matching between React Native & React versions. In case you use Expo, use `npx expo install --fix` in your project to validate and install compatible versions of these dependencies.
 
 React Test Renderer usually has same major & minor version as React, as they are closely related and React Test Renderer is part of [React monorepo](https://github.com/facebook/react).
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

The ["Troubleshooting" guide](https://callstack.github.io/react-native-testing-library/docs/guides/troubleshooting#matching-react-native-react--react-test-renderer-versions) refers to the deprecated Expo command (`expo upgrade`).

This PR updates the verbiage about recommended versions and removes the outdated command with `npx expo install --fix`, which does both (check for recommended versions and dependency incompatibility with the Expo SDK version).

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

Here's a preview of the changes:

![CleanShot 2024-09-06 at 01 25 52@2x](https://github.com/user-attachments/assets/5eeb2d4c-5232-4e04-8d68-8b15145b48a1)

