### PR TITLE
docs: readme example userevent import

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ import '@testing-library/react-native/extend-expect';
 ## Example
 
 ```jsx
-import { render, screen, fireEvent } from '@testing-library/react-native';
+import { render, screen, userEvent } from '@testing-library/react-native';
 import { QuestionsBoard } from '../QuestionsBoard';
 
 // It is recommended to use userEvent with fake timers
@@ -108,7 +108,6 @@ React Native Testing Library consists of following APIs:
 
 - [Migration to 12.0](https://callstack.github.io/react-native-testing-library/docs/migration/v12)
 - [Migration to built-in Jest Matchers](https://callstack.github.io/react-native-testing-library/docs/migration/jest-matchers)
-
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Corrects only the imports in the documentation example. The example mentions and uses `userEvent` but `fireEvent` is currently imported (which is not used in the example at all).

### Test plan

I guess, no need to.