### PR TITLE
fix cleanup of waitFor timers when an error occurs during onTimeout printout

### DIFF
--- a/src/__tests__/wait-for.test.tsx
+++ b/src/__tests__/wait-for.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Pressable, Text, TouchableOpacity, View } from 'react-native';
 
 import { configure, fireEvent, render, screen, waitFor } from '..';
+import { getCleanupQueueSize } from '../cleanup';
 import { cleanup } from '../pure';
 import type { TimerType } from '../test-utils/timers';
 import { setupTimeType } from '../test-utils/timers';
@@ -70,6 +71,12 @@ describe('successful waiting', () => {
     await waitFor(() => {
       expect(onDelayedPress).toHaveBeenCalled();
     });
+  });
+
+  test('does not retain cleanup callback after waitFor settles', async () => {
+    await waitFor(() => true);
+
+    expect(getCleanupQueueSize()).toBe(0);
   });
 
   test.each(['real', 'fake', 'fake-legacy'] as const)(

--- a/src/__tests__/wait-for.test.tsx
+++ b/src/__tests__/wait-for.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Pressable, Text, TouchableOpacity, View } from 'react-native';
 
 import { configure, fireEvent, render, screen, waitFor } from '..';
+import { cleanup } from '../pure';
 import type { TimerType } from '../test-utils/timers';
 import { setupTimeType } from '../test-utils/timers';
 
@@ -175,6 +176,24 @@ describe('timeout errors', () => {
       }),
     ).rejects.toThrow('Unable to find an element with text: Never appears');
   });
+
+  test('rejects with error thrown by onTimeout callback', async () => {
+    const onTimeoutError = new Error('onTimeout failed');
+
+    await expect(
+      waitFor(
+        () => {
+          throw new Error('Original timeout error');
+        },
+        {
+          timeout: 10,
+          onTimeout: () => {
+            throw onTimeoutError;
+          },
+        },
+      ),
+    ).rejects.toBe(onTimeoutError);
+  });
 });
 
 describe('error handling', () => {
@@ -234,6 +253,31 @@ describe('error handling', () => {
     await expect(waitForPromise).rejects.toThrow(
       'Changed from using fake timers to real timers while using waitFor',
     );
+  });
+
+  test('cleanup stops real timer polling for pending waitFor calls', async () => {
+    const expectation = jest.fn(() => {
+      throw new Error('Not ready yet');
+    });
+
+    async function ignoreWaitForRejection() {
+      try {
+        await waitFor(expectation, { timeout: 300, interval: 20 });
+      } catch {
+        // This waitFor call is intentionally abandoned in the test.
+      }
+    }
+
+    void ignoreWaitForRejection();
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(expectation).toHaveBeenCalled();
+
+    await cleanup();
+    const callsAfterCleanup = expectation.mock.calls.length;
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(expectation).toHaveBeenCalledTimes(callsAfterCleanup);
   });
 });
 

--- a/src/__tests__/wait-for.test.tsx
+++ b/src/__tests__/wait-for.test.tsx
@@ -220,8 +220,7 @@ describe('timeout errors', () => {
         },
       ),
     ).rejects.toMatchObject({
-      message:
-        '`onTimeout` threw while handling `waitFor` timeout: onTimeout failed with string',
+      message: '`onTimeout` threw while handling `waitFor` timeout: onTimeout failed with string',
       cause: expect.objectContaining({
         message: 'Original timeout error',
       }),

--- a/src/__tests__/wait-for.test.tsx
+++ b/src/__tests__/wait-for.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Pressable, Text, TouchableOpacity, View } from 'react-native';
 
 import { configure, fireEvent, render, screen, waitFor } from '..';
-import { getCleanupQueueSize } from '../cleanup';
+import { addToCleanupQueue, getCleanupQueueSize } from '../cleanup';
 import { cleanup } from '../pure';
 import type { TimerType } from '../test-utils/timers';
 import { setupTimeType } from '../test-utils/timers';
@@ -294,6 +294,26 @@ describe('error handling', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 60));
     expect(expectation).toHaveBeenCalledTimes(callsAfterCleanup);
+  });
+
+  test('cleanup abort removes pending waitFor callback before cleanup queue is cleared', async () => {
+    const expectation = jest.fn(() => {
+      throw new Error('Not ready yet');
+    });
+
+    const waitForPromise = waitFor(expectation, { timeout: 300, interval: 20 });
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    const queueSizes: number[] = [];
+    addToCleanupQueue(() => {
+      queueSizes.push(getCleanupQueueSize());
+    });
+
+    await cleanup();
+    await expect(waitForPromise).rejects.toThrow('waitFor was aborted by cleanup');
+
+    expect(queueSizes).toEqual([1]);
   });
 
   test('async expectation resolving after cleanup abort has no effect', async () => {

--- a/src/__tests__/wait-for.test.tsx
+++ b/src/__tests__/wait-for.test.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Pressable, Text, TouchableOpacity, View } from 'react-native';
 
 import { configure, fireEvent, render, screen, waitFor } from '..';
-import { addToCleanupQueue, getCleanupQueueSize } from '../cleanup';
 import { cleanup } from '../pure';
 import type { TimerType } from '../test-utils/timers';
 import { setupTimeType } from '../test-utils/timers';
@@ -71,12 +70,6 @@ describe('successful waiting', () => {
     await waitFor(() => {
       expect(onDelayedPress).toHaveBeenCalled();
     });
-  });
-
-  test('does not retain cleanup callback after waitFor settles', async () => {
-    await waitFor(() => true);
-
-    expect(getCleanupQueueSize()).toBe(0);
   });
 
   test.each(['real', 'fake', 'fake-legacy'] as const)(
@@ -294,26 +287,6 @@ describe('error handling', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 60));
     expect(expectation).toHaveBeenCalledTimes(callsAfterCleanup);
-  });
-
-  test('cleanup abort removes pending waitFor callback before cleanup queue is cleared', async () => {
-    const expectation = jest.fn(() => {
-      throw new Error('Not ready yet');
-    });
-
-    const waitForPromise = waitFor(expectation, { timeout: 300, interval: 20 });
-
-    await new Promise((resolve) => setTimeout(resolve, 30));
-
-    const queueSizes: number[] = [];
-    addToCleanupQueue(() => {
-      queueSizes.push(getCleanupQueueSize());
-    });
-
-    await cleanup();
-    await expect(waitForPromise).rejects.toThrow('waitFor was aborted by cleanup');
-
-    expect(queueSizes).toEqual([1]);
   });
 
   test('async expectation resolving after cleanup abort has no effect', async () => {

--- a/src/__tests__/wait-for.test.tsx
+++ b/src/__tests__/wait-for.test.tsx
@@ -258,25 +258,19 @@ describe('error handling', () => {
     );
   });
 
-  test('cleanup stops real timer polling for pending waitFor calls', async () => {
+  test('cleanup rejects pending waitFor calls and stops real timer polling', async () => {
     const expectation = jest.fn(() => {
       throw new Error('Not ready yet');
     });
 
-    async function ignoreWaitForRejection() {
-      try {
-        await waitFor(expectation, { timeout: 300, interval: 20 });
-      } catch {
-        // This waitFor call is intentionally abandoned in the test.
-      }
-    }
-
-    void ignoreWaitForRejection();
+    const waitForPromise = waitFor(expectation, { timeout: 300, interval: 20 });
 
     await new Promise((resolve) => setTimeout(resolve, 60));
     expect(expectation).toHaveBeenCalled();
 
     await cleanup();
+    await expect(waitForPromise).rejects.toThrow('waitFor was aborted by cleanup');
+
     const callsAfterCleanup = expectation.mock.calls.length;
 
     await new Promise((resolve) => setTimeout(resolve, 60));

--- a/src/__tests__/wait-for.test.tsx
+++ b/src/__tests__/wait-for.test.tsx
@@ -177,9 +177,7 @@ describe('timeout errors', () => {
     ).rejects.toThrow('Unable to find an element with text: Never appears');
   });
 
-  test('rejects with error thrown by onTimeout callback', async () => {
-    const onTimeoutError = new Error('onTimeout failed');
-
+  test('chains original timeout error when onTimeout callback throws', async () => {
     await expect(
       waitFor(
         () => {
@@ -188,11 +186,16 @@ describe('timeout errors', () => {
         {
           timeout: 10,
           onTimeout: () => {
-            throw onTimeoutError;
+            throw new Error('onTimeout failed');
           },
         },
       ),
-    ).rejects.toBe(onTimeoutError);
+    ).rejects.toMatchObject({
+      message: '`onTimeout` threw while handling `waitFor` timeout: onTimeout failed',
+      cause: expect.objectContaining({
+        message: 'Original timeout error',
+      }),
+    });
   });
 });
 

--- a/src/__tests__/wait-for.test.tsx
+++ b/src/__tests__/wait-for.test.tsx
@@ -204,6 +204,29 @@ describe('timeout errors', () => {
       }),
     });
   });
+
+  test('chains original timeout error when onTimeout throws a non-Error value', async () => {
+    await expect(
+      waitFor(
+        () => {
+          throw new Error('Original timeout error');
+        },
+        {
+          timeout: 10,
+          onTimeout: () => {
+            // eslint-disable-next-line @typescript-eslint/only-throw-error
+            throw 'onTimeout failed with string';
+          },
+        },
+      ),
+    ).rejects.toMatchObject({
+      message:
+        '`onTimeout` threw while handling `waitFor` timeout: onTimeout failed with string',
+      cause: expect.objectContaining({
+        message: 'Original timeout error',
+      }),
+    });
+  });
 });
 
 describe('error handling', () => {
@@ -282,6 +305,27 @@ describe('error handling', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 60));
     expect(expectation).toHaveBeenCalledTimes(callsAfterCleanup);
+  });
+
+  test('async expectation resolving after cleanup abort has no effect', async () => {
+    let resolveExpectation!: (value: string) => void;
+    const expectationPromise = new Promise<string>((resolve) => {
+      resolveExpectation = resolve;
+    });
+
+    const waitForPromise = waitFor(() => expectationPromise, { timeout: 300, interval: 20 });
+
+    // Wait for at least one interval tick so the expectation is called and its promise is pending
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    // Start cleanup while the expectation promise is still pending
+    const cleanupPromise = cleanup();
+
+    // Resolve the expectation promise while cleanup is in progress
+    resolveExpectation('success');
+
+    await cleanupPromise;
+    await expect(waitForPromise).rejects.toThrow('waitFor was aborted by cleanup');
   });
 });
 

--- a/src/__tests__/wait-for.test.tsx
+++ b/src/__tests__/wait-for.test.tsx
@@ -184,7 +184,7 @@ describe('timeout errors', () => {
     ).rejects.toThrow('Unable to find an element with text: Never appears');
   });
 
-  test('chains original timeout error when onTimeout callback throws', async () => {
+  test('rejects with onTimeout error when onTimeout callback throws', async () => {
     await expect(
       waitFor(
         () => {
@@ -197,15 +197,10 @@ describe('timeout errors', () => {
           },
         },
       ),
-    ).rejects.toMatchObject({
-      message: '`onTimeout` threw while handling `waitFor` timeout: onTimeout failed',
-      cause: expect.objectContaining({
-        message: 'Original timeout error',
-      }),
-    });
+    ).rejects.toThrow('onTimeout failed');
   });
 
-  test('chains original timeout error when onTimeout throws a non-Error value', async () => {
+  test('rejects with onTimeout value when onTimeout throws a non-Error value', async () => {
     await expect(
       waitFor(
         () => {
@@ -219,12 +214,7 @@ describe('timeout errors', () => {
           },
         },
       ),
-    ).rejects.toMatchObject({
-      message: '`onTimeout` threw while handling `waitFor` timeout: onTimeout failed with string',
-      cause: expect.objectContaining({
-        message: 'Original timeout error',
-      }),
-    });
+    ).rejects.toBe('onTimeout failed with string');
   });
 });
 

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -17,3 +17,11 @@ export async function cleanup() {
 export function addToCleanupQueue(fn: CleanUpFunction) {
   cleanupQueue.add(fn);
 }
+
+export function removeFromCleanupQueue(fn: CleanUpFunction) {
+  cleanupQueue.delete(fn);
+}
+
+export function getCleanupQueueSize() {
+  return cleanupQueue.size;
+}

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -21,7 +21,3 @@ export function addToCleanupQueue(fn: CleanUpFunction) {
 export function removeFromCleanupQueue(fn: CleanUpFunction) {
   cleanupQueue.delete(fn);
 }
-
-export function getCleanupQueueSize() {
-  return cleanupQueue.size;
-}

--- a/src/wait-for.ts
+++ b/src/wait-for.ts
@@ -102,6 +102,7 @@ function waitForInternal<T>(
     }
 
     function cleanupWaitFor({ rejectOnAbort = false } = {}) {
+      /* istanbul ignore next */
       if (finished) {
         return;
       }

--- a/src/wait-for.ts
+++ b/src/wait-for.ts
@@ -109,6 +109,8 @@ function waitForInternal<T>(
 
       finished = true;
 
+      removeFromCleanupQueue(cleanupQueueCallback);
+
       if (rejectOnAbort) {
         reject(new Error('waitFor was aborted by cleanup'));
       }
@@ -130,7 +132,6 @@ function waitForInternal<T>(
       }
 
       finalizeWaitFor();
-      removeFromCleanupQueue(cleanupQueueCallback);
 
       if (done.type === 'error') {
         reject(done.error);

--- a/src/wait-for.ts
+++ b/src/wait-for.ts
@@ -210,10 +210,7 @@ function waitForInternal<T>(
             errorForRejection = result;
           }
         } catch (onTimeoutError) {
-          errorForRejection = new Error(
-            `\`onTimeout\` threw while handling \`waitFor\` timeout: ${onTimeoutError instanceof Error ? onTimeoutError.message : String(onTimeoutError)}`,
-            { cause: error },
-          );
+          errorForRejection = onTimeoutError;
         }
       }
       onDone({ type: 'error', error: errorForRejection });

--- a/src/wait-for.ts
+++ b/src/wait-for.ts
@@ -1,6 +1,6 @@
 /* globals jest */
 import { act } from './act';
-import { addToCleanupQueue } from './cleanup';
+import { addToCleanupQueue, removeFromCleanupQueue } from './cleanup';
 import { getConfig } from './config';
 import { flushMicroTasks } from './flush-micro-tasks';
 import { copyStackTraceIfNeeded, ErrorWithStack } from './helpers/errors';
@@ -41,6 +41,7 @@ function waitForInternal<T>(
     let promiseStatus = 'idle';
 
     let overallTimeoutTimer: NodeJS.Timeout | null = null;
+    const cleanupQueueCallback = () => cleanupWaitFor({ rejectOnAbort: true });
 
     const fakeTimersType = getJestFakeTimersType();
 
@@ -95,7 +96,7 @@ function waitForInternal<T>(
     } else {
       overallTimeoutTimer = setTimeout(handleTimeout, timeout);
       intervalId = setInterval(checkRealTimersCallback, interval);
-      addToCleanupQueue(() => cleanupWaitFor({ rejectOnAbort: true }));
+      addToCleanupQueue(cleanupQueueCallback);
       checkExpectation();
     }
 
@@ -122,6 +123,7 @@ function waitForInternal<T>(
       }
 
       cleanupWaitFor();
+      removeFromCleanupQueue(cleanupQueueCallback);
 
       if (done.type === 'error') {
         reject(done.error);

--- a/src/wait-for.ts
+++ b/src/wait-for.ts
@@ -209,14 +209,9 @@ function waitForInternal<T>(
             errorForRejection = result;
           }
         } catch (onTimeoutError) {
-          const onTimeoutMessage =
-            onTimeoutError instanceof Error ? onTimeoutError.message : String(onTimeoutError);
-
           errorForRejection = new Error(
-            `\`onTimeout\` threw while handling \`waitFor\` timeout: ${onTimeoutMessage}`,
-            {
-              cause: error,
-            },
+            `\`onTimeout\` threw while handling \`waitFor\` timeout: ${onTimeoutError instanceof Error ? onTimeoutError.message : String(onTimeoutError)}`,
+            { cause: error },
           );
         }
       }

--- a/src/wait-for.ts
+++ b/src/wait-for.ts
@@ -1,5 +1,6 @@
 /* globals jest */
 import { act } from './act';
+import { addToCleanupQueue } from './cleanup';
 import { getConfig } from './config';
 import { flushMicroTasks } from './flush-micro-tasks';
 import { copyStackTraceIfNeeded, ErrorWithStack } from './helpers/errors';
@@ -94,18 +95,29 @@ function waitForInternal<T>(
     } else {
       overallTimeoutTimer = setTimeout(handleTimeout, timeout);
       intervalId = setInterval(checkRealTimersCallback, interval);
+      addToCleanupQueue(cleanupWaitFor);
       checkExpectation();
     }
 
-    function onDone(done: { type: 'result'; result: T } | { type: 'error'; error: unknown }) {
+    function cleanupWaitFor() {
       finished = true;
+
       if (overallTimeoutTimer) {
         clearTimeout(overallTimeoutTimer);
+        overallTimeoutTimer = null;
       }
 
       if (!fakeTimersType) {
         clearInterval(intervalId);
       }
+    }
+
+    function onDone(done: { type: 'result'; result: T } | { type: 'error'; error: unknown }) {
+      if (finished) {
+        return;
+      }
+
+      cleanupWaitFor();
 
       if (done.type === 'error') {
         reject(done.error);
@@ -120,7 +132,7 @@ function waitForInternal<T>(
           `Changed from using real timers to fake timers while using waitFor. This is not allowed and will result in very strange behavior. Please ensure you're awaiting all async things your test is doing before changing to fake timers. For more info, please go to https://github.com/testing-library/dom-testing-library/issues/830`,
         );
         copyStackTraceIfNeeded(error, stackTraceError);
-        return reject(error);
+        return onDone({ type: 'error', error });
       } else {
         return checkExpectation();
       }
@@ -176,13 +188,19 @@ function waitForInternal<T>(
         error = new Error('Timed out in waitFor.');
         copyStackTraceIfNeeded(error, stackTraceError);
       }
+
+      let errorForRejection: unknown = error;
       if (typeof onTimeout === 'function') {
-        const result = onTimeout(error);
-        if (result) {
-          error = result;
+        try {
+          const result = onTimeout(error);
+          if (result) {
+            errorForRejection = result;
+          }
+        } catch (onTimeoutError) {
+          errorForRejection = onTimeoutError;
         }
       }
-      onDone({ type: 'error', error });
+      onDone({ type: 'error', error: errorForRejection });
     }
   });
 }

--- a/src/wait-for.ts
+++ b/src/wait-for.ts
@@ -197,7 +197,15 @@ function waitForInternal<T>(
             errorForRejection = result;
           }
         } catch (onTimeoutError) {
-          errorForRejection = onTimeoutError;
+          const onTimeoutMessage =
+            onTimeoutError instanceof Error ? onTimeoutError.message : String(onTimeoutError);
+
+          errorForRejection = new Error(
+            `\`onTimeout\` threw while handling \`waitFor\` timeout: ${onTimeoutMessage}`,
+            {
+              cause: error,
+            },
+          );
         }
       }
       onDone({ type: 'error', error: errorForRejection });

--- a/src/wait-for.ts
+++ b/src/wait-for.ts
@@ -42,7 +42,7 @@ function waitForInternal<T>(
     let promiseStatus = 'idle';
 
     let overallTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
-    const cleanupQueueCallback = () => cleanupWaitFor({ rejectOnAbort: true });
+    const cleanupQueueCallback = () => finalizeWaitFor({ rejectOnAbort: true });
 
     const fakeTimersType = getJestFakeTimersType();
 
@@ -101,7 +101,7 @@ function waitForInternal<T>(
       checkExpectation();
     }
 
-    function cleanupWaitFor({ rejectOnAbort = false } = {}) {
+    function finalizeWaitFor({ rejectOnAbort = false } = {}) {
       /* istanbul ignore next */
       if (finished) {
         return;
@@ -129,7 +129,7 @@ function waitForInternal<T>(
         return;
       }
 
-      cleanupWaitFor();
+      finalizeWaitFor();
       removeFromCleanupQueue(cleanupQueueCallback);
 
       if (done.type === 'error') {

--- a/src/wait-for.ts
+++ b/src/wait-for.ts
@@ -36,11 +36,12 @@ function waitForInternal<T>(
 
   // eslint-disable-next-line no-async-promise-executor
   return new Promise(async (resolve, reject) => {
-    let lastError: unknown, intervalId: ReturnType<typeof setTimeout>;
+    let lastError: unknown;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
     let finished = false;
     let promiseStatus = 'idle';
 
-    let overallTimeoutTimer: NodeJS.Timeout | null = null;
+    let overallTimeoutTimer: ReturnType<typeof setTimeout> | null = null;
     const cleanupQueueCallback = () => cleanupWaitFor({ rejectOnAbort: true });
 
     const fakeTimersType = getJestFakeTimersType();
@@ -101,19 +102,24 @@ function waitForInternal<T>(
     }
 
     function cleanupWaitFor({ rejectOnAbort = false } = {}) {
-      if (rejectOnAbort && !finished) {
-        reject(new Error('waitFor was aborted by cleanup'));
+      if (finished) {
+        return;
       }
 
       finished = true;
+
+      if (rejectOnAbort) {
+        reject(new Error('waitFor was aborted by cleanup'));
+      }
 
       if (overallTimeoutTimer) {
         clearTimeout(overallTimeoutTimer);
         overallTimeoutTimer = null;
       }
 
-      if (!fakeTimersType) {
+      if (intervalId) {
         clearInterval(intervalId);
+        intervalId = null;
       }
     }
 

--- a/src/wait-for.ts
+++ b/src/wait-for.ts
@@ -95,11 +95,15 @@ function waitForInternal<T>(
     } else {
       overallTimeoutTimer = setTimeout(handleTimeout, timeout);
       intervalId = setInterval(checkRealTimersCallback, interval);
-      addToCleanupQueue(cleanupWaitFor);
+      addToCleanupQueue(() => cleanupWaitFor({ rejectOnAbort: true }));
       checkExpectation();
     }
 
-    function cleanupWaitFor() {
+    function cleanupWaitFor({ rejectOnAbort = false } = {}) {
+      if (rejectOnAbort && !finished) {
+        reject(new Error('waitFor was aborted by cleanup'));
+      }
+
       finished = true;
 
       if (overallTimeoutTimer) {


### PR DESCRIPTION
This is an attempt at fixing the timer cleanup bug described in https://github.com/callstack/react-native-testing-library/issues/1917.

### Summary

There are 2 fixes in there:

* added a try/catch around processing onTimeout so that if an error happens while doing so (while dumping the screen for example), timers are still cleaned up
* added cleanup of running timers when the top level timer expires.


### Test plan

I included tests for both cases explained above. Very new to this codebase, so I'm not sure I'm doing it correctly. Forgive me is isn't suitable 🙏 .