### PR TITLE
fix: press event order

### DIFF
--- a/experiments-app/src/experiments.ts
+++ b/experiments-app/src/experiments.ts
@@ -1,4 +1,5 @@
 import { AccessibilityScreen } from './screens/Accessibility';
+import { PressEvents } from './screens/PressEvents';
 import { TextInputEventPropagation } from './screens/TextInputEventPropagation';
 import { TextInputEvents } from './screens/TextInputEvents';
 import { ScrollViewEvents } from './screens/ScrollViewEvents';
@@ -12,6 +13,11 @@ export const experiments = [
     key: 'Accessibility',
     title: 'Accessibility',
     component: AccessibilityScreen,
+  },
+  {
+    key: 'PressEvents',
+    title: 'Press Events',
+    component: PressEvents,
   },
   {
     key: 'TextInputEvents',

--- a/experiments-app/src/screens/PressEvents.tsx
+++ b/experiments-app/src/screens/PressEvents.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import {
+  StyleSheet,
+  SafeAreaView,
+  Text,
+  TextInput,
+  View,
+  Pressable,
+  TouchableOpacity,
+} from 'react-native';
+import { nativeEventLogger, logEvent } from '../utils/helpers';
+
+export function PressEvents() {
+  const [value, setValue] = React.useState('');
+
+  const handleChangeText = (value: string) => {
+    setValue(value);
+    logEvent('changeText', value);
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.wrapper}>
+        <TextInput
+          style={styles.textInput}
+          value={value}
+          onPress={nativeEventLogger('press')}
+          onPressIn={nativeEventLogger('pressIn')}
+          onPressOut={nativeEventLogger('pressOut')}
+        />
+      </View>
+      <View style={styles.wrapper}>
+        <Text
+          onPress={nativeEventLogger('press')}
+          onLongPress={nativeEventLogger('longPress')}
+          onPressIn={nativeEventLogger('pressIn')}
+          onPressOut={nativeEventLogger('pressOut')}
+        >
+          Text
+        </Text>
+      </View>
+      <View style={styles.wrapper}>
+        <Pressable
+          onPress={nativeEventLogger('press')}
+          onLongPress={nativeEventLogger('longPress')}
+          onPressIn={nativeEventLogger('pressIn')}
+          onPressOut={nativeEventLogger('pressOut')}
+        >
+          <Text>Pressable</Text>
+        </Pressable>
+      </View>
+      <View style={styles.wrapper}>
+        <TouchableOpacity
+          onPress={nativeEventLogger('press')}
+          onLongPress={nativeEventLogger('longPress')}
+          onPressIn={nativeEventLogger('pressIn')}
+          onPressOut={nativeEventLogger('pressOut')}
+        >
+          <Text>Pressable</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  wrapper: {
+    padding: 20,
+    backgroundColor: 'yellow',
+  },
+  textInput: {
+    backgroundColor: 'white',
+    margin: 20,
+    padding: 8,
+    fontSize: 18,
+    borderWidth: 1,
+    borderColor: 'grey',
+  },
+});

--- a/experiments-app/src/utils/helpers.ts
+++ b/experiments-app/src/utils/helpers.ts
@@ -1,5 +1,7 @@
 import { NativeSyntheticEvent } from 'react-native/types';
 
+let lastEventTimeStamp: number | null = null;
+
 export function nativeEventLogger(name: string) {
   return (event: NativeSyntheticEvent<unknown>) => {
     logEvent(name, event?.nativeEvent);
@@ -14,5 +16,6 @@ export function customEventLogger(name: string) {
 
 export function logEvent(name: string, ...args: unknown[]) {
   // eslint-disable-next-line no-console
-  console.log(`Event: ${name}`, ...args);
+  console.log(`[${Date.now() - (lastEventTimeStamp ?? Date.now())}ms] Event: ${name}`, ...args);
+  lastEventTimeStamp = Date.now();
 }

--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import * as React from 'react';
 import { Pressable, Text, TextInput, View } from 'react-native';
-import { getConfig, resetToDefaults } from '../config';
+import { configure, getConfig, resetToDefaults } from '../config';
 import { fireEvent, render, RenderAPI, screen } from '..';
 
 const PLACEHOLDER_FRESHNESS = 'Add custom freshness';
@@ -247,7 +247,16 @@ test('supports legacy rendering', () => {
   expect(screen.root).toBeDefined();
 });
 
-test('supports concurrent rendering', () => {
+// Enable concurrent rendering globally
+configure({ concurrentRoot: true });
+
+test('globally enable concurrent rendering', () => {
+  render(<View testID="test" />);
+  expect(screen.root).toBeOnTheScreen();
+});
+
+// Enable concurrent rendering locally
+test('locally enable concurrent rendering', () => {
   render(<View testID="test" />, { concurrentRoot: true });
-  expect(screen.root).toBeDefined();
+  expect(screen.root).toBeOnTheScreen();
 });

--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import * as React from 'react';
 import { Pressable, Text, TextInput, View } from 'react-native';
-import { configure, getConfig, resetToDefaults } from '../config';
+import { getConfig, resetToDefaults } from '../config';
 import { fireEvent, render, RenderAPI, screen } from '..';
 
 const PLACEHOLDER_FRESHNESS = 'Add custom freshness';

--- a/src/__tests__/render.test.tsx
+++ b/src/__tests__/render.test.tsx
@@ -247,16 +247,7 @@ test('supports legacy rendering', () => {
   expect(screen.root).toBeDefined();
 });
 
-// Enable concurrent rendering globally
-configure({ concurrentRoot: true });
-
-test('globally enable concurrent rendering', () => {
-  render(<View testID="test" />);
-  expect(screen.root).toBeOnTheScreen();
-});
-
-// Enable concurrent rendering locally
-test('locally enable concurrent rendering', () => {
+test('supports concurrent rendering', () => {
   render(<View testID="test" />, { concurrentRoot: true });
   expect(screen.root).toBeOnTheScreen();
 });

--- a/src/fire-event.ts
+++ b/src/fire-event.ts
@@ -7,7 +7,7 @@ import {
   ScrollViewProps,
 } from 'react-native';
 import act from './act';
-import { isHostElement } from './helpers/component-tree';
+import { isElementMounted, isHostElement } from './helpers/component-tree';
 import { isHostScrollView, isHostTextInput } from './helpers/host-component-names';
 import { isPointerEventEnabled } from './helpers/pointer-events';
 import { isTextInputEditable } from './helpers/text-input';
@@ -121,6 +121,10 @@ type EventName = StringWithAutocomplete<
 >;
 
 function fireEvent(element: ReactTestInstance, eventName: EventName, ...data: unknown[]) {
+  if (!isElementMounted(element)) {
+    return;
+  }
+
   setNativeStateIfNeeded(element, eventName, data[0]);
 
   const handler = findEventHandler(element, eventName);

--- a/src/helpers/component-tree.ts
+++ b/src/helpers/component-tree.ts
@@ -1,5 +1,5 @@
 import { ReactTestInstance } from 'react-test-renderer';
-
+import { screen } from '../screen';
 /**
  * ReactTestInstance referring to host element.
  */
@@ -11,6 +11,10 @@ export type HostTestInstance = ReactTestInstance & { type: string };
  */
 export function isHostElement(element?: ReactTestInstance | null): element is HostTestInstance {
   return typeof element?.type === 'string';
+}
+
+export function isElementMounted(element: ReactTestInstance | null) {
+  return getUnsafeRootElement(element) === screen.UNSAFE_root;
 }
 
 /**

--- a/src/user-event/press/__tests__/__snapshots__/longPress.test.tsx.snap
+++ b/src/user-event/press/__tests__/__snapshots__/longPress.test.tsx.snap
@@ -34,3 +34,98 @@ exports[`userEvent.longPress with fake timers calls onLongPress if the delayLong
   },
 ]
 `;
+
+exports[`userEvent.longPress with fake timers works on Pressable 1`] = `
+[
+  {
+    "name": "pressIn",
+    "payload": {
+      "currentTarget": {
+        "measure": [Function],
+      },
+      "dispatchConfig": {
+        "registrationName": "onResponderGrant",
+      },
+      "isDefaultPrevented": [Function],
+      "isPersistent": [Function],
+      "isPropagationStopped": [Function],
+      "nativeEvent": {
+        "changedTouches": [],
+        "identifier": 0,
+        "locationX": 0,
+        "locationY": 0,
+        "pageX": 0,
+        "pageY": 0,
+        "target": 0,
+        "timestamp": 0,
+        "touches": [],
+      },
+      "persist": [Function],
+      "preventDefault": [Function],
+      "stopPropagation": [Function],
+      "target": {},
+      "timeStamp": 0,
+    },
+  },
+  {
+    "name": "longPress",
+    "payload": {
+      "currentTarget": {
+        "measure": [Function],
+      },
+      "dispatchConfig": {
+        "registrationName": "onResponderGrant",
+      },
+      "isDefaultPrevented": [Function],
+      "isPersistent": [Function],
+      "isPropagationStopped": [Function],
+      "nativeEvent": {
+        "changedTouches": [],
+        "identifier": 0,
+        "locationX": 0,
+        "locationY": 0,
+        "pageX": 0,
+        "pageY": 0,
+        "target": 0,
+        "timestamp": 0,
+        "touches": [],
+      },
+      "persist": [Function],
+      "preventDefault": [Function],
+      "stopPropagation": [Function],
+      "target": {},
+      "timeStamp": 0,
+    },
+  },
+  {
+    "name": "pressOut",
+    "payload": {
+      "currentTarget": {
+        "measure": [Function],
+      },
+      "dispatchConfig": {
+        "registrationName": "onResponderRelease",
+      },
+      "isDefaultPrevented": [Function],
+      "isPersistent": [Function],
+      "isPropagationStopped": [Function],
+      "nativeEvent": {
+        "changedTouches": [],
+        "identifier": 0,
+        "locationX": 0,
+        "locationY": 0,
+        "pageX": 0,
+        "pageY": 0,
+        "target": 0,
+        "timestamp": 500,
+        "touches": [],
+      },
+      "persist": [Function],
+      "preventDefault": [Function],
+      "stopPropagation": [Function],
+      "target": {},
+      "timeStamp": 0,
+    },
+  },
+]
+`;

--- a/src/user-event/press/__tests__/__snapshots__/press.test.tsx.snap
+++ b/src/user-event/press/__tests__/__snapshots__/press.test.tsx.snap
@@ -33,36 +33,6 @@ exports[`userEvent.press with fake timers calls onPressIn, onPress and onPressOu
     },
   },
   {
-    "name": "press",
-    "payload": {
-      "currentTarget": {
-        "measure": [Function],
-      },
-      "dispatchConfig": {
-        "registrationName": "onResponderRelease",
-      },
-      "isDefaultPrevented": [Function],
-      "isPersistent": [Function],
-      "isPropagationStopped": [Function],
-      "nativeEvent": {
-        "changedTouches": [],
-        "identifier": 0,
-        "locationX": 0,
-        "locationY": 0,
-        "pageX": 0,
-        "pageY": 0,
-        "target": 0,
-        "timestamp": 0,
-        "touches": [],
-      },
-      "persist": [Function],
-      "preventDefault": [Function],
-      "stopPropagation": [Function],
-      "target": {},
-      "timeStamp": 0,
-    },
-  },
-  {
     "name": "pressOut",
     "payload": {
       "currentTarget": {
@@ -82,7 +52,37 @@ exports[`userEvent.press with fake timers calls onPressIn, onPress and onPressOu
         "pageX": 0,
         "pageY": 0,
         "target": 0,
-        "timestamp": 0,
+        "timestamp": 130,
+        "touches": [],
+      },
+      "persist": [Function],
+      "preventDefault": [Function],
+      "stopPropagation": [Function],
+      "target": {},
+      "timeStamp": 0,
+    },
+  },
+  {
+    "name": "press",
+    "payload": {
+      "currentTarget": {
+        "measure": [Function],
+      },
+      "dispatchConfig": {
+        "registrationName": "onResponderRelease",
+      },
+      "isDefaultPrevented": [Function],
+      "isPersistent": [Function],
+      "isPropagationStopped": [Function],
+      "nativeEvent": {
+        "changedTouches": [],
+        "identifier": 0,
+        "locationX": 0,
+        "locationY": 0,
+        "pageX": 0,
+        "pageY": 0,
+        "target": 0,
+        "timestamp": 130,
         "touches": [],
       },
       "persist": [Function],

--- a/src/user-event/press/__tests__/__snapshots__/press.test.tsx.snap
+++ b/src/user-event/press/__tests__/__snapshots__/press.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`userEvent.press with fake timers calls onPressIn, onPress and onPressOut prop of touchable 1`] = `
+exports[`userEvent.press with fake timers works on Pressable 1`] = `
 [
   {
     "name": "pressIn",

--- a/src/user-event/press/__tests__/longPress.real-timers.test.tsx
+++ b/src/user-event/press/__tests__/longPress.real-timers.test.tsx
@@ -1,12 +1,75 @@
 import React from 'react';
-import { Pressable, Text } from 'react-native';
-import { render, screen } from '../../../pure';
+import { Pressable, Text, TouchableHighlight, TouchableOpacity } from 'react-native';
+import { createEventLogger, getEventsNames } from '../../../test-utils';
+import { render, screen } from '../../..';
 import { userEvent } from '../..';
 
 describe('userEvent.longPress with real timers', () => {
   beforeEach(() => {
     jest.useRealTimers();
     jest.restoreAllMocks();
+  });
+
+  test('works on Pressable', async () => {
+    const { events, logEvent } = createEventLogger();
+    const user = userEvent.setup();
+
+    render(
+      <Pressable
+        onPress={logEvent('press')}
+        onPressIn={logEvent('pressIn')}
+        onPressOut={logEvent('pressOut')}
+        onLongPress={logEvent('longPress')}
+        testID="pressable"
+      />,
+    );
+
+    await user.longPress(screen.getByTestId('pressable'));
+    expect(getEventsNames(events)).toEqual(['pressIn', 'longPress', 'pressOut']);
+  });
+
+  test('works on TouchableOpacity', async () => {
+    const mockOnPress = jest.fn();
+
+    render(
+      <TouchableOpacity onPress={mockOnPress}>
+        <Text>press me</Text>
+      </TouchableOpacity>,
+    );
+
+    await userEvent.longPress(screen.getByText('press me'));
+    expect(mockOnPress).toHaveBeenCalled();
+  });
+
+  test('works on TouchableHighlight', async () => {
+    const mockOnPress = jest.fn();
+
+    render(
+      <TouchableHighlight onPress={mockOnPress}>
+        <Text>press me</Text>
+      </TouchableHighlight>,
+    );
+
+    await userEvent.longPress(screen.getByText('press me'));
+    expect(mockOnPress).toHaveBeenCalled();
+  });
+
+  test('works on Text', async () => {
+    const { events, logEvent } = createEventLogger();
+
+    render(
+      <Text
+        onPress={logEvent('press')}
+        onPressIn={logEvent('pressIn')}
+        onPressOut={logEvent('pressOut')}
+        onLongPress={logEvent('longPress')}
+      >
+        press me
+      </Text>,
+    );
+
+    await userEvent.longPress(screen.getByText('press me'));
+    expect(getEventsNames(events)).toEqual(['pressIn', 'longPress', 'pressOut']);
   });
 
   test('calls onLongPress if the delayLongPress is the default one', async () => {

--- a/src/user-event/press/__tests__/longPress.test.tsx
+++ b/src/user-event/press/__tests__/longPress.test.tsx
@@ -1,13 +1,76 @@
 import React from 'react';
-import { Pressable, Text } from 'react-native';
-import { render, screen } from '../../../pure';
+import { Pressable, Text, TouchableHighlight, TouchableOpacity } from 'react-native';
+import { createEventLogger, getEventsNames } from '../../../test-utils';
+import { render, screen } from '../../..';
 import { userEvent } from '../..';
-import { createEventLogger } from '../../../test-utils';
 
 describe('userEvent.longPress with fake timers', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(0);
+  });
+
+  test('works on Pressable', async () => {
+    const { events, logEvent } = createEventLogger();
+    const user = userEvent.setup();
+
+    render(
+      <Pressable
+        onPress={logEvent('press')}
+        onPressIn={logEvent('pressIn')}
+        onPressOut={logEvent('pressOut')}
+        onLongPress={logEvent('longPress')}
+        testID="pressable"
+      />,
+    );
+
+    await user.longPress(screen.getByTestId('pressable'));
+    expect(getEventsNames(events)).toEqual(['pressIn', 'longPress', 'pressOut']);
+    expect(events).toMatchSnapshot();
+  });
+
+  test('works on TouchableOpacity', async () => {
+    const mockOnPress = jest.fn();
+
+    render(
+      <TouchableOpacity onPress={mockOnPress}>
+        <Text>press me</Text>
+      </TouchableOpacity>,
+    );
+
+    await userEvent.longPress(screen.getByText('press me'));
+    expect(mockOnPress).toHaveBeenCalled();
+  });
+
+  test('works on TouchableHighlight', async () => {
+    const mockOnPress = jest.fn();
+
+    render(
+      <TouchableHighlight onPress={mockOnPress}>
+        <Text>press me</Text>
+      </TouchableHighlight>,
+    );
+
+    await userEvent.longPress(screen.getByText('press me'));
+    expect(mockOnPress).toHaveBeenCalled();
+  });
+
+  test('works on Text', async () => {
+    const { events, logEvent } = createEventLogger();
+
+    render(
+      <Text
+        onPress={logEvent('press')}
+        onPressIn={logEvent('pressIn')}
+        onPressOut={logEvent('pressOut')}
+        onLongPress={logEvent('longPress')}
+      >
+        press me
+      </Text>,
+    );
+
+    await userEvent.longPress(screen.getByText('press me'));
+    expect(getEventsNames(events)).toEqual(['pressIn', 'longPress', 'pressOut']);
   });
 
   test('calls onLongPress if the delayLongPress is the default one', async () => {

--- a/src/user-event/press/__tests__/press.real-timers.test.tsx
+++ b/src/user-event/press/__tests__/press.real-timers.test.tsx
@@ -32,7 +32,7 @@ describe('userEvent.press with real timers', () => {
     );
     await user.press(screen.getByTestId('pressable'));
 
-    expect(getEventsNames(events)).toEqual(['pressIn', 'press', 'pressOut']);
+    expect(getEventsNames(events)).toEqual(['pressIn', 'pressOut', 'press']);
   });
 
   test('does not trigger event when pressable is disabled', async () => {
@@ -128,7 +128,7 @@ describe('userEvent.press with real timers', () => {
     );
     await user.press(screen.getByTestId('pressable'));
 
-    expect(getEventsNames(events)).toEqual(['pressIn', 'press', 'pressOut']);
+    expect(getEventsNames(events)).toEqual(['pressIn', 'pressOut', 'press']);
   });
 
   test('crawls up in the tree to find an element that responds to touch events', async () => {

--- a/src/user-event/press/__tests__/press.real-timers.test.tsx
+++ b/src/user-event/press/__tests__/press.real-timers.test.tsx
@@ -198,7 +198,7 @@ describe('userEvent.press with real timers', () => {
     );
     await userEvent.press(screen.getByText('press me'));
 
-    expect(getEventsNames(events)).toEqual(['pressIn', 'press', 'pressOut']);
+    expect(getEventsNames(events)).toEqual(['pressIn', 'pressOut', 'press']);
   });
 
   test('does not trigger on disabled Text', async () => {
@@ -240,7 +240,7 @@ describe('userEvent.press with real timers', () => {
     expect(events).toEqual([]);
   });
 
-  test('works on TetInput', async () => {
+  test('works on TextInput', async () => {
     const { events, logEvent } = createEventLogger();
 
     render(
@@ -255,7 +255,7 @@ describe('userEvent.press with real timers', () => {
     expect(getEventsNames(events)).toEqual(['pressIn', 'pressOut']);
   });
 
-  test('does not call onPressIn and onPressOut on non editable TetInput', async () => {
+  test('does not call onPressIn and onPressOut on non editable TextInput', async () => {
     const { events, logEvent } = createEventLogger();
 
     render(
@@ -270,7 +270,7 @@ describe('userEvent.press with real timers', () => {
     expect(events).toEqual([]);
   });
 
-  test('does not call onPressIn and onPressOut on TetInput with pointer events disabled', async () => {
+  test('does not call onPressIn and onPressOut on TextInput with pointer events disabled', async () => {
     const { events, logEvent } = createEventLogger();
 
     render(

--- a/src/user-event/press/__tests__/press.real-timers.test.tsx
+++ b/src/user-event/press/__tests__/press.real-timers.test.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  Button,
   Pressable,
   Text,
   TextInput,
@@ -17,7 +18,7 @@ describe('userEvent.press with real timers', () => {
     jest.restoreAllMocks();
   });
 
-  test('calls onPressIn, onPress and onPressOut prop of touchable', async () => {
+  test('works on Pressable', async () => {
     const { events, logEvent } = createEventLogger();
     const user = userEvent.setup();
 
@@ -30,9 +31,77 @@ describe('userEvent.press with real timers', () => {
         testID="pressable"
       />,
     );
-    await user.press(screen.getByTestId('pressable'));
 
+    await user.press(screen.getByTestId('pressable'));
     expect(getEventsNames(events)).toEqual(['pressIn', 'pressOut', 'press']);
+  });
+
+  test('works on TouchableOpacity', async () => {
+    const mockOnPress = jest.fn();
+
+    render(
+      <TouchableOpacity onPress={mockOnPress}>
+        <Text>press me</Text>
+      </TouchableOpacity>,
+    );
+
+    await userEvent.press(screen.getByText('press me'));
+    expect(mockOnPress).toHaveBeenCalled();
+  });
+
+  test('works on TouchableHighlight', async () => {
+    const mockOnPress = jest.fn();
+
+    render(
+      <TouchableHighlight onPress={mockOnPress}>
+        <Text>press me</Text>
+      </TouchableHighlight>,
+    );
+
+    await userEvent.press(screen.getByText('press me'));
+    expect(mockOnPress).toHaveBeenCalled();
+  });
+
+  test('works on Text', async () => {
+    const { events, logEvent } = createEventLogger();
+
+    render(
+      <Text
+        onPress={logEvent('press')}
+        onPressIn={logEvent('pressIn')}
+        onPressOut={logEvent('pressOut')}
+        onLongPress={logEvent('longPress')}
+      >
+        press me
+      </Text>,
+    );
+
+    await userEvent.press(screen.getByText('press me'));
+    expect(getEventsNames(events)).toEqual(['pressIn', 'pressOut', 'press']);
+  });
+
+  test('works on TextInput', async () => {
+    const { events, logEvent } = createEventLogger();
+
+    render(
+      <TextInput
+        placeholder="email"
+        onPressIn={logEvent('pressIn')}
+        onPressOut={logEvent('pressOut')}
+      />,
+    );
+
+    await userEvent.press(screen.getByPlaceholderText('email'));
+    expect(getEventsNames(events)).toEqual(['pressIn', 'pressOut']);
+  });
+
+  test('works on Button', async () => {
+    const { events, logEvent } = createEventLogger();
+
+    render(<Button title="press me" onPress={logEvent('press')} />);
+
+    await userEvent.press(screen.getByText('press me'));
+    expect(getEventsNames(events)).toEqual(['press']);
   });
 
   test('does not trigger event when pressable is disabled', async () => {
@@ -157,50 +226,6 @@ describe('userEvent.press with real timers', () => {
     expect(mockOnLongPress).not.toHaveBeenCalled();
   });
 
-  test('works on TouchableOpacity', async () => {
-    const mockOnPress = jest.fn();
-
-    render(
-      <TouchableOpacity onPress={mockOnPress}>
-        <Text>press me</Text>
-      </TouchableOpacity>,
-    );
-    await userEvent.press(screen.getByText('press me'));
-
-    expect(mockOnPress).toHaveBeenCalled();
-  });
-
-  test('works on TouchableHighlight', async () => {
-    const mockOnPress = jest.fn();
-
-    render(
-      <TouchableHighlight onPress={mockOnPress}>
-        <Text>press me</Text>
-      </TouchableHighlight>,
-    );
-    await userEvent.press(screen.getByText('press me'));
-
-    expect(mockOnPress).toHaveBeenCalled();
-  });
-
-  test('works on Text', async () => {
-    const { events, logEvent } = createEventLogger();
-
-    render(
-      <Text
-        onPress={logEvent('press')}
-        onPressIn={logEvent('pressIn')}
-        onPressOut={logEvent('pressOut')}
-        onLongPress={logEvent('longPress')}
-      >
-        press me
-      </Text>,
-    );
-    await userEvent.press(screen.getByText('press me'));
-
-    expect(getEventsNames(events)).toEqual(['pressIn', 'pressOut', 'press']);
-  });
-
   test('does not trigger on disabled Text', async () => {
     const { events, logEvent } = createEventLogger();
 
@@ -238,21 +263,6 @@ describe('userEvent.press with real timers', () => {
     await userEvent.press(screen.getByText('press me'));
 
     expect(events).toEqual([]);
-  });
-
-  test('works on TextInput', async () => {
-    const { events, logEvent } = createEventLogger();
-
-    render(
-      <TextInput
-        placeholder="email"
-        onPressIn={logEvent('pressIn')}
-        onPressOut={logEvent('pressOut')}
-      />,
-    );
-    await userEvent.press(screen.getByPlaceholderText('email'));
-
-    expect(getEventsNames(events)).toEqual(['pressIn', 'pressOut']);
   });
 
   test('does not call onPressIn and onPressOut on non editable TextInput', async () => {
@@ -295,7 +305,6 @@ describe('userEvent.press with real timers', () => {
     );
 
     await userEvent.press(screen.getByText('press me'));
-
     expect(mockOnPress).toHaveBeenCalled();
   });
 });

--- a/src/user-event/press/__tests__/press.test.tsx
+++ b/src/user-event/press/__tests__/press.test.tsx
@@ -199,7 +199,7 @@ describe('userEvent.press with fake timers', () => {
     );
 
     await userEvent.press(screen.getByText('press me'));
-    expect(getEventsNames(events)).toEqual(['pressIn', 'press', 'pressOut']);
+    expect(getEventsNames(events)).toEqual(['pressIn', 'pressOut', 'press']);
   });
 
   test('press works on Button', async () => {

--- a/src/user-event/press/__tests__/press.test.tsx
+++ b/src/user-event/press/__tests__/press.test.tsx
@@ -129,7 +129,7 @@ describe('userEvent.press with fake timers', () => {
     );
     await user.press(screen.getByTestId('pressable'));
 
-    expect(getEventsNames(events)).toEqual(['pressIn', 'press', 'pressOut']);
+    expect(getEventsNames(events)).toEqual(['pressIn', 'pressOut', 'press']);
   });
 
   test('crawls up in the tree to find an element that responds to touch events', async () => {

--- a/src/user-event/press/__tests__/press.test.tsx
+++ b/src/user-event/press/__tests__/press.test.tsx
@@ -18,7 +18,7 @@ describe('userEvent.press with fake timers', () => {
     jest.setSystemTime(0);
   });
 
-  test('calls onPressIn, onPress and onPressOut prop of touchable', async () => {
+  test('works on Pressable', async () => {
     const { events, logEvent } = createEventLogger();
     const user = userEvent.setup();
 
@@ -31,9 +31,78 @@ describe('userEvent.press with fake timers', () => {
         testID="pressable"
       />,
     );
-    await user.press(screen.getByTestId('pressable'));
 
+    await user.press(screen.getByTestId('pressable'));
+    expect(getEventsNames(events)).toEqual(['pressIn', 'pressOut', 'press']);
     expect(events).toMatchSnapshot();
+  });
+
+  test('works on TouchableOpacity', async () => {
+    const mockOnPress = jest.fn();
+
+    render(
+      <TouchableOpacity onPress={mockOnPress}>
+        <Text>press me</Text>
+      </TouchableOpacity>,
+    );
+
+    await userEvent.press(screen.getByText('press me'));
+    expect(mockOnPress).toHaveBeenCalled();
+  });
+
+  test('works on TouchableHighlight', async () => {
+    const mockOnPress = jest.fn();
+
+    render(
+      <TouchableHighlight onPress={mockOnPress}>
+        <Text>press me</Text>
+      </TouchableHighlight>,
+    );
+
+    await userEvent.press(screen.getByText('press me'));
+    expect(mockOnPress).toHaveBeenCalled();
+  });
+
+  test('works on Text', async () => {
+    const { events, logEvent } = createEventLogger();
+
+    render(
+      <Text
+        onPress={logEvent('press')}
+        onPressIn={logEvent('pressIn')}
+        onPressOut={logEvent('pressOut')}
+        onLongPress={logEvent('longPress')}
+      >
+        press me
+      </Text>,
+    );
+
+    await userEvent.press(screen.getByText('press me'));
+    expect(getEventsNames(events)).toEqual(['pressIn', 'pressOut', 'press']);
+  });
+
+  test('works on TextInput', async () => {
+    const { events, logEvent } = createEventLogger();
+
+    render(
+      <TextInput
+        placeholder="email"
+        onPressIn={logEvent('pressIn')}
+        onPressOut={logEvent('pressOut')}
+      />,
+    );
+
+    await userEvent.press(screen.getByPlaceholderText('email'));
+    expect(getEventsNames(events)).toEqual(['pressIn', 'pressOut']);
+  });
+
+  test('works on Button', async () => {
+    const { events, logEvent } = createEventLogger();
+
+    render(<Button title="press me" onPress={logEvent('press')} />);
+
+    await userEvent.press(screen.getByText('press me'));
+    expect(getEventsNames(events)).toEqual(['press']);
   });
 
   test('does not trigger event when pressable is disabled', async () => {
@@ -158,59 +227,6 @@ describe('userEvent.press with fake timers', () => {
     expect(mockOnLongPress).not.toHaveBeenCalled();
   });
 
-  test('works on TouchableOpacity', async () => {
-    const mockOnPress = jest.fn();
-
-    render(
-      <TouchableOpacity onPress={mockOnPress}>
-        <Text>press me</Text>
-      </TouchableOpacity>,
-    );
-    await userEvent.press(screen.getByText('press me'));
-
-    expect(mockOnPress).toHaveBeenCalled();
-  });
-
-  test('works on TouchableHighlight', async () => {
-    const mockOnPress = jest.fn();
-
-    render(
-      <TouchableHighlight onPress={mockOnPress}>
-        <Text>press me</Text>
-      </TouchableHighlight>,
-    );
-    await userEvent.press(screen.getByText('press me'));
-
-    expect(mockOnPress).toHaveBeenCalled();
-  });
-
-  test('press works on Text', async () => {
-    const { events, logEvent } = createEventLogger();
-
-    render(
-      <Text
-        onPress={logEvent('press')}
-        onPressIn={logEvent('pressIn')}
-        onPressOut={logEvent('pressOut')}
-        onLongPress={logEvent('longPress')}
-      >
-        press me
-      </Text>,
-    );
-
-    await userEvent.press(screen.getByText('press me'));
-    expect(getEventsNames(events)).toEqual(['pressIn', 'pressOut', 'press']);
-  });
-
-  test('press works on Button', async () => {
-    const { events, logEvent } = createEventLogger();
-
-    render(<Button title="press me" onPress={logEvent('press')} />);
-
-    await userEvent.press(screen.getByText('press me'));
-    expect(getEventsNames(events)).toEqual(['press']);
-  });
-
   test('longPress works Text', async () => {
     const { events, logEvent } = createEventLogger();
 
@@ -266,36 +282,6 @@ describe('userEvent.press with fake timers', () => {
     await userEvent.press(screen.getByText('press me'));
 
     expect(events).toEqual([]);
-  });
-
-  test('press works on TextInput', async () => {
-    const { events, logEvent } = createEventLogger();
-
-    render(
-      <TextInput
-        placeholder="email"
-        onPressIn={logEvent('pressIn')}
-        onPressOut={logEvent('pressOut')}
-      />,
-    );
-
-    await userEvent.press(screen.getByPlaceholderText('email'));
-    expect(getEventsNames(events)).toEqual(['pressIn', 'pressOut']);
-  });
-
-  test('longPress works on TextInput', async () => {
-    const { events, logEvent } = createEventLogger();
-
-    render(
-      <TextInput
-        placeholder="email"
-        onPressIn={logEvent('pressIn')}
-        onPressOut={logEvent('pressOut')}
-      />,
-    );
-
-    await userEvent.longPress(screen.getByPlaceholderText('email'));
-    expect(getEventsNames(events)).toEqual(['pressIn', 'pressOut']);
   });
 
   test('does not call onPressIn and onPressOut on non editable TextInput', async () => {

--- a/src/user-event/press/__tests__/press.test.tsx
+++ b/src/user-event/press/__tests__/press.test.tsx
@@ -372,3 +372,27 @@ describe('userEvent.press with fake timers', () => {
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
 });
+
+function Component() {
+  const [mounted, setMounted] = React.useState(true);
+
+  const onPressIn = () => {
+    setMounted(false);
+  };
+
+  return (
+    <View>
+      {mounted && (
+        <Pressable onPressIn={onPressIn}>
+          <Text>Unmount</Text>
+        </Pressable>
+      )}
+    </View>
+  );
+}
+
+test('unmounts component', async () => {
+  render(<Component />);
+  await userEvent.press(screen.getByText('Unmount'));
+  expect(screen.queryByText('Unmount')).not.toBeOnTheScreen();
+});

--- a/src/user-event/press/constants.ts
+++ b/src/user-event/press/constants.ts
@@ -1,7 +1,0 @@
-// These are constants defined in the React Native repo
-
-// Used to define the delay before calling onPressOut after a press
-export const DEFAULT_MIN_PRESS_DURATION = 130;
-
-// Default minimum press duration to trigger a long press
-export const DEFAULT_LONG_PRESS_DELAY_MS = 500;

--- a/src/user-event/press/press.ts
+++ b/src/user-event/press/press.ts
@@ -118,11 +118,19 @@ async function emitTextPressEvents(
   await wait(config);
   dispatchEvent(element, 'pressIn', EventBuilder.Common.touch());
 
-  // Emit either `press` or `longPress`.
-  dispatchEvent(element, options.type, EventBuilder.Common.touch());
-
   await wait(config, options.duration);
+
+  // Long press events are emitted before `pressOut`.
+  if (options.type === 'longPress') {
+    dispatchEvent(element, 'longPress', EventBuilder.Common.touch());
+  }
+
   dispatchEvent(element, 'pressOut', EventBuilder.Common.touch());
+
+  // Regular press events are emitted after `pressOut`.
+  if (options.type === 'press') {
+    dispatchEvent(element, 'press', EventBuilder.Common.touch());
+  }
 }
 
 /**

--- a/src/user-event/press/press.ts
+++ b/src/user-event/press/press.ts
@@ -9,6 +9,7 @@ import { UserEventConfig, UserEventInstance } from '../setup';
 import { dispatchEvent, wait } from '../utils';
 
 // These are constants defined in the React Native repo
+// See: https://github.com/facebook/react-native/blob/50e38cc9f1e6713228a91ad50f426c4f65e65e1a/packages/react-native/Libraries/Pressability/Pressability.js#L264
 export const DEFAULT_MIN_PRESS_DURATION = 130;
 export const DEFAULT_LONG_PRESS_DELAY_MS = 500;
 

--- a/src/user-event/press/press.ts
+++ b/src/user-event/press/press.ts
@@ -20,7 +20,6 @@ export interface PressOptions {
 export async function press(this: UserEventInstance, element: ReactTestInstance): Promise<void> {
   await basePress(this.config, element, {
     type: 'press',
-    duration: undefined,
   });
 }
 
@@ -37,7 +36,7 @@ export async function longPress(
 
 interface BasePressOptions {
   type: 'press' | 'longPress';
-  duration: number | undefined;
+  duration?: number;
 }
 
 const basePress = async (

--- a/src/user-event/press/press.ts
+++ b/src/user-event/press/press.ts
@@ -20,7 +20,7 @@ export interface PressOptions {
 export async function press(this: UserEventInstance, element: ReactTestInstance): Promise<void> {
   await basePress(this.config, element, {
     type: 'press',
-    duration: DEFAULT_MIN_PRESS_DURATION,
+    duration: undefined,
   });
 }
 
@@ -37,7 +37,7 @@ export async function longPress(
 
 interface BasePressOptions {
   type: 'press' | 'longPress';
-  duration: number;
+  duration: number | undefined;
 }
 
 const basePress = async (
@@ -77,16 +77,17 @@ const emitPressablePressEvents = async (
 
   dispatchEvent(element, 'responderGrant', EventBuilder.Common.responderGrant());
 
-  await wait(config, options.duration);
+  const duration = options.duration ?? DEFAULT_MIN_PRESS_DURATION;
+  await wait(config, duration);
 
   dispatchEvent(element, 'responderRelease', EventBuilder.Common.responderRelease());
 
   // React Native will wait for minimal delay of DEFAULT_MIN_PRESS_DURATION
   // before emitting the `pressOut` event. We need to wait here, so that
   // `press()` function does not return before that.
-  if (DEFAULT_MIN_PRESS_DURATION - options.duration > 0) {
+  if (DEFAULT_MIN_PRESS_DURATION - duration > 0) {
     await act(async () => {
-      await wait(config, DEFAULT_MIN_PRESS_DURATION - options.duration);
+      await wait(config, DEFAULT_MIN_PRESS_DURATION - duration);
     });
   }
 };

--- a/src/user-event/utils/dispatch-event.ts
+++ b/src/user-event/utils/dispatch-event.ts
@@ -1,5 +1,6 @@
 import { ReactTestInstance } from 'react-test-renderer';
 import act from '../../act';
+import { isElementMounted } from '../../helpers/component-tree';
 
 /**
  * Basic dispatch event function used by User Event module.
@@ -9,6 +10,10 @@ import act from '../../act';
  * @param event event payload(s)
  */
 export function dispatchEvent(element: ReactTestInstance, eventName: string, ...event: unknown[]) {
+  if (!isElementMounted(element)) {
+    return;
+  }
+
   const handler = getEventHandler(element, eventName);
   if (!handler) {
     return;


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Resolves: #1687 

Reverses `pressOut` and `press` event order so that it matches experimental data for regular presses:
 1. `pressIn`,
 2. (press duration)
 3. `pressOut`
 4. (no waiting) `press`. 

The previous setup matched edge case for very short (< 130ms) presses, when order was:
1. `pressIn`
2. (short press duration < 130 ms)
3. `press`
4. (wait till 130 ms - short press duration)
5. `pressOut`

## Scope
- [x] Fix event order
- [x] Prevent triggering events on unmounted components

See experiments: https://github.com/callstack/react-native-testing-library/wiki/Press-Events

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

All tests pass
<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
