### PR TITLE
fix: toBeDisabled now also evaluates disabled prop when element is Text

### DIFF
--- a/src/helpers/__tests__/accessiblity.test.tsx
+++ b/src/helpers/__tests__/accessiblity.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Pressable, Switch, Text, TextInput, TouchableOpacity, View } from 'react-native';
 
 import { isHiddenFromAccessibility, isInaccessible, render, screen } from '../..';
-import { computeAriaLabel, isAccessibilityElement } from '../accessibility';
+import { computeAriaDisabled, computeAriaLabel, isAccessibilityElement } from '../accessibility';
 
 describe('isHiddenFromAccessibility', () => {
   test('returns false for accessible elements', () => {
@@ -278,11 +278,11 @@ describe('isHiddenFromAccessibility', () => {
   test('has isInaccessible alias', () => {
     expect(isInaccessible).toBe(isHiddenFromAccessibility);
   });
-});
 
-test('is not triggered for element with "aria-modal" prop', () => {
-  render(<View aria-modal testID="subject" />);
-  expect(isHiddenFromAccessibility(screen.getByTestId('subject'))).toBe(false);
+  test('is not triggered for element with "aria-modal" prop', () => {
+    render(<View aria-modal testID="subject" />);
+    expect(isHiddenFromAccessibility(screen.getByTestId('subject'))).toBe(false);
+  });
 });
 
 describe('isAccessibilityElement', () => {
@@ -406,5 +406,69 @@ describe('computeAriaLabel', () => {
     );
 
     expect(computeAriaLabel(screen.getByTestId('subject'))).toEqual('External Label');
+  });
+});
+
+describe('computeAriaDisabled', () => {
+  test('supports basic usage', () => {
+    render(
+      <View>
+        <View testID="disabled" aria-disabled />
+        <View testID="not-disabled" />
+        <View testID="disabled-by-state" accessibilityState={{ disabled: true }} />
+        <View testID="not-disabled-by-state" accessibilityState={{ disabled: false }} />
+      </View>,
+    );
+
+    expect(computeAriaDisabled(screen.getByTestId('disabled'))).toBe(true);
+    expect(computeAriaDisabled(screen.getByTestId('not-disabled'))).toBe(false);
+    expect(computeAriaDisabled(screen.getByTestId('disabled-by-state'))).toBe(true);
+    expect(computeAriaDisabled(screen.getByTestId('not-disabled-by-state'))).toBe(false);
+  });
+
+  test('supports TextInput', () => {
+    render(
+      <View>
+        <TextInput testID="disabled" editable={false} />
+        <TextInput testID="not-disabled" editable />
+      </View>,
+    );
+
+    expect(computeAriaDisabled(screen.getByTestId('disabled'))).toBe(true);
+    expect(computeAriaDisabled(screen.getByTestId('not-disabled'))).toBe(false);
+  });
+
+  test('supports Button', () => {
+    render(
+      <View>
+        <Pressable testID="disabled" disabled>
+          <Text>Disabled Button</Text>
+        </Pressable>
+        <Pressable testID="not-disabled">
+          <Text>Enabled Button</Text>
+        </Pressable>
+      </View>,
+    );
+
+    expect(computeAriaDisabled(screen.getByTestId('disabled'))).toBe(true);
+    expect(computeAriaDisabled(screen.getByTestId('not-disabled'))).toBe(false);
+  });
+
+  test('supports Text', () => {
+    render(
+      <View>
+        <Text testID="disabled" disabled>
+          Disabled Text
+        </Text>
+        <Text testID="aria-disabled" aria-disabled>
+          Disabled Text
+        </Text>
+        <Text testID="not-disabled">Enabled Text</Text>
+      </View>,
+    );
+
+    expect(computeAriaDisabled(screen.getByTestId('disabled'))).toBe(true);
+    expect(computeAriaDisabled(screen.getByTestId('aria-disabled'))).toBe(true);
+    expect(computeAriaDisabled(screen.getByTestId('not-disabled'))).toBe(false);
   });
 });

--- a/src/helpers/__tests__/accessiblity.test.tsx
+++ b/src/helpers/__tests__/accessiblity.test.tsx
@@ -433,7 +433,7 @@ describe('computeAriaDisabled', () => {
       <View>
         <TextInput testID="default" />
         <TextInput testID="editable" editable />
-        <TextInput testID="editable-false" editable={false} />   
+        <TextInput testID="editable-false" editable={false} />
       </View>,
     );
 
@@ -448,7 +448,7 @@ describe('computeAriaDisabled', () => {
         <Pressable testID="default" role="button">
           <Text>Default Button</Text>
         </Pressable>
-        <Pressable testID="disabled" role="button" disabled >
+        <Pressable testID="disabled" role="button" disabled>
           <Text>Disabled Button</Text>
         </Pressable>
         <Pressable testID="disabled-false" role="button" disabled={false}>
@@ -466,12 +466,8 @@ describe('computeAriaDisabled', () => {
     render(
       <View>
         <Text>Default Text</Text>
-        <Text disabled>
-          Disabled Text
-        </Text>
-        <Text aria-disabled>
-          ARIA Disabled Text
-        </Text>
+        <Text disabled>Disabled Text</Text>
+        <Text aria-disabled>ARIA Disabled Text</Text>
       </View>,
     );
 

--- a/src/helpers/__tests__/accessiblity.test.tsx
+++ b/src/helpers/__tests__/accessiblity.test.tsx
@@ -413,62 +413,70 @@ describe('computeAriaDisabled', () => {
   test('supports basic usage', () => {
     render(
       <View>
+        <View testID="default" />
         <View testID="disabled" aria-disabled />
-        <View testID="not-disabled" />
+        <View testID="disabled-false" aria-disabled={false} />
         <View testID="disabled-by-state" accessibilityState={{ disabled: true }} />
-        <View testID="not-disabled-by-state" accessibilityState={{ disabled: false }} />
+        <View testID="disabled-false-by-state" accessibilityState={{ disabled: false }} />
       </View>,
     );
 
+    expect(computeAriaDisabled(screen.getByTestId('default'))).toBe(false);
     expect(computeAriaDisabled(screen.getByTestId('disabled'))).toBe(true);
-    expect(computeAriaDisabled(screen.getByTestId('not-disabled'))).toBe(false);
+    expect(computeAriaDisabled(screen.getByTestId('disabled-false'))).toBe(false);
     expect(computeAriaDisabled(screen.getByTestId('disabled-by-state'))).toBe(true);
-    expect(computeAriaDisabled(screen.getByTestId('not-disabled-by-state'))).toBe(false);
+    expect(computeAriaDisabled(screen.getByTestId('disabled-false-by-state'))).toBe(false);
   });
 
   test('supports TextInput', () => {
     render(
       <View>
-        <TextInput testID="disabled" editable={false} />
-        <TextInput testID="not-disabled" editable />
+        <TextInput testID="default" />
+        <TextInput testID="editable" editable />
+        <TextInput testID="editable-false" editable={false} />   
       </View>,
     );
 
-    expect(computeAriaDisabled(screen.getByTestId('disabled'))).toBe(true);
-    expect(computeAriaDisabled(screen.getByTestId('not-disabled'))).toBe(false);
+    expect(computeAriaDisabled(screen.getByTestId('default'))).toBe(false);
+    expect(computeAriaDisabled(screen.getByTestId('editable'))).toBe(false);
+    expect(computeAriaDisabled(screen.getByTestId('editable-false'))).toBe(true);
   });
 
   test('supports Button', () => {
     render(
       <View>
-        <Pressable testID="disabled" disabled>
+        <Pressable testID="default" role="button">
+          <Text>Default Button</Text>
+        </Pressable>
+        <Pressable testID="disabled" role="button" disabled >
           <Text>Disabled Button</Text>
         </Pressable>
-        <Pressable testID="not-disabled">
-          <Text>Enabled Button</Text>
+        <Pressable testID="disabled-false" role="button" disabled={false}>
+          <Text>Disabled False Button</Text>
         </Pressable>
       </View>,
     );
 
+    expect(computeAriaDisabled(screen.getByTestId('default'))).toBe(false);
     expect(computeAriaDisabled(screen.getByTestId('disabled'))).toBe(true);
-    expect(computeAriaDisabled(screen.getByTestId('not-disabled'))).toBe(false);
+    expect(computeAriaDisabled(screen.getByTestId('disabled-false'))).toBe(false);
   });
 
   test('supports Text', () => {
     render(
       <View>
-        <Text testID="disabled" disabled>
+        <Text>Default Text</Text>
+        <Text disabled>
           Disabled Text
         </Text>
-        <Text testID="aria-disabled" aria-disabled>
-          Disabled Text
+        <Text aria-disabled>
+          ARIA Disabled Text
         </Text>
-        <Text testID="not-disabled">Enabled Text</Text>
       </View>,
     );
 
-    expect(computeAriaDisabled(screen.getByTestId('disabled'))).toBe(true);
-    expect(computeAriaDisabled(screen.getByTestId('aria-disabled'))).toBe(true);
-    expect(computeAriaDisabled(screen.getByTestId('not-disabled'))).toBe(false);
+    expect(computeAriaDisabled(screen.getByText('Default Text'))).toBe(false);
+    expect(computeAriaDisabled(screen.getByText('Disabled Text'))).toBe(true);
+    expect(computeAriaDisabled(screen.getByText('ARIA Disabled Text'))).toBe(true);
   });
 });

--- a/src/helpers/accessibility.ts
+++ b/src/helpers/accessibility.ts
@@ -209,6 +209,11 @@ export function computeAriaDisabled(element: ReactTestInstance): boolean {
   }
 
   const { props } = element;
+
+  if (isHostText(element) && props.disabled) {
+    return true;
+  }
+  
   return props['aria-disabled'] ?? props.accessibilityState?.disabled ?? false;
 }
 

--- a/src/helpers/accessibility.ts
+++ b/src/helpers/accessibility.ts
@@ -213,7 +213,7 @@ export function computeAriaDisabled(element: ReactTestInstance): boolean {
   if (isHostText(element) && props.disabled) {
     return true;
   }
-  
+
   return props['aria-disabled'] ?? props.accessibilityState?.disabled ?? false;
 }
 


### PR DESCRIPTION
### Summary

Resolves #1801 by ensuring `Text` components with the `disabled` prop are correctly identified as disabled by `computeAriaDisabled`.

Previously, `computeAriaDisabled` didn't check for the `disabled` prop on `Text` elements, causing queries like `getByRole('text', { disabled: true })` to fail. The change adds a check to return `true` when `isHostText(element)` and `props.disabled` are both true, aligning `react-native-testing-library`'s behavior with expected accessibility states.

### Test plan

New unit tests have been added for `computeAriaDisabled` to verify this change. These tests cover:

1.  **`Text` component with `disabled={true}`:** Asserts `computeAriaDisabled` returns `true`.

2.  **`Text` component without `disabled` prop or `disabled={false}`:** Asserts `computeAriaDisabled` returns `false`.

3.  **Existing `TextInput` behavior:** Ensures non-editable `TextInput` components are still correctly identified as disabled.

4.  **`aria-disabled` and `accessibilityState.disabled` props:** Verifies these existing checks continue to function.

The new `computeAriaDisabled` tests should pass, demonstrating correct handling of the `disabled` prop on `Text` components.