### PR TITLE
fix: update ESLint plugin documentation link in warning message

### DIFF
--- a/src/queries/__tests__/find-by.test.tsx
+++ b/src/queries/__tests__/find-by.test.tsx
@@ -18,6 +18,6 @@ test('findByTestId detects screen being detached', async () => {
     Screen is no longer attached. Check your test for "findBy*" or "waitFor" calls that have not been awaited.
 
     We recommend enabling "eslint-plugin-testing-library" to catch these issues at build time:
-    https://callstack.github.io/react-native-testing-library/docs/getting-started#eslint-plugin"
+    https://callstack.github.io/react-native-testing-library/docs/start/quick-start#eslint-plugin"
   `);
 });

--- a/src/queries/make-queries.ts
+++ b/src/queries/make-queries.ts
@@ -88,7 +88,7 @@ function formatErrorMessage(message: string, printElementTree: boolean) {
   }
 
   if (screen.isDetached) {
-    return `${message}\n\nScreen is no longer attached. Check your test for "findBy*" or "waitFor" calls that have not been awaited.\n\nWe recommend enabling "eslint-plugin-testing-library" to catch these issues at build time:\nhttps://callstack.github.io/react-native-testing-library/docs/getting-started#eslint-plugin`;
+    return `${message}\n\nScreen is no longer attached. Check your test for "findBy*" or "waitFor" calls that have not been awaited.\n\nWe recommend enabling "eslint-plugin-testing-library" to catch these issues at build time:\nhttps://callstack.github.io/react-native-testing-library/docs/start/quick-start#eslint-plugin`;
   }
 
   const json = screen.toJSON();


### PR DESCRIPTION
### What I did

- Updated the outdated ESLint plugin link in the `screen.isDetached` warning message.

### Why

- To ensure developers are directed to the correct documentation for `eslint-plugin-testing-library`.

### Checklist

- [x] Updated only a string message (no logic changes)
- [x] Confirmed that the new link is valid and working
- [x] All tests still pass
