### PR TITLE
chore: fix nightly RN check - npmMinimalAgeGate exclusions

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -8,5 +8,6 @@ npmPreapprovedPackages:
   - react-test-renderer
   - '@react-native/*'
   - '@types/react'
+  - '@types/react-test-renderer'
 
 yarnPath: .yarn/releases/yarn-4.11.0.cjs


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Whitelist React/React Native packages in `.yarnrc.yml` via `npmPreapprovedPackages` to exempt them from the `npmMinimalAgeGate`.
> 
> - **Tooling (Yarn)**:
>   - Update `.yarnrc.yml` to add `npmPreapprovedPackages` (React/React Native packages and types) so they bypass `npmMinimalAgeGate` (`'3d'`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 236e109765410191931f8ad37f1f0ce74575dcf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->