### PR TITLE
feat: automatically extend matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,7 @@ This library has a `peerDependencies` listing for `react-test-renderer`. Make su
 
 ### Additional Jest matchers
 
-You can use the built-in Jest matchers by adding the following line to your `jest-setup.ts` file (configured using [`setupFilesAfterEnv`](https://jestjs.io/docs/configuration#setupfilesafterenv-array)):
-
-```ts
-import '@testing-library/react-native/extend-expect';
-```
+You can use the built-in Jest matchers automatically by having any import from `@testing-library/react-native` in your test.
 
 ## Example
 

--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -1,1 +1,0 @@
-export * from './build/matchers/extend-expect';

--- a/extend-expect.js
+++ b/extend-expect.js
@@ -1,1 +1,0 @@
-require('./build/matchers/extend-expect');

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,5 +1,4 @@
 import { resetToDefaults } from './src/pure';
-import './src/matchers/extend-expect';
 
 beforeEach(() => {
   resetToDefaults();

--- a/matchers.d.ts
+++ b/matchers.d.ts
@@ -1,0 +1,1 @@
+export * from './build/matchers';

--- a/matchers.js
+++ b/matchers.js
@@ -1,0 +1,2 @@
+// makes it so people can import from '@testing-library/react-native/pure'
+module.exports = require('./build/matchers');

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "files": [
     "build/",
     "jest-preset/",
-    "extend-expect.js",
-    "extend-expect.d.ts",
+    "matchers.js",
+    "matchers.d.ts",
     "pure.js",
     "pure.d.ts",
     "dont-cleanup-after-each.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { cleanup } from './pure';
 import { flushMicroTasks } from './flush-micro-tasks';
 import { getIsReactActEnvironment, setReactActEnvironment } from './act';
+import './matchers/extend-expect';
 
 if (!process?.env?.RNTL_SKIP_AUTO_CLEANUP) {
   // If we're running in a test runner that supports afterEach

--- a/src/matchers/__tests__/to-be-checked.test.tsx
+++ b/src/matchers/__tests__/to-be-checked.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { type AccessibilityRole, Switch, View } from 'react-native';
-import render from '../../render';
-import { screen } from '../../screen';
+import { render, screen } from '../..';
 
 function renderViewsWithRole(role: AccessibilityRole) {
   render(

--- a/src/matchers/__tests__/to-be-partially-checked.test.tsx
+++ b/src/matchers/__tests__/to-be-partially-checked.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { type AccessibilityRole, View } from 'react-native';
-import render from '../../render';
-import { screen } from '../../screen';
+import { render, screen } from '../..';
 
 function renderViewsWithRole(role: AccessibilityRole) {
   return render(


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Extend Jest matchers by default when importing anything from `@testing-library/react-native`.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
