### PR TITLE
feat: event debugging (WIP)

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -14,9 +14,10 @@ test('configure() overrides existing config values', () => {
   configure({ defaultDebugOptions: { message: 'debug message' } });
   expect(getConfig()).toEqual({
     asyncUtilTimeout: 5000,
+    concurrentRoot: true,
+    debug: false,
     defaultDebugOptions: { message: 'debug message' },
     defaultIncludeHiddenElements: false,
-    concurrentRoot: true,
   });
 });
 

--- a/src/__tests__/fire-event-debug.test.tsx
+++ b/src/__tests__/fire-event-debug.test.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { Pressable, Text, View } from 'react-native';
+
+import { configure, fireEvent, render, screen } from '..';
+import { _console } from '../helpers/logger';
+
+beforeEach(() => {
+  jest.spyOn(_console, 'debug').mockImplementation(() => {});
+  jest.spyOn(_console, 'info').mockImplementation(() => {});
+  jest.spyOn(_console, 'warn').mockImplementation(() => {});
+  jest.spyOn(_console, 'error').mockImplementation(() => {});
+});
+
+test('should log warning when firing event on element without handler', () => {
+  render(
+    <View>
+      <Text>No handler</Text>
+    </View>,
+  );
+
+  fireEvent.press(screen.getByText('No handler'));
+
+  expect(_console.warn).toHaveBeenCalledTimes(1);
+  expect(jest.mocked(_console.warn).mock.calls[0][0]).toMatchInlineSnapshot(`
+    "  ▲ Fire Event: no event handler for "press" event found on <Text>No handler</Text> or any of its ancestors.
+    "
+  `);
+});
+
+test('should log warning when firing event on single disabled element', () => {
+  render(
+    <View>
+      <Pressable onPress={() => {}} disabled>
+        <Text>Disabled button</Text>
+      </Pressable>
+    </View>,
+  );
+
+  fireEvent.press(screen.getByText('Disabled button'));
+
+  expect(_console.warn).toHaveBeenCalledTimes(1);
+  expect(jest.mocked(_console.warn).mock.calls[0][0]).toMatchInlineSnapshot(`
+    "  ▲ Fire Event: no enabled event handler for "press" event found. Found disabled event handler(s) on:
+         - <Pressable disabled={true} /> (composite element)
+    "
+  `);
+});
+
+test('should log warning about multiple disabled handlers', () => {
+  render(
+    <View>
+      <Pressable testID="outer" onPress={() => {}} disabled>
+        <Pressable testID="inner" onPress={() => {}} disabled>
+          <Text>Nested disabled</Text>
+        </Pressable>
+      </Pressable>
+    </View>,
+  );
+
+  fireEvent.press(screen.getByText('Nested disabled'));
+
+  expect(_console.warn).toHaveBeenCalledTimes(1);
+  expect(jest.mocked(_console.warn).mock.calls[0][0]).toMatchInlineSnapshot(`
+    "  ▲ Fire Event: no enabled event handler for "press" event found. Found disabled event handler(s) on:
+         - <Pressable disabled={true} testID="inner" /> (composite element)
+         - <Pressable disabled={true} testID="outer" /> (composite element)
+    "
+  `);
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,11 @@ export type Config = {
    * Otherwise `render` will default to concurrent rendering.
    */
   concurrentRoot: boolean;
+
+  /**
+   * Verbose logging for the library.
+   */
+  debug: boolean;
 };
 
 export type ConfigAliasOptions = {
@@ -30,6 +35,7 @@ const defaultConfig: Config = {
   asyncUtilTimeout: 1000,
   defaultIncludeHiddenElements: false,
   concurrentRoot: true,
+  debug: false,
 };
 
 let config = { ...defaultConfig };

--- a/src/helpers/format-element.ts
+++ b/src/helpers/format-element.ts
@@ -37,7 +37,7 @@ export function formatElement(
       // This prop is needed persuade the prettyFormat that the element is
       // a ReactTestRendererJSON instance, so it is formatted as JSX.
       $$typeof: Symbol.for('react.test.json'),
-      type: `${element.type}`,
+      type: formatElementName(element.type),
       props: mapProps ? mapProps(props) : props,
       children: childrenToDisplay,
     },
@@ -50,6 +50,25 @@ export function formatElement(
       min: compact,
     },
   );
+}
+
+function formatElementName(type: ReactTestInstance['type']) {
+  if (typeof type === 'function') {
+    return type.displayName ?? type.name;
+  }
+
+  if (typeof type === 'object') {
+    if ('type' in type) {
+      // @ts-expect-error: despite typing this can happen for React.memo.
+      return formatElementName(type.type);
+    }
+    if ('render' in type) {
+      // @ts-expect-error: despite typing this can happen for React.forwardRefs.
+      return formatElementName(type.render);
+    }
+  }
+
+  return `${type}`;
 }
 
 export function formatElementList(elements: ReactTestInstance[], options?: FormatElementOptions) {

--- a/src/helpers/logger.ts
+++ b/src/helpers/logger.ts
@@ -3,6 +3,8 @@ import pc from 'picocolors';
 import redent from 'redent';
 import * as nodeUtil from 'util';
 
+import { getConfig } from '../config';
+
 export const _console = {
   debug: nodeConsole.debug,
   info: nodeConsole.info,
@@ -12,8 +14,10 @@ export const _console = {
 
 export const logger = {
   debug(message: unknown, ...args: unknown[]) {
-    const output = formatMessage('●', message, ...args);
-    _console.debug(pc.dim(output));
+    if (getConfig().debug) {
+      const output = formatMessage('●', message, ...args);
+      _console.debug(pc.dim(output));
+    }
   },
 
   info(message: unknown, ...args: unknown[]) {

--- a/src/helpers/map-props.ts
+++ b/src/helpers/map-props.ts
@@ -28,6 +28,7 @@ const propsToDisplay = [
   'aria-valuenow',
   'aria-valuetext',
   'defaultValue',
+  'disabled',
   'editable',
   'importantForAccessibility',
   'nativeID',

--- a/src/user-event/clear.ts
+++ b/src/user-event/clear.ts
@@ -1,7 +1,9 @@
 import type { ReactTestInstance } from 'react-test-renderer';
 
 import { ErrorWithStack } from '../helpers/errors';
+import { formatElement } from '../helpers/format-element';
 import { isHostTextInput } from '../helpers/host-component-names';
+import { logger } from '../helpers/logger';
 import { isPointerEventEnabled } from '../helpers/pointer-events';
 import { getTextInputValue, isEditableTextInput } from '../helpers/text-input';
 import { EventBuilder } from './event-builder';
@@ -17,7 +19,17 @@ export async function clear(this: UserEventInstance, element: ReactTestInstance)
     );
   }
 
-  if (!isEditableTextInput(element) || !isPointerEventEnabled(element)) {
+  if (!isEditableTextInput(element)) {
+    logger.warn(
+      `User Event (clear): element ${formatElement(element, { compact: true })} is not editable.`,
+    );
+    return;
+  }
+
+  if (!isPointerEventEnabled(element)) {
+    logger.warn(
+      `User Event (clear): element ${formatElement(element, { compact: true })} has pointer event handlers disabled.`,
+    );
     return;
   }
 

--- a/src/user-event/paste.ts
+++ b/src/user-event/paste.ts
@@ -8,6 +8,8 @@ import { nativeState } from '../native-state';
 import { EventBuilder } from './event-builder';
 import type { UserEventInstance } from './setup';
 import { dispatchEvent, getTextContentSize, wait } from './utils';
+import { formatElement } from '../helpers/format-element';
+import { logger } from '../helpers/logger';
 
 export async function paste(
   this: UserEventInstance,
@@ -21,7 +23,17 @@ export async function paste(
     );
   }
 
-  if (!isEditableTextInput(element) || !isPointerEventEnabled(element)) {
+  if (!isEditableTextInput(element)) {
+    logger.warn(
+      `User Event (paste): element ${formatElement(element, { compact: true })} is not editable.`,
+    );
+    return;
+  }
+
+  if (!isPointerEventEnabled(element)) {
+    logger.warn(
+      `User Event (paste): element ${formatElement(element, { compact: true })} has pointer event handlers disabled.`,
+    );
     return;
   }
 

--- a/src/user-event/type/type.ts
+++ b/src/user-event/type/type.ts
@@ -9,6 +9,8 @@ import { EventBuilder } from '../event-builder';
 import type { UserEventConfig, UserEventInstance } from '../setup';
 import { dispatchEvent, getTextContentSize, wait } from '../utils';
 import { parseKeys } from './parse-keys';
+import { logger } from '../../helpers/logger';
+import { formatElement } from '../../helpers/format-element';
 
 export interface TypeOptions {
   skipPress?: boolean;
@@ -29,11 +31,19 @@ export async function type(
     );
   }
 
-  // Skip events if the element is disabled
-  if (!isEditableTextInput(element) || !isPointerEventEnabled(element)) {
+  if (!isEditableTextInput(element)) {
+    logger.warn(
+      `User Event (type): element ${formatElement(element, { compact: true })} is not editable.`,
+    );
     return;
   }
 
+  if (!isPointerEventEnabled(element)) {
+    logger.warn(
+      `User Event (type): element ${formatElement(element, { compact: true })} has pointer event handlers disabled.`,
+    );
+    return;
+  }
   const keys = parseKeys(text);
 
   if (!options?.skipPress) {

--- a/src/user-event/utils/dispatch-event.ts
+++ b/src/user-event/utils/dispatch-event.ts
@@ -3,6 +3,8 @@ import type { ReactTestInstance } from 'react-test-renderer';
 import act from '../../act';
 import { getEventHandler } from '../../event-handler';
 import { isElementMounted } from '../../helpers/component-tree';
+import { formatElement } from '../../helpers/format-element';
+import { logger } from '../../helpers/logger';
 
 /**
  * Basic dispatch event function used by User Event module.
@@ -22,6 +24,11 @@ export async function dispatchEvent(
 
   const handler = getEventHandler(element, eventName);
   if (!handler) {
+    logger.warn(
+      `User Event: no event handler for "${eventName}" found on ${formatElement(element, {
+        compact: true,
+      })}`,
+    );
     return;
   }
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Resolves #1717 
Resolves #1718 

Introduces (event) debugging mode that outputs information about event handles not being called due to disabled state, etc.

### Details

Enabling: `configure({ debug: true })`. Cannot be configured on `render` as `fireEvent` and `userEvent` are independent modules, not returns from `render`.

Fire Event:
- logs warnings when event handler was found but disabled:
- logs warning when no event handler was invoked for given `fireEvent` call.

User Event:
- logs debug for events that have missing event handlers.

### To Do

- User Event: log warning if no event at all has been called for given `userEvent` call.
- Fire Event & User Event: consider logging debug for matches/called event handlers.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
