### PR TITLE
fix: Do not infer generic Props type from RenderHookOptions

### DIFF
--- a/src/render-hook.tsx
+++ b/src/render-hook.tsx
@@ -38,7 +38,7 @@ export type RenderHookOptions<Props> = {
 
 export function renderHook<Result, Props>(
   hookToRender: (props: Props) => Result,
-  options?: RenderHookOptions<Props>,
+  options?: RenderHookOptions<NoInfer<Props>>,
 ): RenderHookResult<Result, Props> {
   const result = React.createRef<Result>() as RefObject<Result>;
 
@@ -67,7 +67,7 @@ export function renderHook<Result, Props>(
 
 export async function renderHookAsync<Result, Props>(
   hookToRender: (props: Props) => Result,
-  options?: RenderHookOptions<Props>,
+  options?: RenderHookOptions<NoInfer<Props>>,
 ): Promise<RenderHookAsyncResult<Result, Props>> {
   const result = React.createRef<Result>() as RefObject<Result>;
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Unsure when this happened, but noticed it when bumping a react-native project to 0.80.1. (Using typescript 5.5.4)

`renderHook` and `renderHookAsync` should not infer `Props` from `RenderHookOptions`.
See the following example:
```ts
type ExampleProps = {
  required: string;
  optional?: number;
};

const exampleHook = (_: ExampleProps) => {};

const { rerender } = renderHook(exampleHook, {
  initialProps: {
    required: '',
    unknown: 1,
  },
});

rerender({
  required: '',
  unknown: 1, // This should be invalid
  optional: 1, // <--- type error here despite optional being a valid prop
});
```

This is resulting in optional props not specified in the initialProps setting to type-error when using `rerender()`.

This is because the `Props` generic type is being inferred from both `ExampleProps` and  `{ required: string, unknown: number }` due to it appearing also in initialProps.

This is addressed by wrapping it with `NoInfer<>` so that the options are ignored for inferring `Props`

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
After the fix is applied, the type-errors are correctly pointing out that `unknown` is not a prop.
```ts
type ExampleProps = {
  required: string;
  optional?: number;
};

const exampleHook = (_: ExampleProps) => {};

const { rerender } = renderHook(exampleHook, {
  initialProps: {
    required: '',
    unknown: 1, // <--- type error here
  },
});

rerender({
  required: '',
  unknown: 1, // <--- type error here
  optional: 1, 
});
```