### PR TITLE
fix: support accessibilityLabelledBy arrays

### DIFF
--- a/src/helpers/accessibility.ts
+++ b/src/helpers/accessibility.ts
@@ -153,10 +153,11 @@ export function computeAriaLabel(instance: TestInstance): string | undefined {
   const labelElementId =
     instance.props['aria-labelledby'] ?? instance.props.accessibilityLabelledBy;
   if (labelElementId) {
+    const labelElementIds = Array.isArray(labelElementId) ? labelElementId : [labelElementId];
     const container = getContainerInstance(instance);
     const labelInstance = findAll(
       container,
-      (node) => isTestInstance(node) && node.props.nativeID === labelElementId,
+      (node) => isTestInstance(node) && labelElementIds.includes(node.props.nativeID),
       { includeHiddenElements: true },
     );
     if (labelInstance.length > 0) {

--- a/src/queries/__tests__/role.test.tsx
+++ b/src/queries/__tests__/role.test.tsx
@@ -195,6 +195,40 @@ describe('supports name option', () => {
     expect(screen.getByRole('button', { name: 'Save' }).props.testID).toBe('target-button');
   });
 
+  test('returns an element that has the corresponding role and a matching accessibilityLabelledBy', async () => {
+    await render(
+      <>
+        <Text nativeID="button-label">Save</Text>
+        <Pressable
+          accessible
+          role="button"
+          testID="target-button"
+          accessibilityLabelledBy="button-label"
+        />
+      </>,
+    );
+
+    // assert on the testId to be sure that the returned element is the one with the accessibilityRole
+    expect(screen.getByRole('button', { name: 'Save' }).props.testID).toBe('target-button');
+  });
+
+  test('returns an element that has the corresponding role and a matching accessibilityLabelledBy array', async () => {
+    await render(
+      <>
+        <Text nativeID="button-label">Save</Text>
+        <Pressable
+          accessible
+          role="button"
+          testID="target-button"
+          accessibilityLabelledBy={['button-label']}
+        />
+      </>,
+    );
+
+    // assert on the testId to be sure that the returned element is the one with the accessibilityRole
+    expect(screen.getByRole('button', { name: 'Save' }).props.testID).toBe('target-button');
+  });
+
   test('returns an element when the direct child is text', async () => {
     await render(
       <Text accessibilityRole="header" testID="target-header">


### PR DESCRIPTION
### Summary

Fixes accessible name matching when `accessibilityLabelledBy` is an array.

React Native types allow `accessibilityLabelledBy` to be `string | string[]`, but
the previous lookup compared `nativeID` directly with the prop value. That made
`getByRole('button', { name })` miss elements labelled by an array value.

This PR keeps the existing string behavior and normalizes the label id prop to
an array before matching label elements.

Fixes #1839

### Test plan

- `yarn test src/queries/__tests__/role.test.tsx -t accessibilityLabelledBy`
- `yarn test src/queries/__tests__/role.test.tsx`
- `yarn typecheck`
- `yarn lint`
- `yarn test`
- `yarn prettier`
- `git diff --check`
