### PR TITLE
feat: support `Image` with `alt` prop as label

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -33,6 +33,7 @@ test('resetToDefaults() resets internal config to defaults', () => {
     hostComponentNames: {
       text: 'A',
       textInput: 'A',
+      image: 'A',
       switch: 'A',
       scrollView: 'A',
       modal: 'A',
@@ -41,6 +42,7 @@ test('resetToDefaults() resets internal config to defaults', () => {
   expect(getConfig().hostComponentNames).toEqual({
     text: 'A',
     textInput: 'A',
+    image: 'A',
     switch: 'A',
     scrollView: 'A',
     modal: 'A',

--- a/src/__tests__/host-component-names.test.tsx
+++ b/src/__tests__/host-component-names.test.tsx
@@ -14,6 +14,7 @@ describe('getHostComponentNames', () => {
       hostComponentNames: {
         text: 'banana',
         textInput: 'banana',
+        image: 'banana',
         switch: 'banana',
         scrollView: 'banana',
         modal: 'banana',
@@ -23,6 +24,7 @@ describe('getHostComponentNames', () => {
     expect(getHostComponentNames()).toEqual({
       text: 'banana',
       textInput: 'banana',
+      image: 'banana',
       switch: 'banana',
       scrollView: 'banana',
       modal: 'banana',
@@ -37,6 +39,7 @@ describe('getHostComponentNames', () => {
     expect(hostComponentNames).toEqual({
       text: 'Text',
       textInput: 'TextInput',
+      image: 'Image',
       switch: 'RCTSwitch',
       scrollView: 'RCTScrollView',
       modal: 'Modal',
@@ -67,6 +70,7 @@ describe('configureHostComponentNamesIfNeeded', () => {
     expect(getConfig().hostComponentNames).toEqual({
       text: 'Text',
       textInput: 'TextInput',
+      image: 'Image',
       switch: 'RCTSwitch',
       scrollView: 'RCTScrollView',
       modal: 'Modal',
@@ -78,6 +82,7 @@ describe('configureHostComponentNamesIfNeeded', () => {
       hostComponentNames: {
         text: 'banana',
         textInput: 'banana',
+        image: 'banana',
         switch: 'banana',
         scrollView: 'banana',
         modal: 'banana',
@@ -89,13 +94,14 @@ describe('configureHostComponentNamesIfNeeded', () => {
     expect(getConfig().hostComponentNames).toEqual({
       text: 'banana',
       textInput: 'banana',
+      image: 'banana',
       switch: 'banana',
       scrollView: 'banana',
       modal: 'banana',
     });
   });
 
-  test('throw an error when autodetection fails', () => {
+  test('throw an error when auto-detection fails', () => {
     const mockCreate = jest.spyOn(TestRenderer, 'create') as jest.Mock;
     const renderer = TestRenderer.create(<View />);
 

--- a/src/__tests__/react-native-api.test.tsx
+++ b/src/__tests__/react-native-api.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FlatList, ScrollView, Switch, Text, TextInput, View } from 'react-native';
+import { FlatList, Image, Modal, ScrollView, Switch, Text, TextInput, View } from 'react-native';
 import { render, screen } from '..';
 
 /**
@@ -7,7 +7,7 @@ import { render, screen } from '..';
  * changed in a way that may impact our code like queries or event handling.
  */
 
-test('React Native API assumption: <View> renders single host element', () => {
+test('React Native API assumption: <View> renders a single host element', () => {
   render(<View testID="test" />);
 
   expect(screen.toJSON()).toMatchInlineSnapshot(`
@@ -17,7 +17,7 @@ test('React Native API assumption: <View> renders single host element', () => {
   `);
 });
 
-test('React Native API assumption: <Text> renders single host element', () => {
+test('React Native API assumption: <Text> renders a single host element', () => {
   render(<Text testID="test">Hello</Text>);
 
   expect(screen.toJSON()).toMatchInlineSnapshot(`
@@ -29,7 +29,7 @@ test('React Native API assumption: <Text> renders single host element', () => {
   `);
 });
 
-test('React Native API assumption: nested <Text> renders single host element', () => {
+test('React Native API assumption: nested <Text> renders a single host element', () => {
   render(
     <Text testID="test">
       <Text testID="before">Before</Text>
@@ -63,7 +63,7 @@ test('React Native API assumption: nested <Text> renders single host element', (
   `);
 });
 
-test('React Native API assumption: <TextInput> renders single host element', () => {
+test('React Native API assumption: <TextInput> renders a single host element', () => {
   render(
     <TextInput
       testID="test"
@@ -102,7 +102,7 @@ test('React Native API assumption: <TextInput> with nested Text renders single h
   `);
 });
 
-test('React Native API assumption: <Switch> renders single host element', () => {
+test('React Native API assumption: <Switch> renders a single host element', () => {
   render(<Switch testID="test" value={true} onChange={jest.fn()} />);
 
   expect(screen.toJSON()).toMatchInlineSnapshot(`
@@ -123,151 +123,23 @@ test('React Native API assumption: <Switch> renders single host element', () => 
   `);
 });
 
-test('React Native API assumption: aria-* props render on host View', () => {
-  render(
-    <View
-      testID="test"
-      aria-busy
-      aria-checked
-      aria-disabled
-      aria-expanded
-      aria-hidden
-      aria-label="Label"
-      aria-labelledby="LabelledBy"
-      aria-live="polite"
-      aria-modal
-      aria-pressed
-      aria-readonly
-      aria-required
-      aria-selected
-      aria-valuemax={10}
-      aria-valuemin={0}
-      aria-valuenow={5}
-      aria-valuetext="ValueText"
-    />,
-  );
+test('React Native API assumption: <Image> renders a single host element', () => {
+  render(<Image testID="test" source={{ uri: 'https://fake.url/image.jpg' }} alt="Alt text" />);
 
   expect(screen.toJSON()).toMatchInlineSnapshot(`
-    <View
-      aria-busy={true}
-      aria-checked={true}
-      aria-disabled={true}
-      aria-expanded={true}
-      aria-hidden={true}
-      aria-label="Label"
-      aria-labelledby="LabelledBy"
-      aria-live="polite"
-      aria-modal={true}
-      aria-pressed={true}
-      aria-readonly={true}
-      aria-required={true}
-      aria-selected={true}
-      aria-valuemax={10}
-      aria-valuemin={0}
-      aria-valuenow={5}
-      aria-valuetext="ValueText"
+    <Image
+      alt="Alt text"
+      source={
+        {
+          "uri": "https://fake.url/image.jpg",
+        }
+      }
       testID="test"
     />
   `);
 });
 
-test('React Native API assumption: aria-* props render on host Text', () => {
-  render(
-    <Text
-      testID="test"
-      aria-busy
-      aria-checked
-      aria-disabled
-      aria-expanded
-      aria-hidden
-      aria-label="Label"
-      aria-labelledby="LabelledBy"
-      aria-live="polite"
-      aria-modal
-      aria-pressed
-      aria-readonly
-      aria-required
-      aria-selected
-      aria-valuemax={10}
-      aria-valuemin={0}
-      aria-valuenow={5}
-      aria-valuetext="ValueText"
-    />,
-  );
-
-  expect(screen.toJSON()).toMatchInlineSnapshot(`
-    <Text
-      aria-busy={true}
-      aria-checked={true}
-      aria-disabled={true}
-      aria-expanded={true}
-      aria-hidden={true}
-      aria-label="Label"
-      aria-labelledby="LabelledBy"
-      aria-live="polite"
-      aria-modal={true}
-      aria-pressed={true}
-      aria-readonly={true}
-      aria-required={true}
-      aria-selected={true}
-      aria-valuemax={10}
-      aria-valuemin={0}
-      aria-valuenow={5}
-      aria-valuetext="ValueText"
-      testID="test"
-    />
-  `);
-});
-
-test('React Native API assumption: aria-* props render on host TextInput', () => {
-  render(
-    <TextInput
-      testID="test"
-      aria-busy
-      aria-checked
-      aria-disabled
-      aria-expanded
-      aria-hidden
-      aria-label="Label"
-      aria-labelledby="LabelledBy"
-      aria-live="polite"
-      aria-modal
-      aria-pressed
-      aria-readonly
-      aria-required
-      aria-selected
-      aria-valuemax={10}
-      aria-valuemin={0}
-      aria-valuenow={5}
-      aria-valuetext="ValueText"
-    />,
-  );
-
-  expect(screen.toJSON()).toMatchInlineSnapshot(`
-    <TextInput
-      aria-busy={true}
-      aria-checked={true}
-      aria-disabled={true}
-      aria-expanded={true}
-      aria-hidden={true}
-      aria-label="Label"
-      aria-labelledby="LabelledBy"
-      aria-live="polite"
-      aria-modal={true}
-      aria-pressed={true}
-      aria-readonly={true}
-      aria-required={true}
-      aria-selected={true}
-      aria-valuemax={10}
-      aria-valuemin={0}
-      aria-valuenow={5}
-      aria-valuetext="ValueText"
-      testID="test"
-    />
-  `);
-});
-
-test('ScrollView renders correctly', () => {
+test('React Native API assumption: <ScrollView> renders a single host element', () => {
   render(
     <ScrollView testID="scrollView">
       <View testID="view" />
@@ -287,7 +159,7 @@ test('ScrollView renders correctly', () => {
   `);
 });
 
-test('FlatList renders correctly', () => {
+test('React Native API assumption: <FlatList> renders a single host <ScrollView> element', () => {
   render(
     <FlatList testID="flatList" data={[1, 2]} renderItem={({ item }) => <Text>{item}</Text>} />,
   );
@@ -338,5 +210,169 @@ test('FlatList renders correctly', () => {
         </View>
       </View>
     </RCTScrollView>
+  `);
+});
+
+test('React Native API assumption: <Modal> renders a single host element', () => {
+  render(
+    <Modal testID="test">
+      <Text>Modal Content</Text>
+    </Modal>,
+  );
+
+  expect(screen.toJSON()).toMatchInlineSnapshot(`
+    <Modal
+      hardwareAccelerated={false}
+      testID="test"
+      visible={true}
+    >
+      <Text>
+        Modal Content
+      </Text>
+    </Modal>
+  `);
+});
+
+test('React Native API assumption: aria-* props render directly on host View', () => {
+  render(
+    <View
+      testID="test"
+      aria-busy
+      aria-checked
+      aria-disabled
+      aria-expanded
+      aria-hidden
+      aria-label="Label"
+      aria-labelledby="LabelledBy"
+      aria-live="polite"
+      aria-modal
+      aria-pressed
+      aria-readonly
+      aria-required
+      aria-selected
+      aria-valuemax={10}
+      aria-valuemin={0}
+      aria-valuenow={5}
+      aria-valuetext="ValueText"
+    />,
+  );
+
+  expect(screen.toJSON()).toMatchInlineSnapshot(`
+    <View
+      aria-busy={true}
+      aria-checked={true}
+      aria-disabled={true}
+      aria-expanded={true}
+      aria-hidden={true}
+      aria-label="Label"
+      aria-labelledby="LabelledBy"
+      aria-live="polite"
+      aria-modal={true}
+      aria-pressed={true}
+      aria-readonly={true}
+      aria-required={true}
+      aria-selected={true}
+      aria-valuemax={10}
+      aria-valuemin={0}
+      aria-valuenow={5}
+      aria-valuetext="ValueText"
+      testID="test"
+    />
+  `);
+});
+
+test('React Native API assumption: aria-* props render directly on host Text', () => {
+  render(
+    <Text
+      testID="test"
+      aria-busy
+      aria-checked
+      aria-disabled
+      aria-expanded
+      aria-hidden
+      aria-label="Label"
+      aria-labelledby="LabelledBy"
+      aria-live="polite"
+      aria-modal
+      aria-pressed
+      aria-readonly
+      aria-required
+      aria-selected
+      aria-valuemax={10}
+      aria-valuemin={0}
+      aria-valuenow={5}
+      aria-valuetext="ValueText"
+    />,
+  );
+
+  expect(screen.toJSON()).toMatchInlineSnapshot(`
+    <Text
+      aria-busy={true}
+      aria-checked={true}
+      aria-disabled={true}
+      aria-expanded={true}
+      aria-hidden={true}
+      aria-label="Label"
+      aria-labelledby="LabelledBy"
+      aria-live="polite"
+      aria-modal={true}
+      aria-pressed={true}
+      aria-readonly={true}
+      aria-required={true}
+      aria-selected={true}
+      aria-valuemax={10}
+      aria-valuemin={0}
+      aria-valuenow={5}
+      aria-valuetext="ValueText"
+      testID="test"
+    />
+  `);
+});
+
+test('React Native API assumption: aria-* props render directly on host TextInput', () => {
+  render(
+    <TextInput
+      testID="test"
+      aria-busy
+      aria-checked
+      aria-disabled
+      aria-expanded
+      aria-hidden
+      aria-label="Label"
+      aria-labelledby="LabelledBy"
+      aria-live="polite"
+      aria-modal
+      aria-pressed
+      aria-readonly
+      aria-required
+      aria-selected
+      aria-valuemax={10}
+      aria-valuemin={0}
+      aria-valuenow={5}
+      aria-valuetext="ValueText"
+    />,
+  );
+
+  expect(screen.toJSON()).toMatchInlineSnapshot(`
+    <TextInput
+      aria-busy={true}
+      aria-checked={true}
+      aria-disabled={true}
+      aria-expanded={true}
+      aria-hidden={true}
+      aria-label="Label"
+      aria-labelledby="LabelledBy"
+      aria-live="polite"
+      aria-modal={true}
+      aria-pressed={true}
+      aria-readonly={true}
+      aria-required={true}
+      aria-selected={true}
+      aria-valuemax={10}
+      aria-valuemin={0}
+      aria-valuenow={5}
+      aria-valuetext="ValueText"
+      testID="test"
+    />
   `);
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,7 @@ export type ConfigAliasOptions = {
 export type HostComponentNames = {
   text: string;
   textInput: string;
+  image: string;
   switch: string;
   scrollView: string;
   modal: string;

--- a/src/helpers/accessibility.ts
+++ b/src/helpers/accessibility.ts
@@ -103,7 +103,8 @@ export function isAccessibilityElement(element: ReactTestInstance | null): boole
     return false;
   }
 
-  if (isHostImage(element) && element.props.alt) {
+  // https://github.com/facebook/react-native/blob/8dabed60f456e76a9e53273b601446f34de41fb5/packages/react-native/Libraries/Image/Image.ios.js#L172
+  if (isHostImage(element) && element.props.alt !== undefined) {
     return true;
   }
 
@@ -162,11 +163,17 @@ export function computeAriaModal(element: ReactTestInstance): boolean | undefine
 }
 
 export function computeAriaLabel(element: ReactTestInstance): string | undefined {
+  const explicitLabel = element.props['aria-label'] ?? element.props.accessibilityLabel;
+  if (explicitLabel) {
+    return explicitLabel;
+  }
+
+  //https://github.com/facebook/react-native/blob/8dabed60f456e76a9e53273b601446f34de41fb5/packages/react-native/Libraries/Image/Image.ios.js#L173
   if (isHostImage(element) && element.props.alt) {
     return element.props.alt;
   }
 
-  return element.props['aria-label'] ?? element.props.accessibilityLabel;
+  return undefined;
 }
 
 export function computeAriaLabelledBy(element: ReactTestInstance): string | undefined {

--- a/src/helpers/accessibility.ts
+++ b/src/helpers/accessibility.ts
@@ -149,6 +149,13 @@ export function getRole(element: ReactTestInstance): Role | AccessibilityRole {
   return 'none';
 }
 
+/**
+ * There are some duplications between (ARIA) `Role` and `AccessibilityRole` types.
+ * Resolve them by using ARIA `Role` type where possible.
+ *
+ * @param role Role to normalize
+ * @returns Normalized role
+ */
 export function normalizeRole(role: string): Role | AccessibilityRole {
   if (role === 'image') {
     return 'img';

--- a/src/helpers/accessibility.ts
+++ b/src/helpers/accessibility.ts
@@ -143,9 +143,8 @@ export function getRole(element: ReactTestInstance): Role | AccessibilityRole {
     return 'text';
   }
 
-  if (isHostImage(element) && element.props.alt) {
-    return 'img';
-  }
+  // Note: host Image elements report "image" role in screen reader only on Android, but not on iOS.
+  // It's better to require explicit role for Image elements.
 
   return 'none';
 }

--- a/src/helpers/accessibility.ts
+++ b/src/helpers/accessibility.ts
@@ -103,6 +103,10 @@ export function isAccessibilityElement(element: ReactTestInstance | null): boole
     return false;
   }
 
+  if (isHostImage(element) && element.props.alt) {
+    return true;
+  }
+
   if (element.props.accessible !== undefined) {
     return element.props.accessible;
   }
@@ -131,14 +135,26 @@ export function isAccessibilityElement(element: ReactTestInstance | null): boole
 export function getRole(element: ReactTestInstance): Role | AccessibilityRole {
   const explicitRole = element.props.role ?? element.props.accessibilityRole;
   if (explicitRole) {
-    return explicitRole;
+    return normalizeRole(explicitRole);
   }
 
   if (isHostText(element)) {
     return 'text';
   }
 
+  if (isHostImage(element) && element.props.alt) {
+    return 'img';
+  }
+
   return 'none';
+}
+
+export function normalizeRole(role: string): Role | AccessibilityRole {
+  if (role === 'image') {
+    return 'img';
+  }
+
+  return role as Role | AccessibilityRole;
 }
 
 export function computeAriaModal(element: ReactTestInstance): boolean | undefined {

--- a/src/helpers/accessibility.ts
+++ b/src/helpers/accessibility.ts
@@ -9,6 +9,7 @@ import { ReactTestInstance } from 'react-test-renderer';
 import { getHostSiblings, getUnsafeRootElement } from './component-tree';
 import {
   getHostComponentNames,
+  isHostImage,
   isHostSwitch,
   isHostText,
   isHostTextInput,
@@ -145,6 +146,10 @@ export function computeAriaModal(element: ReactTestInstance): boolean | undefine
 }
 
 export function computeAriaLabel(element: ReactTestInstance): string | undefined {
+  if (isHostImage(element) && element.props.alt) {
+    return element.props.alt;
+  }
+
   return element.props['aria-label'] ?? element.props.accessibilityLabel;
 }
 

--- a/src/helpers/format-default.ts
+++ b/src/helpers/format-default.ts
@@ -9,6 +9,7 @@ const propsToDisplay = [
   'accessibilityLabelledBy',
   'accessibilityRole',
   'accessibilityViewIsModal',
+  'alt',
   'aria-busy',
   'aria-checked',
   'aria-disabled',

--- a/src/helpers/host-component-names.tsx
+++ b/src/helpers/host-component-names.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ReactTestInstance } from 'react-test-renderer';
-import { Modal, ScrollView, Switch, Text, TextInput, View } from 'react-native';
+import { Image, Modal, ScrollView, Switch, Text, TextInput, View } from 'react-native';
 import { configureInternal, getConfig, HostComponentNames } from '../config';
 import { renderWithAct } from '../render-act';
 import { HostTestInstance } from './component-tree';
@@ -34,6 +34,7 @@ function detectHostComponentNames(): HostComponentNames {
       <View>
         <Text testID="text">Hello</Text>
         <TextInput testID="textInput" />
+        <Image testID="image" />
         <Switch testID="switch" />
         <ScrollView testID="scrollView" />
         <Modal testID="modal" />
@@ -43,6 +44,7 @@ function detectHostComponentNames(): HostComponentNames {
     return {
       text: getByTestId(renderer.root, 'text').type as string,
       textInput: getByTestId(renderer.root, 'textInput').type as string,
+      image: getByTestId(renderer.root, 'image').type as string,
       switch: getByTestId(renderer.root, 'switch').type as string,
       scrollView: getByTestId(renderer.root, 'scrollView').type as string,
       modal: getByTestId(renderer.root, 'modal').type as string,
@@ -83,6 +85,14 @@ export function isHostText(element?: ReactTestInstance | null): element is HostT
  */
 export function isHostTextInput(element?: ReactTestInstance | null): element is HostTestInstance {
   return element?.type === getHostComponentNames().textInput;
+}
+
+/**
+ * Checks if the given element is a host Image element.
+ * @param element The element to check.
+ */
+export function isHostImage(element?: ReactTestInstance | null): element is HostTestInstance {
+  return element?.type === getHostComponentNames().image;
 }
 
 /**

--- a/src/matchers/__tests__/to-have-accessible-name.test.tsx
+++ b/src/matchers/__tests__/to-have-accessible-name.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, Text, TextInput } from 'react-native';
+import { View, Text, TextInput, Image } from 'react-native';
 import { render, screen } from '../..';
 import '../extend-expect';
 
@@ -72,17 +72,26 @@ test('toHaveAccessibleName() handles view with "aria-labelledby" prop', () => {
   expect(element).not.toHaveAccessibleName('Other label');
 });
 
-test('toHaveAccessibleName() handles view with implicit accessible name', () => {
+test('toHaveAccessibleName() handles Text with text content', () => {
   render(<Text testID="view">Text</Text>);
+
   const element = screen.getByTestId('view');
   expect(element).toHaveAccessibleName('Text');
   expect(element).not.toHaveAccessibleName('Other text');
 });
 
+test('toHaveAccessibleName() handles Image with "alt" prop', () => {
+  render(<Image testID="image" alt="Test image" />);
+
+  const element = screen.getByTestId('image');
+  expect(element).toHaveAccessibleName('Test image');
+  expect(element).not.toHaveAccessibleName('Other text');
+});
+
 test('toHaveAccessibleName() supports calling without expected name', () => {
   render(<View testID="view" accessibilityLabel="Test label" />);
-  const element = screen.getByTestId('view');
 
+  const element = screen.getByTestId('view');
   expect(element).toHaveAccessibleName();
   expect(() => expect(element).not.toHaveAccessibleName()).toThrowErrorMatchingInlineSnapshot(`
     "expect(element).not.toHaveAccessibleName()

--- a/src/queries/__tests__/hint-text.test.tsx
+++ b/src/queries/__tests__/hint-text.test.tsx
@@ -8,11 +8,11 @@ const TEXT_HINT = 'static text';
 const NO_MATCHES_TEXT: any = 'not-existent-element';
 
 const getMultipleInstancesFoundMessage = (value: string) => {
-  return `Found multiple elements with accessibilityHint: ${value}`;
+  return `Found multiple elements with accessibility hint: ${value}`;
 };
 
 const getNoInstancesFoundMessage = (value: string) => {
-  return `Unable to find an element with accessibilityHint: ${value}`;
+  return `Unable to find an element with accessibility hint: ${value}`;
 };
 
 const Typography = ({ children, ...rest }: any) => {
@@ -114,7 +114,7 @@ test('byHintText queries support hidden option', () => {
   expect(screen.queryByHintText('hidden', { includeHiddenElements: false })).toBeFalsy();
   expect(() => screen.getByHintText('hidden', { includeHiddenElements: false }))
     .toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an element with accessibilityHint: hidden
+    "Unable to find an element with accessibility hint: hidden
 
     <Text
       accessibilityHint="hidden"
@@ -133,7 +133,7 @@ test('error message renders the element tree, preserving only helpful props', as
   render(<Pressable accessibilityHint="HINT" key="3" />);
 
   expect(() => screen.getByHintText('FOO')).toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an element with accessibilityHint: FOO
+    "Unable to find an element with accessibility hint: FOO
 
     <View
       accessibilityHint="HINT"
@@ -142,7 +142,7 @@ test('error message renders the element tree, preserving only helpful props', as
   `);
 
   expect(() => screen.getAllByHintText('FOO')).toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an element with accessibilityHint: FOO
+    "Unable to find an element with accessibility hint: FOO
 
     <View
       accessibilityHint="HINT"
@@ -151,7 +151,7 @@ test('error message renders the element tree, preserving only helpful props', as
   `);
 
   await expect(screen.findByHintText('FOO')).rejects.toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an element with accessibilityHint: FOO
+    "Unable to find an element with accessibility hint: FOO
 
     <View
       accessibilityHint="HINT"
@@ -160,7 +160,7 @@ test('error message renders the element tree, preserving only helpful props', as
   `);
 
   await expect(screen.findAllByHintText('FOO')).rejects.toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an element with accessibilityHint: FOO
+    "Unable to find an element with accessibility hint: FOO
 
     <View
       accessibilityHint="HINT"

--- a/src/queries/__tests__/label-text.test.tsx
+++ b/src/queries/__tests__/label-text.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, Text, TextInput, Pressable } from 'react-native';
+import { View, Text, TextInput, Image, Pressable } from 'react-native';
 import { render, screen } from '../..';
 
 const BUTTON_LABEL = 'cool button';
@@ -218,6 +218,18 @@ test('getByLabelText supports nested aria-labelledby', () => {
 
   expect(screen.getByLabelText('Nested Text Label')).toBe(screen.getByTestId('text-input'));
   expect(screen.getByLabelText(/nested text label/i)).toBe(screen.getByTestId('text-input'));
+});
+
+test('getByLabelText supports "Image"" with "alt" prop', () => {
+  render(
+    <>
+      <Image alt="Image Label" testID="image" />
+    </>,
+  );
+
+  const expectedElement = screen.getByTestId('image');
+  expect(screen.getByLabelText('Image Label')).toBe(expectedElement);
+  expect(screen.getByLabelText(/image label/i)).toBe(expectedElement);
 });
 
 test('error message renders the element tree, preserving only helpful props', async () => {

--- a/src/queries/__tests__/role-value.test.tsx
+++ b/src/queries/__tests__/role-value.test.tsx
@@ -77,7 +77,7 @@ describe('accessibility value', () => {
 
     expect(() => screen.getByRole('adjustable', { name: 'Hello', value: { min: 5 } }))
       .toThrowErrorMatchingInlineSnapshot(`
-      "Unable to find an element with role: "adjustable", name: "Hello", min value: 5
+      "Unable to find an element with role: adjustable, name: Hello, min value: 5
 
       <Text
         accessibilityRole="adjustable"
@@ -100,7 +100,7 @@ describe('accessibility value', () => {
     `);
     expect(() => screen.getByRole('adjustable', { name: 'World', value: { min: 10 } }))
       .toThrowErrorMatchingInlineSnapshot(`
-      "Unable to find an element with role: "adjustable", name: "World", min value: 10
+      "Unable to find an element with role: adjustable, name: World, min value: 10
 
       <Text
         accessibilityRole="adjustable"
@@ -123,7 +123,7 @@ describe('accessibility value', () => {
     `);
     expect(() => screen.getByRole('adjustable', { name: 'Hello', value: { min: 5 } }))
       .toThrowErrorMatchingInlineSnapshot(`
-      "Unable to find an element with role: "adjustable", name: "Hello", min value: 5
+      "Unable to find an element with role: adjustable, name: Hello, min value: 5
 
       <Text
         accessibilityRole="adjustable"
@@ -146,7 +146,7 @@ describe('accessibility value', () => {
     `);
     expect(() => screen.getByRole('adjustable', { selected: true, value: { min: 10 } }))
       .toThrowErrorMatchingInlineSnapshot(`
-      "Unable to find an element with role: "adjustable", selected state: true, min value: 10
+      "Unable to find an element with role: adjustable, selected state: true, min value: 10
 
       <Text
         accessibilityRole="adjustable"

--- a/src/queries/__tests__/role.test.tsx
+++ b/src/queries/__tests__/role.test.tsx
@@ -227,12 +227,22 @@ describe('supports name option', () => {
   });
 
   test('supports host Image element with "alt" prop', () => {
-    render(<Image alt="An elephant" testID="image" />);
+    render(
+      <>
+        <Image testID="image1" role="img" alt="an elephant" />
+        <Image testID="image2" accessibilityRole="image" alt="a tiger" />
+      </>,
+    );
 
-    const expectedElement = screen.getByTestId('image');
-    expect(screen.getByRole('img', { name: 'An elephant' })).toBe(expectedElement);
-    expect(screen.getByRole('image', { name: 'An elephant' })).toBe(expectedElement);
-    expect(screen.getByRole(/img/, { name: 'An elephant' })).toBe(expectedElement);
+    const expectedElement1 = screen.getByTestId('image1');
+    expect(screen.getByRole('img', { name: 'an elephant' })).toBe(expectedElement1);
+    expect(screen.getByRole('image', { name: 'an elephant' })).toBe(expectedElement1);
+    expect(screen.getByRole(/img/, { name: /elephant/ })).toBe(expectedElement1);
+
+    const expectedElement2 = screen.getByTestId('image2');
+    expect(screen.getByRole('img', { name: 'a tiger' })).toBe(expectedElement2);
+    expect(screen.getByRole('image', { name: 'a tiger' })).toBe(expectedElement2);
+    expect(screen.getByRole(/img/, { name: /tiger/ })).toBe(expectedElement2);
   });
 });
 

--- a/src/queries/__tests__/role.test.tsx
+++ b/src/queries/__tests__/role.test.tsx
@@ -4,6 +4,7 @@ import {
   Pressable,
   Text,
   TextInput,
+  Image,
   TouchableOpacity,
   TouchableWithoutFeedback,
   View,
@@ -17,11 +18,11 @@ const TEXT_LABEL = 'cool text';
 const NO_MATCHES_TEXT: any = 'not-existent-element';
 
 const getMultipleInstancesFoundMessage = (value: string) => {
-  return `Found multiple elements with role: "${value}"`;
+  return `Found multiple elements with role: ${value}`;
 };
 
 const getNoInstancesFoundMessage = (value: string) => {
-  return `Unable to find an element with role: "${value}"`;
+  return `Unable to find an element with role: ${value}`;
 };
 
 const Typography = ({ children, ...rest }: any) => {
@@ -223,6 +224,15 @@ describe('supports name option', () => {
     // assert on the testId to be sure that the returned element is the one with the accessibilityRole
     expect(screen.getByRole('header', { name: 'About' })).toBe(screen.getByTestId('target-header'));
     expect(screen.getByRole('header', { name: 'About' }).props.testID).toBe('target-header');
+  });
+
+  test('supports host Image element with "alt" prop', () => {
+    render(<Image alt="An elephant" testID="image" />);
+
+    const expectedElement = screen.getByTestId('image');
+    expect(screen.getByRole('img', { name: 'An elephant' })).toBe(expectedElement);
+    expect(screen.getByRole('image', { name: 'An elephant' })).toBe(expectedElement);
+    expect(screen.getByRole(/img/, { name: 'An elephant' })).toBe(expectedElement);
   });
 });
 
@@ -768,7 +778,7 @@ describe('error messages', () => {
     render(<View />);
 
     expect(() => screen.getByRole('button')).toThrowErrorMatchingInlineSnapshot(`
-      "Unable to find an element with role: "button"
+      "Unable to find an element with role: button
 
       <View />"
     `);
@@ -778,7 +788,7 @@ describe('error messages', () => {
     render(<View />);
 
     expect(() => screen.getByRole('button', { name: 'Save' })).toThrowErrorMatchingInlineSnapshot(`
-      "Unable to find an element with role: "button", name: "Save"
+      "Unable to find an element with role: button, name: Save
 
       <View />"
     `);
@@ -789,7 +799,7 @@ describe('error messages', () => {
 
     expect(() => screen.getByRole('button', { name: 'Save', disabled: true }))
       .toThrowErrorMatchingInlineSnapshot(`
-      "Unable to find an element with role: "button", name: "Save", disabled state: true
+      "Unable to find an element with role: button, name: Save, disabled state: true
 
       <View />"
     `);
@@ -800,7 +810,7 @@ describe('error messages', () => {
 
     expect(() => screen.getByRole('button', { name: 'Save', disabled: true, selected: true }))
       .toThrowErrorMatchingInlineSnapshot(`
-      "Unable to find an element with role: "button", name: "Save", disabled state: true, selected state: true
+      "Unable to find an element with role: button, name: Save, disabled state: true, selected state: true
 
       <View />"
     `);
@@ -811,7 +821,7 @@ describe('error messages', () => {
 
     expect(() => screen.getByRole('button', { disabled: true }))
       .toThrowErrorMatchingInlineSnapshot(`
-      "Unable to find an element with role: "button", disabled state: true
+      "Unable to find an element with role: button, disabled state: true
 
       <View />"
     `);
@@ -822,7 +832,7 @@ describe('error messages', () => {
 
     expect(() => screen.getByRole('adjustable', { value: { min: 1 } }))
       .toThrowErrorMatchingInlineSnapshot(`
-      "Unable to find an element with role: "adjustable", min value: 1
+      "Unable to find an element with role: adjustable, min value: 1
 
       <View />"
     `);
@@ -832,7 +842,7 @@ describe('error messages', () => {
         value: { min: 1, max: 2, now: 1, text: /hello/ },
       }),
     ).toThrowErrorMatchingInlineSnapshot(`
-      "Unable to find an element with role: "adjustable", min value: 1, max value: 2, now value: 1, text value: /hello/
+      "Unable to find an element with role: adjustable, min value: 1, max value: 2, now value: 1, text value: /hello/
 
       <View />"
     `);
@@ -852,7 +862,7 @@ test('byRole queries support hidden option', () => {
   expect(screen.queryByRole('button', { includeHiddenElements: false })).toBeFalsy();
   expect(() => screen.getByRole('button', { includeHiddenElements: false }))
     .toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an element with role: "button"
+    "Unable to find an element with role: button
 
     <View
       accessibilityRole="button"
@@ -889,7 +899,7 @@ describe('matches only accessible elements', () => {
     expect(screen.queryByRole('button', { name: 'Action' })).toBeFalsy();
   });
 
-  test('ignores elements with accessible={undefined} and that are implicitely not accessible', () => {
+  test('ignores elements with accessible={undefined} and that are implicitly not accessible', () => {
     render(
       <View accessibilityRole="menu">
         <Text>Action</Text>
@@ -903,7 +913,7 @@ test('error message renders the element tree, preserving only helpful props', as
   render(<View accessibilityRole="button" key="3" />);
 
   expect(() => screen.getByRole('link')).toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an element with role: "link"
+    "Unable to find an element with role: link
 
     <View
       accessibilityRole="button"
@@ -911,7 +921,7 @@ test('error message renders the element tree, preserving only helpful props', as
   `);
 
   expect(() => screen.getAllByRole('link')).toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an element with role: "link"
+    "Unable to find an element with role: link
 
     <View
       accessibilityRole="button"
@@ -919,7 +929,7 @@ test('error message renders the element tree, preserving only helpful props', as
   `);
 
   await expect(screen.findByRole('link')).rejects.toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an element with role: "link"
+    "Unable to find an element with role: link
 
     <View
       accessibilityRole="button"
@@ -927,7 +937,7 @@ test('error message renders the element tree, preserving only helpful props', as
   `);
 
   await expect(screen.findAllByRole('link')).rejects.toThrowErrorMatchingInlineSnapshot(`
-    "Unable to find an element with role: "link"
+    "Unable to find an element with role: link
 
     <View
       accessibilityRole="button"

--- a/src/queries/hint-text.ts
+++ b/src/queries/hint-text.ts
@@ -31,9 +31,9 @@ const queryAllByHintText = (
   };
 
 const getMultipleError = (hint: TextMatch) =>
-  `Found multiple elements with accessibilityHint: ${String(hint)} `;
+  `Found multiple elements with accessibility hint: ${String(hint)} `;
 const getMissingError = (hint: TextMatch) =>
-  `Unable to find an element with accessibilityHint: ${String(hint)}`;
+  `Unable to find an element with accessibility hint: ${String(hint)}`;
 
 const { getBy, getAllBy, queryBy, queryAllBy, findBy, findAllBy } = makeQueries(
   queryAllByHintText,

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -5,6 +5,7 @@ import {
   accessibilityValueKeys,
   getRole,
   isAccessibilityElement,
+  normalizeRole,
 } from '../helpers/accessibility';
 import { findAll } from '../helpers/find-all';
 import {
@@ -38,6 +39,10 @@ export type ByRoleOptions = CommonQueryOptions &
     value?: AccessibilityValueMatcher;
   };
 
+const matchRole = (node: ReactTestInstance, role: ByRoleMatcher) => {
+  return matchStringProp(getRole(node), role);
+};
+
 const matchAccessibleNameIfNeeded = (node: ReactTestInstance, name?: TextMatch) => {
   if (name == null) return true;
 
@@ -60,12 +65,13 @@ const queryAllByRole = (
   instance: ReactTestInstance,
 ): QueryAllByQuery<ByRoleMatcher, ByRoleOptions> =>
   function queryAllByRoleFn(role, options) {
+    const normalizedRole = typeof role === 'string' ? normalizeRole(role) : role;
     return findAll(
       instance,
       (node) =>
         // run the cheapest checks first, and early exit to avoid unneeded computations
         isAccessibilityElement(node) &&
-        matchStringProp(getRole(node), role) &&
+        matchRole(node, normalizedRole) &&
         matchAccessibleStateIfNeeded(node, options) &&
         matchAccessibilityValueIfNeeded(node, options?.value) &&
         matchAccessibleNameIfNeeded(node, options?.name),
@@ -74,10 +80,10 @@ const queryAllByRole = (
   };
 
 const formatQueryParams = (role: TextMatch, options: ByRoleOptions = {}) => {
-  const params = [`role: "${String(role)}"`];
+  const params = [`role: ${String(role)}`];
 
   if (options.name) {
-    params.push(`name: "${String(options.name)}"`);
+    params.push(`name: ${String(options.name)}`);
   }
 
   accessibilityStateKeys.forEach((stateKey) => {

--- a/src/queries/role.ts
+++ b/src/queries/role.ts
@@ -39,10 +39,6 @@ export type ByRoleOptions = CommonQueryOptions &
     value?: AccessibilityValueMatcher;
   };
 
-const matchRole = (node: ReactTestInstance, role: ByRoleMatcher) => {
-  return matchStringProp(getRole(node), role);
-};
-
 const matchAccessibleNameIfNeeded = (node: ReactTestInstance, name?: TextMatch) => {
   if (name == null) return true;
 
@@ -71,7 +67,7 @@ const queryAllByRole = (
       (node) =>
         // run the cheapest checks first, and early exit to avoid unneeded computations
         isAccessibilityElement(node) &&
-        matchRole(node, normalizedRole) &&
+        matchStringProp(getRole(node), normalizedRole) &&
         matchAccessibleStateIfNeeded(node, options) &&
         matchAccessibilityValueIfNeeded(node, options?.value) &&
         matchAccessibleNameIfNeeded(node, options?.name),


### PR DESCRIPTION
### Summary

Modifies existing a11y queries and matchers to support `Image` element with `alt` prop as a source for a11y label/accessible name.

Code that changes for `Image` + `alt` prop:
* `computeAriaLabel`
* `*ByLabelText` queries
* `*ByRole` queries
* `toHaveAccessibleName` matcher

Additionally:
* host `Image` element is not considered to have image role, as experimentally only Android screen reader announces it, while on iOS "image" trait is not given by default and requires explicit `role`/`accessibilityRole` to be set.
* added code to support mapping from `image` (AccessibilityRole` to `img` (ARIA `Role`), so that users can use both names to match image elements.

Complements/Replaces #1663 as now `getByRole('image', { name: 'alt text' })` or `getByLabelText` can be used to query images with `alt` prop.

#### References
- https://github.com/facebook/react-native/blob/8dabed60f456e76a9e53273b601446f34de41fb5/packages/react-native/Libraries/Image/Image.ios.js#L173
- https://github.com/facebook/react-native/blob/8dabed60f456e76a9e53273b601446f34de41fb5/packages/react-native/Libraries/Image/Image.android.js#L188

### Test plan

Added relevant automated tests.